### PR TITLE
[codex] Add macOS Homebrew management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-Personal dotfiles managed with Nix and Home Manager for shell and developer tooling on macOS and Linux.
+Personal dotfiles managed with Nix and Home Manager for shell and developer tooling on macOS and Linux. macOS system activation uses nix-darwin, with Homebrew installed through nix-homebrew for native cask apps.
 
 ## 🚀 Quick Start
 
@@ -32,7 +32,7 @@ echo "extra-experimental-features = nix-command flakes" >> ~/.config/nix/nix.con
 git clone https://github.com/atyrode/dotfiles.git ~/dotfiles
 cd ~/dotfiles
 if [ -L ~/.zshrc ]; then mv ~/.zshrc ~/.zshrc.backup.$(date +%Y%m%d%H%M%S); fi
-HOME_MANAGER_BACKUP_EXT=backup nix run .#home-manager -- switch --flake .#alex-aarch64-darwin
+nix run .#darwin-rebuild -- switch --flake .#alex-aarch64-darwin
 
 # 4. Restart shell
 exec zsh
@@ -64,6 +64,10 @@ exec zsh
 - **dua** - Disk usage analyzer
 - **Docker** + **docker-compose** + **dive** - Container tools on Linux configs
 - **fastfetch** - System info on startup
+
+### macOS Apps
+- **Nix app bundles** - ChatGPT, Discord, Obsidian, Signal, Spotify, and WhatsApp
+- **Homebrew casks** - Zen Browser and Steam, managed through nix-darwin
 
 ---
 
@@ -123,6 +127,8 @@ zconf
 
 ```
 dotfiles/
+├── darwin/                # nix-darwin and Homebrew configuration
+│   └── default.nix        # macOS system and cask definitions
 ├── flake.nix              # Main flake configuration
 ├── install.sh             # Quick install script
 └── home/                  # Home Manager modules
@@ -159,7 +165,13 @@ alex-x86_64-linux
 For this Mac, the manual switch command is:
 
 ```bash
-HOME_MANAGER_BACKUP_EXT=backup nix run .#home-manager -- switch --flake .#alex-aarch64-darwin
+nix run .#darwin-rebuild -- switch --flake .#alex-aarch64-darwin
+```
+
+On Linux, the matching configuration still uses Home Manager directly:
+
+```bash
+HOME_MANAGER_BACKUP_EXT=backup nix run .#home-manager -- switch --flake .#alex-x86_64-linux
 ```
 
 ### Change Username
@@ -171,6 +183,10 @@ If you want to keep the username but force a config, set `FLAKE_CONFIG` before r
 ### Add Packages
 
 Edit `home/packages.nix` and add to the `home.packages` list, then run `zconf`.
+
+### Add macOS Homebrew Apps
+
+Edit `darwin/default.nix` and add cask names to `homebrew.casks`, then run `zconf` on macOS.
 
 ### Modify Shell Functions
 
@@ -206,6 +222,13 @@ If the error says an existing symlink such as `~/.zshrc` would be clobbered,
 run `./install.sh` instead of the manual switch command. The installer backs up
 symlinked shell entrypoints before activation.
 
+**macOS Homebrew activation fails:**
+```bash
+zconf
+```
+
+The macOS configuration installs Homebrew through nix-homebrew and then applies the declared casks through nix-darwin. The first activation may ask for administrator authentication.
+
 ---
 
 ## 📝 Requirements
@@ -222,3 +245,5 @@ Nix will be installed automatically if not present.
 
 - [Nix](https://nixos.org/)
 - [Home Manager](https://github.com/nix-community/home-manager)
+- [nix-darwin](https://github.com/LnL7/nix-darwin)
+- [nix-homebrew](https://github.com/zhaofengli/nix-homebrew)

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -133,6 +133,14 @@ When instructions conflict, follow the most specific applicable instruction. If 
 - If validation fails, distinguish failures caused by the current change from pre-existing or unrelated failures when practical. Report the exact command, the relevant failure, and the likely cause. Do not claim success when checks fail.
 - If checks cannot be run, state exactly why and describe the remaining risk.
 
+## Web Rendering Checks
+
+- For web projects, when a change can affect layout, styling, routing, browser behavior, or user-visible content, use Playwright to inspect the rendered page when practical.
+- Prefer the project's existing Playwright setup. If Playwright is absent but a rendered-browser check is important, install or invoke it through the project's package manager in a project-local way; do not install global browser tooling.
+- Capture screenshots for relevant desktop and mobile viewports, inspect console and network failures, and use the rendered result to catch visual regressions, broken routes, hydration errors, missing assets, and unreadable or overlapping UI.
+- Prefer local dev servers, preview builds, fixtures, or test environments. Ask before using Playwright against production, authenticated, paid, private, or rate-limited systems.
+- If Playwright cannot be installed or run in the current environment, use the closest available browser-rendering or screenshot alternative and report the limitation.
+
 ## Final Handoff
 
 - For implementation work, make the source-control state explicit: branch, changed files, commits if created, push/PR status if relevant, validation run, and remaining risk.

--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  homeDirectory,
+  homebrew-cask,
+  homebrew-core,
+  pkgs,
+  username,
+  ...
+}:
+
+{
+  nixpkgs.config.allowUnfree = true;
+
+  system = {
+    primaryUser = username;
+    stateVersion = 7;
+  };
+
+  users.users.${username}.home = homeDirectory;
+
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    backupFileExtension = "backup";
+
+    users.${username} = {
+      imports = [ ../home ];
+
+      home = {
+        inherit username homeDirectory;
+      };
+    };
+  };
+
+  nix-homebrew = {
+    enable = true;
+    enableRosetta = pkgs.stdenv.hostPlatform.isAarch64;
+    user = username;
+    autoMigrate = true;
+
+    taps = {
+      "homebrew/homebrew-core" = homebrew-core;
+      "homebrew/homebrew-cask" = homebrew-cask;
+    };
+
+    mutableTaps = false;
+  };
+
+  homebrew = {
+    enable = true;
+    taps = builtins.attrNames config.nix-homebrew.taps;
+
+    casks = [
+      "steam"
+      "zen"
+    ];
+
+    onActivation = {
+      autoUpdate = false;
+      upgrade = false;
+      cleanup = "none";
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "brew-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781226006,
+        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
+        "owner": "Homebrew",
+        "repo": "brew",
+        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Homebrew",
+        "ref": "6.0.1",
+        "repo": "brew",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -17,6 +34,76 @@
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "homebrew-cask": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782802828,
+        "narHash": "sha256-ibjbdyIyCzrO2VJrLmUGza3P1PKrdwTFJpEL7wcgl6E=",
+        "owner": "homebrew",
+        "repo": "homebrew-cask",
+        "rev": "cccf0b1ea39d255aeed197adf298f25f20a3a8d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "homebrew",
+        "repo": "homebrew-cask",
+        "type": "github"
+      }
+    },
+    "homebrew-core": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782797615,
+        "narHash": "sha256-5YOo426pepVsHCejNoUQaKravmFUXEz+1I+vS2yjOY8=",
+        "owner": "homebrew",
+        "repo": "homebrew-core",
+        "rev": "907454ea24f451d2a462f6c364099277a553b866",
+        "type": "github"
+      },
+      "original": {
+        "owner": "homebrew",
+        "repo": "homebrew-core",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nix-homebrew": {
+      "inputs": {
+        "brew-src": "brew-src"
+      },
+      "locked": {
+        "lastModified": 1781389246,
+        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
+        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
         "type": "github"
       }
     },
@@ -39,6 +126,10 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "homebrew-cask": "homebrew-cask",
+        "homebrew-core": "homebrew-core",
+        "nix-darwin": "nix-darwin",
+        "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,12 +3,36 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    
+
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
+
+    nix-darwin.url = "github:LnL7/nix-darwin";
+    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+
+    nix-homebrew.url = "github:zhaofengli/nix-homebrew";
+
+    homebrew-core = {
+      url = "github:homebrew/homebrew-core";
+      flake = false;
+    };
+
+    homebrew-cask = {
+      url = "github:homebrew/homebrew-cask";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, home-manager, ... }:
+  outputs = {
+    self,
+    nixpkgs,
+    home-manager,
+    nix-darwin,
+    nix-homebrew,
+    homebrew-core,
+    homebrew-cask,
+    ...
+  }:
   let
     lib = nixpkgs.lib;
 
@@ -23,6 +47,11 @@
       "x86_64-darwin"
       "aarch64-linux"
       "x86_64-linux"
+    ];
+
+    darwinSystems = [
+      "aarch64-darwin"
+      "x86_64-darwin"
     ];
 
     # Safe fallback for bare `home-manager --flake .` invocations.
@@ -54,7 +83,29 @@
         ];
       };
 
+    mkDarwinConfig = { system, username ? defaultUsername, homeDirectory ? homeDirectoryFor system username }:
+      nix-darwin.lib.darwinSystem {
+        specialArgs = {
+          inherit
+            homeDirectory
+            homebrew-cask
+            homebrew-core
+            username
+            ;
+        };
+
+        modules = [
+          home-manager.darwinModules.home-manager
+          nix-homebrew.darwinModules.nix-homebrew
+          ./darwin
+          {
+            nixpkgs.hostPlatform = system;
+          }
+        ];
+      };
+
     configs = forAllSystems (system: mkHomeConfig { inherit system; });
+    darwinConfigs = lib.genAttrs darwinSystems (system: mkDarwinConfig { inherit system; });
   in {
     homeConfigurations =
       {
@@ -74,11 +125,29 @@
         "${defaultUsername}-linux" = configs."x86_64-linux";
       };
 
-    apps = forAllSystems (system: {
-      home-manager = {
-        type = "app";
-        program = "${home-manager.packages.${system}.home-manager}/bin/home-manager";
+    darwinConfigurations =
+      lib.mapAttrs' (
+        system: config:
+          lib.nameValuePair "${defaultUsername}-${system}" config
+      ) darwinConfigs
+      // {
+        "${defaultUsername}-darwin" = darwinConfigs.${defaultDarwinSystem};
       };
-    });
+
+    apps = forAllSystems (
+      system:
+        {
+          home-manager = {
+            type = "app";
+            program = "${home-manager.packages.${system}.home-manager}/bin/home-manager";
+          };
+        }
+        // lib.optionalAttrs (lib.hasSuffix "-darwin" system) {
+          darwin-rebuild = {
+            type = "app";
+            program = "${nix-darwin.packages.${system}.darwin-rebuild}/bin/darwin-rebuild";
+          };
+        }
+    );
   };
 }

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -497,7 +497,12 @@ EOF
   ];
 
   darwinPackages = with pkgs; [
-    # Add macOS-only packages here.
+    chatgpt
+    discord
+    obsidian
+    signal-desktop
+    spotify
+    whatsapp-for-mac
   ];
 
   linuxPackages = with pkgs; [

--- a/home/shell/nix.zsh
+++ b/home/shell/nix.zsh
@@ -95,6 +95,36 @@ _dotfiles_should_restart_shell() {
   [[ -t 0 && -t 1 ]] || return 1
 }
 
+_dotfiles_switch_home_manager() {
+  local flake_dir="$1"
+  local flake_config="$2"
+
+  echo -e "$(c_folder "Switching") Home Manager from: $flake_dir#$flake_config"
+  HOME_MANAGER_BACKUP_EXT=backup command nix run "$flake_dir#home-manager" -- switch --flake "$flake_dir#$flake_config" || {
+    echo -e "$(c_ko "Home Manager switch failed")"
+    return 1
+  }
+}
+
+_dotfiles_switch_darwin() {
+  local flake_dir="$1"
+  local flake_config="$2"
+
+  echo -e "$(c_folder "Switching") nix-darwin from: $flake_dir#$flake_config"
+
+  if (( ${+commands[darwin-rebuild]} )); then
+    command darwin-rebuild switch --flake "$flake_dir#$flake_config" || {
+      echo -e "$(c_ko "nix-darwin switch failed")"
+      return 1
+    }
+  else
+    command nix run "$flake_dir#darwin-rebuild" -- switch --flake "$flake_dir#$flake_config" || {
+      echo -e "$(c_ko "nix-darwin switch failed")"
+      return 1
+    }
+  fi
+}
+
 zconf() {
   # If a venv is active, deactivate it first
   if [[ -n "$VIRTUAL_ENV" ]]; then
@@ -111,6 +141,9 @@ zconf() {
   local flake_dir
   flake_dir="$(_dotfiles_dir)" || return 1
 
+  local system
+  system="$(_dotfiles_system)" || return 1
+
   local flake_config
   flake_config="$(_dotfiles_config)" || return 1
 
@@ -118,11 +151,11 @@ zconf() {
 
   _dotfiles_source_nix
 
-  echo -e "$(c_folder "Switching") Home Manager from: $flake_dir#$flake_config"
-  HOME_MANAGER_BACKUP_EXT=backup command nix run "$flake_dir#home-manager" -- switch --flake "$flake_dir#$flake_config" || {
-    echo -e "$(c_ko "Home Manager switch failed")"
-    return 1
-  }
+  if [[ "$system" == *-darwin && "${DOTFILES_FORCE_HOME_MANAGER:-0}" != "1" ]]; then
+    _dotfiles_switch_darwin "$flake_dir" "$flake_config" || return 1
+  else
+    _dotfiles_switch_home_manager "$flake_dir" "$flake_config" || return 1
+  fi
 
   # Reload HM session vars (PATH, etc.) for this shell. Restarting the shell is
   # opt-in because replacing the terminal process can hang embedded terminals.
@@ -134,7 +167,7 @@ zconf() {
     exec zsh -l
   fi
 
-  echo -e "$(c_ok "Home Manager switch complete.")"
+  echo -e "$(c_ok "Configuration switch complete.")"
   echo -e "Run $(c_file "exec zsh -l") or open a new terminal to reload the shell."
 }
 

--- a/install.sh
+++ b/install.sh
@@ -145,13 +145,21 @@ backup_home_manager_symlink_conflicts() {
     backup_if_symlink "$HOME/.zshenv"
 }
 
+switch_configuration() {
+    if [[ "$SYSTEM" == *-darwin ]]; then
+        nix run ".#darwin-rebuild" -- switch --flake ".#$FLAKE_CONFIG"
+    else
+        HOME_MANAGER_BACKUP_EXT=backup nix run ".#home-manager" -- switch --flake ".#$FLAKE_CONFIG"
+    fi
+}
+
 SYSTEM="$(detect_system)"
 FLAKE_CONFIG="${FLAKE_CONFIG:-alex-${SYSTEM}}"
 DOTFILES_DIR="$(resolve_dotfiles_dir)"
 
 echo "Installing dotfiles..."
 echo "System: $SYSTEM"
-echo "Home Manager config: $FLAKE_CONFIG"
+echo "Configuration: $FLAKE_CONFIG"
 
 ensure_nix
 ensure_flakes
@@ -159,10 +167,10 @@ prepare_dotfiles_dir
 warn_about_untracked_files
 backup_home_manager_symlink_conflicts
 
-echo "Building and activating Home Manager configuration..."
+echo "Building and activating configuration..."
 echo "This may take a few minutes on first run."
 
-if HOME_MANAGER_BACKUP_EXT=backup nix run ".#home-manager" -- switch --flake ".#$FLAKE_CONFIG"; then
+if switch_configuration; then
     echo ""
     echo "Installation complete."
     echo ""
@@ -188,6 +196,10 @@ else
     echo ""
     echo "Installation failed. Try the same switch manually for the full error:"
     echo "   cd $DOTFILES_DIR"
-    echo "   HOME_MANAGER_BACKUP_EXT=backup nix run .#home-manager -- switch --flake .#$FLAKE_CONFIG"
+    if [[ "$SYSTEM" == *-darwin ]]; then
+        echo "   nix run .#darwin-rebuild -- switch --flake .#$FLAKE_CONFIG"
+    else
+        echo "   HOME_MANAGER_BACKUP_EXT=backup nix run .#home-manager -- switch --flake .#$FLAKE_CONFIG"
+    fi
     exit 1
 fi


### PR DESCRIPTION
## Summary

- Add nix-darwin and nix-homebrew inputs and expose macOS darwinConfigurations.
- Add a Darwin module that installs/manages Homebrew and declares Zen Browser and Steam casks.
- Keep `zconf` as the update command: macOS uses `darwin-rebuild`, Linux keeps Home Manager.
- Add macOS app packages from nixpkgs and update install/docs for the new flow.

## Validation

- `bash -n install.sh`
- `zsh -n home/shell/nix.zsh`
- `git diff --check`
- `nix eval --json .#homeConfigurations.alex-x86_64-linux.config.home.packages --apply 'builtins.length'`
- `nix eval --json path:/tmp/nix-dotfiles-eval.E42QEu#darwinConfigurations.alex-aarch64-darwin.config.homebrew.casks`
- `nix eval --raw path:/tmp/nix-dotfiles-eval.E42QEu#darwinConfigurations.alex-aarch64-darwin.config.system.build.toplevel.drvPath`

## Notes

The Darwin eval used a `/tmp` copy before the file was tracked locally because flakes ignore untracked files. After committing, `darwin/default.nix` is tracked on this branch.