### PR TITLE
Update shared tooling and Codex workflow guidance

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -73,9 +73,10 @@ When instructions conflict, follow the most specific applicable instruction. If 
 
 - Fetch remote state before committing, branching, merging, pushing, deploying, or making release decisions when remote state is relevant.
 - Keep `main` stable. Use short-lived feature or fix branches when a separate branch is useful.
-- Do not create commits, tags, releases, or pull requests unless the operator asks for source-control output or the repository workflow clearly requires it for the requested task.
-- Never push without explicit operator direction.
-- Push directly to `main` only when the operator explicitly asks for it and the repository workflow allows it.
+- Agents may create local commits and push non-`main` branches for completed, scoped work after checking worktree and remote state, unless the operator says to keep changes local.
+- Opening a pull request is allowed when pushing a branch for review is the natural repository workflow, unless the operator asks not to.
+- Do not create tags or releases unless the operator explicitly requests them.
+- Do not push directly to `main` unless the operator explicitly names `main` as the target and the repository workflow allows it.
 - Do not change branch protection, bypass branch protection, force-push protected/shared branches, delete remote refs, or rewrite shared remote history unless the operator explicitly authorizes that exact action in the current conversation.
 - Treat approvals as scoped to the current request unless the operator explicitly says they should persist.
 
@@ -85,7 +86,7 @@ When instructions conflict, follow the most specific applicable instruction. If 
 - Prefer read-only inspection before write actions.
 - Ask before proceeding when an action would be destructive, expensive, public, privileged, persistent, externally visible, security-sensitive, or likely to affect production/shared systems.
 - Use dry-run, diff, plan, validate-only, status, or smoke-test modes before risky actions when available.
-- Do not create commits, tags, releases, pull requests, deployments, published packages, issue comments, emails, cloud changes, database migrations, or data mutations unless explicitly requested or clearly required by the approved workflow.
+- Do not create tags, releases, deployments, published packages, issue comments, emails, cloud changes, database migrations, or data mutations unless explicitly requested or clearly required by the approved workflow.
 - Treat database changes, backfills, credential rotation, infrastructure changes, and production operations as high-risk. Validate first, document rollback or remediation where practical, and avoid running them against shared systems without explicit direction.
 
 ## Operator Scripts And External Systems

--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781615165,
-        "narHash": "sha256-CFF4fNNfr2GZSx1xJhBNBi7VMj8OtOqZGOV+fiBSbzw=",
+        "lastModified": 1783388784,
+        "narHash": "sha256-w+YU5vatysjLZIg1wOKSzo/RL9Z66eBQuIjVnBM/1Zg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "34dd288e65012954cf7170658e0e6a61255b0327",
+        "rev": "63d02d1c19f1c2b47a5bc7e55c620b6af7b218a6",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1782802828,
-        "narHash": "sha256-ibjbdyIyCzrO2VJrLmUGza3P1PKrdwTFJpEL7wcgl6E=",
+        "lastModified": 1783403707,
+        "narHash": "sha256-h04UkrmrQy6T1D5eZeIdd7PiEEK7vJfXPBPP4B8rIKw=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "cccf0b1ea39d255aeed197adf298f25f20a3a8d7",
+        "rev": "e9afc581264e848952c4e71f47c50e4533271eac",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1782797615,
-        "narHash": "sha256-5YOo426pepVsHCejNoUQaKravmFUXEz+1I+vS2yjOY8=",
+        "lastModified": 1783409850,
+        "narHash": "sha256-S/V9HVXmM9g1hVabxE0DQ/0uoAS8KK713YPLVzbcHlA=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "907454ea24f451d2a462f6c364099277a553b866",
+        "rev": "fbf309cd90121b489dd09dd33b21ea63443ae475",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781761792,
-        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "lastModified": 1783395956,
+        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -466,7 +466,8 @@ EOF
     bat
     tree
     ripgrep
-    
+    unzip
+
     # System monitoring
     btop
     dua


### PR DESCRIPTION
## Summary

- refresh the locked flake inputs
- add `unzip` to the shared Home Manager package set
- clarify the Codex Git workflow instructions

## Why

These small foundational updates keep the shared profile current, provide an archive tool required by agent workflows, and make branch and push behavior explicit before the larger agent-platform change lands.

## Validation

- the stacked successor branch passes the full native `nix flake check`
- all configured systems pass no-build flake evaluation
- GitHub Actions workflow validation passes
