### PR TITLE
Finish declarative OMP platform contracts

### DIFF
--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -4,7 +4,9 @@
 }:
 
 let
-  baseConfig = ../omp/config.yml;
+  defaultsConfig = ../omp/defaults.yml;
+  policyConfig = ../omp/policy.yml;
+  settingsGuardExtension = ../omp/extensions/managed-settings-guard.ts;
   budgetPreset = ../omp/presets/budget.yml;
   fablePreset = ../omp/presets/fable-primary.yml;
   gptPreset = ../omp/presets/gpt56.yml;
@@ -37,6 +39,7 @@ in
     pkgs.runCommand "check-omp-stack"
       {
         nativeBuildInputs = [
+          pkgs.bun
           pkgs.findutils
           pkgs.jq
           pkgs.yq-go
@@ -51,7 +54,8 @@ in
         test "''${raw_version##*/}" = "16.3.14"
 
         for config in \
-          ${baseConfig} \
+          ${defaultsConfig} \
+          ${policyConfig} \
           ${budgetPreset} \
           ${fablePreset} \
           ${gptPreset}
@@ -60,38 +64,178 @@ in
         done
 
         "$raw_omp" models \
-          --config ${baseConfig} \
+          --config ${defaultsConfig} \
           --config ${gptPreset} \
           --config ${opusPreset} \
+          --config ${policyConfig} \
           --json >/dev/null
 
-        test "$(yq eval '.modelRoles.default' ${baseConfig})" = "openai-codex/gpt-5.6-terra:medium"
-        test "$(yq eval '.tools.approvalMode' ${baseConfig})" = "write"
-        test "$(yq eval '.secrets.enabled' ${baseConfig})" = "true"
+        test "$(yq eval '.modelRoles.default' ${defaultsConfig})" = "openai-codex/gpt-5.6-terra:medium"
+        test "$(yq eval '.tools.approvalMode' ${defaultsConfig})" = "null"
+        test "$(yq eval '.secrets.enabled' ${defaultsConfig})" = "null"
+        test "$(yq eval '.tools.approvalMode' ${policyConfig})" = "write"
+        test "$(yq eval '.secrets.enabled' ${policyConfig})" = "true"
+        test "$(yq eval 'keys | sort | join(",")' ${policyConfig})" = "secrets,tools"
+        test "$(yq eval '.tools | keys | join(",")' ${policyConfig})" = "approvalMode"
+        test "$(yq eval '.secrets | keys | join(",")' ${policyConfig})" = "enabled"
         test "$(yq eval '.retry.modelFallback' ${fablePreset})" = "false"
 
         for command in omp ompb ompf ompg ompo; do
           command_version="$(${pkgs.omp-configured}/bin/"$command" --version)"
           test "''${command_version##*/}" = "16.3.14"
         done
+        test ! -e ${pkgs.omp-configured}/bin/pi
+        test "$(
+          find ${pkgs.omp-configured}/bin -mindepth 1 -maxdepth 1 -printf '%f\n' | sort | paste -sd, -
+        )" = "omp,ompb,ompf,ompg,ompo"
         test "$(${pkgs.herdr-configured}/bin/herdr --version)" = "herdr 0.7.3"
 
-        set +e
-        ${pkgs.herdr-configured}/bin/herdr update > "$TMPDIR/herdr.out" 2> "$TMPDIR/herdr.err"
-        herdr_update_status=$?
-        set -e
-        test "$herdr_update_status" -eq 2
-        grep -q 'managed by Nix' "$TMPDIR/herdr.err"
+        for invocation in 'update' '--handoff update' 'update --handoff'; do
+          read -r -a args <<< "$invocation"
+          set +e
+          ${pkgs.herdr-configured}/bin/herdr "''${args[@]}" \
+            > "$TMPDIR/herdr.out" 2> "$TMPDIR/herdr.err"
+          herdr_update_status=$?
+          set -e
+          test "$herdr_update_status" -eq 2
+          grep -q 'managed by Nix' "$TMPDIR/herdr.err"
+        done
 
         ${pkgs.omp-configured}/bin/omp models --json > "$TMPDIR/models.json" 2> "$TMPDIR/models.err"
         test ! -s "$TMPDIR/models.err"
         jq -e '.models | type == "array"' "$TMPDIR/models.json" >/dev/null
+
+        set +e
+        ${pkgs.omp-configured}/bin/omp acp \
+          --config "$TMPDIR/missing-one-shot.yml" \
+          > "$TMPDIR/acp.out" 2> "$TMPDIR/acp.err"
+        acp_status=$?
+        set -e
+        test "$acp_status" -ne 0
+        grep -q 'Config overlay not found' "$TMPDIR/acp.err"
+
+        acp_home="$TMPDIR/acp-home"
+        mkdir -p "$acp_home"
+        printf '%s\n' \
+          '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{}}}' \
+          | env HOME="$acp_home" PI_CODING_AGENT_DIR="$acp_home/agent" \
+            timeout 20 ${pkgs.omp-configured}/bin/omp acp > "$TMPDIR/acp-init.jsonl"
+        jq -e \
+          '.id == 1 and .result.protocolVersion == 1 and .result.agentInfo.version == "16.3.14"' \
+          "$TMPDIR/acp-init.jsonl" >/dev/null
+        test ! -e "$acp_home/.pi"
+
+        rpc_home="$TMPDIR/rpc-home"
+        rpc_project="$TMPDIR/rpc-project"
+        mkdir -p "$rpc_home" "$rpc_project/.omp" "$rpc_project/.agents/skills/project-fixture"
+        printf '%s\n' 'managed-project-guidance-fixture' > "$rpc_project/.omp/AGENTS.md"
+        printf '%s\n' '{"defaultThinkingLevel":"low"}' > "$rpc_project/.omp/settings.json"
+        cat > "$rpc_project/.omp/config.yml" <<'EOF'
+        defaultThinkingLevel: high
+        tools:
+          approvalMode: yolo
+        secrets:
+          enabled: false
+        EOF
+        cat > "$rpc_project/.agents/skills/project-fixture/SKILL.md" <<'EOF'
+        ---
+        name: project-fixture
+        description: managed-project-skill-fixture
+        ---
+
+        Project fixture skill.
+        EOF
+        printf '%s\n' \
+          '{"id":"state","type":"get_state"}' \
+          '{"id":"commands","type":"get_available_commands"}' \
+          | env \
+            HOME="$rpc_home" \
+            OPENAI_API_KEY=fixture-placeholder \
+            timeout 20 ${pkgs.omp-configured}/bin/omp \
+              --profile work \
+              --cwd "$rpc_project" \
+              --mode rpc \
+              --no-session \
+              --no-tools \
+              --no-lsp > "$TMPDIR/rpc.jsonl"
+        jq -s -e '
+          (map(select(.id == "state" and .success == true))[0].data
+            | (.thinkingLevel == "high")
+              and (.systemPrompt | join("\n") | contains("managed-project-guidance-fixture")))
+          and
+          (map(select(.id == "commands" and .success == true))[0].data.commands
+            | any(.name == "skill:project-fixture" and .description == "managed-project-skill-fixture"))
+        ' "$TMPDIR/rpc.jsonl" >/dev/null
+        test ! -e "$rpc_home/.pi"
+
+        cat > "$TMPDIR/settings-guard.test.ts" <<'EOF'
+        import guard, {
+          restoreManagedPaths,
+          resolveMachineConfigPath,
+        } from "${settingsGuardExtension}";
+
+        const restored = restoreManagedPaths(
+          {
+            modelRoles: { default: "changed", extra: "keep" },
+            custom: { keep: true },
+          },
+          { modelRoles: { default: "baseline" } },
+        );
+        if (!restored.changed) throw new Error("managed change was not detected");
+        const config = restored.config as Record<string, any>;
+        if (config.modelRoles.default !== "baseline") throw new Error("managed value was not restored");
+        if (config.modelRoles.extra !== undefined) throw new Error("managed parent was only partially restored");
+        if (config.custom.keep !== true) throw new Error("unmanaged value was lost");
+
+        const agentDir = `''${process.env.HOME}/.omp/agent`;
+        await Bun.write(`''${agentDir}/config.yaml`, "custom: baseline\n");
+        if (!resolveMachineConfigPath().endsWith("config.yaml")) {
+          throw new Error("legacy yaml fallback was not selected");
+        }
+
+        const handlers = new Map<string, Function>();
+        const pi = { on(name: string, handler: Function) { handlers.set(name, handler); } };
+        guard(pi as any);
+        let warning = "";
+        await handlers.get("session_start")?.({}, {
+          ui: { notify(message: string) { warning = message; } },
+        });
+        await Bun.write(
+          `''${agentDir}/config.yaml`,
+          "modelRoles:\n  default: attempted-change\ncustom: preserved-edit\n",
+        );
+        await Bun.sleep(1_200);
+        const watched = Bun.YAML.parse(await Bun.file(`''${agentDir}/config.yaml`).text());
+        if (watched.modelRoles !== undefined || watched.custom !== "preserved-edit") {
+          throw new Error("watcher did not restore managed paths and retain unmanaged edits");
+        }
+        if (!warning.includes("tried to change Nix-managed")) {
+          throw new Error("watcher did not report the rejected persistence");
+        }
+        warning = "";
+        const settingsResult = await handlers.get("input")?.(
+          { text: "  /SeTtInGs  " },
+          { ui: { notify(message: string) { warning = message; } } },
+        );
+        if (settingsResult?.handled !== true || !warning.includes("Nix-managed settings")) {
+          throw new Error("settings command was not guarded");
+        }
+        if (await handlers.get("input")?.({ text: "/settingsx" }, { ui: { notify() {} } })) {
+          throw new Error("unrelated input was consumed");
+        }
+        await handlers.get("session_shutdown")?.();
+        EOF
+        mkdir -p "$HOME/.omp/agent"
+        ${pkgs.bun}/bin/bun "$TMPDIR/settings-guard.test.ts"
 
         test "$(
           find ${pkgs.omp-agents}/share/omp/agents -maxdepth 1 -name '*.md' | wc -l
         )" -eq 13
         grep -q 'HERDR_INTEGRATION_ID=omp' \
           ${pkgs.herdr-omp-integration}/share/omp/extensions/herdr-omp-agent-state.ts
+        test "$(find ${pkgs.omp-configured.platformRoot}/agents -maxdepth 1 -name '*.md' | wc -l)" -eq 13
+        test -f ${pkgs.omp-configured.platformRoot}/extensions/managed-settings-guard.ts
+        test -f ${pkgs.omp-configured.platformRoot}/rules/no-shell-text-surgery.md
 
         mkdir "$out"
       '';
@@ -99,40 +243,396 @@ in
   omp-wrapper =
     pkgs.runCommand "check-omp-wrapper"
       {
-        nativeBuildInputs = [ pkgs.diffutils ];
+        nativeBuildInputs = [
+          pkgs.diffutils
+          pkgs.jq
+        ];
       }
       ''
             export HOME="$TMPDIR/home"
             export XDG_CONFIG_HOME="$HOME/.config"
-            mkdir -p "$XDG_CONFIG_HOME/omp"
-            printf 'custom: true\n' > "$XDG_CONFIG_HOME/omp/local.yml"
+            project="$TMPDIR/project"
+            mkdir -p "$HOME/.omp/agent" "$XDG_CONFIG_HOME/omp" "$project/.omp"
+            cat > "$HOME/.omp/agent/config.yml" <<'EOF'
+        modelRoles:
+          machine-only: machine/model:low
+        EOF
+            cat > "$project/.omp/settings.json" <<'EOF'
+        {"modelRoles":{"default":"project/settings:low"}}
+        EOF
+            cat > "$project/.omp/config.yml" <<'EOF'
+        modelRoles:
+          default: project/model:medium
+        tools:
+          approvalMode: yolo
+        secrets:
+          enabled: false
+        EOF
+            cat > "$XDG_CONFIG_HOME/omp/local.yml" <<'EOF'
+        custom:
+          privateToken: do-not-print
+        modelRoles:
+          default: local/model:low
+        tools:
+          approvalMode: yolo
+        secrets:
+          enabled: false
+        EOF
+            cat > "$TMPDIR/managed-one-shot.yml" <<'EOF'
+        modelRoles:
+          default: one-shot/model:high
+        tools:
+          approvalMode: yolo
+        secrets:
+          enabled: false
+        privateToken: do-not-print
+        EOF
+            cd "$project"
 
-            ${configuredStub}/bin/ompo --model custom > "$TMPDIR/actual"
+            ${configuredStub}/bin/ompo \
+              --config "$TMPDIR/one-shot.yml" \
+              --model custom \
+              -- \
+              --config literal > "$TMPDIR/actual"
             cat > "$TMPDIR/expected" <<EOF
+        --extension
+        ${configuredStub.platformRoot}
         --config
-        ${toString baseConfig}
+        ${configuredStub.defaultsConfig}
+        --config
+        $project/.omp/settings.json
+        --config
+        $project/.omp/config.yml
         --config
         $XDG_CONFIG_HOME/omp/local.yml
         --config
-        ${toString gptPreset}
+        ${configuredStub.presets.gpt}
         --config
-        ${toString opusPreset}
+        ${configuredStub.presets.opusFallback}
+        --config
+        $TMPDIR/one-shot.yml
+        --config
+        ${configuredStub.policyConfig}
         --model
         custom
+        --
+        --config
+        literal
         EOF
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
-            ${configuredStub}/bin/omp models --json > "$TMPDIR/actual"
+            ${configuredStub}/bin/ompo acp \
+              --config="$TMPDIR/acp-one-shot.yml" \
+              --approval-mode yolo > "$TMPDIR/actual"
+            cat > "$TMPDIR/expected" <<EOF
+        acp
+        --extension
+        ${configuredStub.platformRoot}
+        --config
+        ${configuredStub.defaultsConfig}
+        --config
+        $project/.omp/settings.json
+        --config
+        $project/.omp/config.yml
+        --config
+        $XDG_CONFIG_HOME/omp/local.yml
+        --config
+        ${configuredStub.presets.gpt}
+        --config
+        ${configuredStub.presets.opusFallback}
+        --config
+        $TMPDIR/acp-one-shot.yml
+        --config
+        ${configuredStub.policyConfig}
+        --approval-mode
+        yolo
+        EOF
+            diff -u "$TMPDIR/expected" "$TMPDIR/actual"
+
+            ${configuredStub}/bin/ompo models --json > "$TMPDIR/actual"
             printf 'models\n--json\n' > "$TMPDIR/expected"
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
-            set +e
-            ${configuredStub}/bin/omp update > "$TMPDIR/update.out" 2> "$TMPDIR/update.err"
-            update_status=$?
-            set -e
+            ${configuredStub}/bin/ompo --profile work config path > "$TMPDIR/actual"
+            printf '%s\n' '--profile' 'work' 'config' 'path' > "$TMPDIR/expected"
+            diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
-            test "$update_status" -eq 2
-            grep -q 'managed by Nix' "$TMPDIR/update.err"
+            ${configuredStub}/bin/ompo --no-extensions models --json > "$TMPDIR/actual"
+            printf '%s\n' '--no-extensions' 'models' '--json' > "$TMPDIR/expected"
+            diff -u "$TMPDIR/expected" "$TMPDIR/actual"
+
+            set +e
+            ${configuredStub}/bin/omp --no-extensions --mode rpc \
+              > "$TMPDIR/no-extensions.out" 2> "$TMPDIR/no-extensions.err"
+            no_extensions_status=$?
+            set -e
+            test "$no_extensions_status" -eq 2
+            grep -q 'Nix-owned settings guard' "$TMPDIR/no-extensions.err"
+
+            ${configuredStub}/bin/omp --resume models > "$TMPDIR/actual"
+            cat > "$TMPDIR/expected" <<EOF
+        --extension
+        ${configuredStub.platformRoot}
+        --config
+        ${configuredStub.defaultsConfig}
+        --config
+        $project/.omp/settings.json
+        --config
+        $project/.omp/config.yml
+        --config
+        $XDG_CONFIG_HOME/omp/local.yml
+        --config
+        ${configuredStub.policyConfig}
+        --resume
+        models
+        EOF
+            diff -u "$TMPDIR/expected" "$TMPDIR/actual"
+
+            ${configuredStub}/bin/omp --help config > "$TMPDIR/actual"
+            printf '%s\n' '--help' 'config' > "$TMPDIR/expected"
+            diff -u "$TMPDIR/expected" "$TMPDIR/actual"
+
+            ${configuredStub}/bin/ompg config set completion.notify off --json > "$TMPDIR/actual"
+            printf '%s\n' 'config' 'set' 'completion.notify' 'off' '--json' > "$TMPDIR/expected"
+            diff -u "$TMPDIR/expected" "$TMPDIR/actual"
+
+            for invocation in \
+              'config set modelRoles {}' \
+              'config set tools {}' \
+              'config --json reset providers.webSearch' \
+              'config set providers.anthropic.serverSideFallback true' \
+              '--profile work config set tools.approvalMode yolo' \
+              'config reset secrets.enabled --json'
+            do
+              read -r -a args <<< "$invocation"
+              set +e
+              ${configuredStub}/bin/omp "''${args[@]}" \
+                > "$TMPDIR/refused.out" 2> "$TMPDIR/refused.err"
+              refused_status=$?
+              set -e
+              test "$refused_status" -eq 2
+              grep -Eq 'Nix-managed default|Nix-managed preset|enforced by Nix policy' "$TMPDIR/refused.err"
+            done
+
+            ${configuredStub}/bin/ompg \
+              --config "$TMPDIR/managed-one-shot.yml" \
+              config managed --json > "$TMPDIR/managed.json"
+            jq -e '.launcher == "ompg"' "$TMPDIR/managed.json" >/dev/null
+            jq -e '.profile == "default"' "$TMPDIR/managed.json" >/dev/null
+            jq -e '.statePath == $ENV.HOME + "/.omp/agent"' "$TMPDIR/managed.json" >/dev/null
+            jq -e '.effectiveManaged.modelRoles.default == "one-shot/model:high"' \
+              "$TMPDIR/managed.json" >/dev/null
+            jq -e '.effectiveManaged.modelRoles["machine-only"] == "machine/model:low"' \
+              "$TMPDIR/managed.json" >/dev/null
+            jq -e '.effectiveManaged.tools.approvalMode == "write"' "$TMPDIR/managed.json" >/dev/null
+            jq -e '.effectiveManaged.secrets.enabled == true' "$TMPDIR/managed.json" >/dev/null
+            jq -e '.effectiveManaged.privateToken == null' "$TMPDIR/managed.json" >/dev/null
+            ! grep -q 'do-not-print' "$TMPDIR/managed.json"
+            jq -e '.enforcedPolicy == {"tools":{"approvalMode":"write"},"secrets":{"enabled":true}}' \
+              "$TMPDIR/managed.json" >/dev/null
+            test "$(jq -r '[.sources[].kind] | join(",")' "$TMPDIR/managed.json")" = \
+              'writable-machine-state,managed-defaults,native-project,native-project,machine-local,preset,one-shot-config,managed-policy,runtime-flags'
+            jq -e '.sources[0].present == true' "$TMPDIR/managed.json" >/dev/null
+            jq -e --arg projectSettings "$project/.omp/settings.json" \
+              '.sources[] | select(.format == "settings.json") | .path == $projectSettings and .present == true' \
+              "$TMPDIR/managed.json" >/dev/null
+            jq -e --arg project "$project/.omp/config.yml" \
+              '.sources[] | select(.kind == "native-project") | .path == $project and .present == true' \
+              "$TMPDIR/managed.json" >/dev/null
+            jq -e --arg oneShot "$TMPDIR/managed-one-shot.yml" \
+              '.sources[] | select(.kind == "one-shot-config") | .path == $oneShot' \
+              "$TMPDIR/managed.json" >/dev/null
+
+            PI_SMOL_MODEL=env/smol:low ${configuredStub}/bin/omp \
+              --approval-mode yolo \
+              --model runtime/default:high \
+              --smol runtime/smol:medium \
+              --slow runtime/slow:xhigh \
+              --plan runtime/plan:high \
+              --thinking xhigh \
+              --advisor \
+              config managed --json > "$TMPDIR/runtime-managed.json"
+            jq -e '
+              .effectiveManaged.tools.approvalMode == "yolo"
+              and .effectiveManaged.modelRoles.default == "runtime/default:high"
+              and .effectiveManaged.modelRoles.smol == "runtime/smol:medium"
+              and .effectiveManaged.modelRoles.slow == "runtime/slow:xhigh"
+              and .effectiveManaged.modelRoles.plan == "runtime/plan:high"
+              and .effectiveManaged.defaultThinkingLevel == "xhigh"
+              and .effectiveManaged.advisor.enabled == true
+            ' \
+              "$TMPDIR/runtime-managed.json" >/dev/null
+            jq -e '.runtimeOverrides == {
+              "approvalMode":"yolo",
+              "model":"runtime/default:high",
+              "thinking":"xhigh",
+              "smol":"runtime/smol:medium",
+              "slow":"runtime/slow:xhigh",
+              "plan":"runtime/plan:high",
+              "advisor":true
+            }' \
+              "$TMPDIR/runtime-managed.json" >/dev/null
+
+            PI_SMOL_MODEL=env/smol:low PI_SLOW_MODEL=env/slow:high PI_PLAN_MODEL=env/plan:medium \
+              ${configuredStub}/bin/omp config managed --json > "$TMPDIR/runtime-env.json"
+            jq -e '
+              .effectiveManaged.modelRoles.smol == "env/smol:low"
+              and .effectiveManaged.modelRoles.slow == "env/slow:high"
+              and .effectiveManaged.modelRoles.plan == "env/plan:medium"
+            ' "$TMPDIR/runtime-env.json" >/dev/null
+
+            PI_CODING_AGENT_DIR="$TMPDIR/custom-agent" \
+              ${configuredStub}/bin/omp config managed --json > "$TMPDIR/custom-state.json"
+            jq -e --arg state "$TMPDIR/custom-agent" '.statePath == $state' \
+              "$TMPDIR/custom-state.json" >/dev/null
+
+            ${configuredStub}/bin/omp --profile work \
+              config managed --json > "$TMPDIR/profile-state.json"
+            jq -e --arg state "$HOME/.omp/profiles/work/agent" \
+              '.profile == "work" and .statePath == $state' \
+              "$TMPDIR/profile-state.json" >/dev/null
+
+            OMP_PROFILE=default PI_PROFILE=work \
+              PI_CODING_AGENT_DIR="$HOME/.omp/profiles/work/agent" \
+              ${configuredStub}/bin/omp config managed --json > "$TMPDIR/default-profile-state.json"
+            jq -e --arg state "$HOME/.omp/agent" \
+              '.profile == "default" and .statePath == $state' \
+              "$TMPDIR/default-profile-state.json" >/dev/null
+
+            set +e
+            ${configuredStub}/bin/omp --profile ../../escape config managed --json \
+              > "$TMPDIR/invalid-profile.out" 2> "$TMPDIR/invalid-profile.err"
+            invalid_profile_status=$?
+            set -e
+            test "$invalid_profile_status" -eq 1
+            grep -q 'Invalid OMP profile' "$TMPDIR/invalid-profile.err"
+
+            PI_CONFIG_DIR=.custom-omp \
+              ${configuredStub}/bin/omp config managed --json > "$TMPDIR/config-root.json"
+            jq -e --arg state "$HOME/.custom-omp/agent" '.statePath == $state' \
+              "$TMPDIR/config-root.json" >/dev/null
+
+            yaml_home="$TMPDIR/yaml-home"
+            mkdir -p "$yaml_home/.omp/agent"
+            cat > "$yaml_home/.omp/agent/config.yaml" <<'EOF'
+        modelRoles:
+          yaml-machine: machine/yaml:low
+        EOF
+            HOME="$yaml_home" XDG_CONFIG_HOME="$yaml_home/.config" \
+              ${configuredStub}/bin/omp --cwd "$project" config managed --json \
+                > "$TMPDIR/yaml-state.json"
+            jq -e --arg path "$yaml_home/.omp/agent/config.yaml" '
+              .sources[0].path == $path
+              and .sources[0].present == true
+              and .effectiveManaged.modelRoles["yaml-machine"] == "machine/yaml:low"
+            ' "$TMPDIR/yaml-state.json" >/dev/null
+
+            ${configuredStub}/bin/omp --system-prompt --cwd \
+              config managed --json > "$TMPDIR/arity.json"
+            jq -e --arg project "$project/.omp/config.yml" \
+              '.sources[] | select(.format == "config.yml") | .path == $project' \
+              "$TMPDIR/arity.json" >/dev/null
+
+            mkdir -p "$HOME/tmp/.omp" "$HOME/.omp"
+            cat > "$HOME/.omp/config.yml" <<'EOF'
+        modelRoles:
+          default: home/project:high
+        EOF
+            cat > "$HOME/tmp/.omp/config.yml" <<'EOF'
+        modelRoles:
+          default: tmp/project:low
+        EOF
+            (
+              cd "$HOME"
+              XDG_CONFIG_HOME="$TMPDIR/auto-xdg" \
+                ${configuredStub}/bin/omp config managed --json > "$TMPDIR/home-auto.json"
+              XDG_CONFIG_HOME="$TMPDIR/auto-xdg" \
+                ${configuredStub}/bin/omp --allow-home config managed --json > "$TMPDIR/home-allowed.json"
+            )
+            jq -e --arg cwd "$HOME/tmp" '
+              .effectiveCwd == $cwd and .effectiveManaged.modelRoles.default == "tmp/project:low"
+            ' "$TMPDIR/home-auto.json" >/dev/null
+            jq -e --arg cwd "$HOME" '
+              .effectiveCwd == $cwd and .effectiveManaged.modelRoles.default == "home/project:high"
+            ' "$TMPDIR/home-allowed.json" >/dev/null
+
+            legacy_project="$TMPDIR/legacy-project"
+            mkdir -p "$legacy_project/.omp"
+            cat > "$legacy_project/.omp/config.yml" <<'EOF'
+        theme: custom-dark
+        codexResets:
+          autoRedeem: true
+        memories:
+          enabled: false
+        EOF
+            cat > "$legacy_project/relative.yml" <<'EOF'
+        modelRoles:
+          default: relative/one-shot:high
+        EOF
+            ${configuredStub}/bin/omp \
+              --cwd "$legacy_project" \
+              --config relative.yml \
+              config managed --json > "$TMPDIR/legacy-managed.json"
+            jq -e --arg oneShot "$legacy_project/relative.yml" '
+              .effectiveManaged.theme.dark == "custom-dark"
+              and .effectiveManaged.codexResets.autoRedeem == "yes"
+              and .effectiveManaged.memory.backend == "off"
+              and .effectiveManaged.modelRoles.default == "relative/one-shot:high"
+              and (.sources[] | select(.kind == "one-shot-config") | .path == $oneShot)
+            ' "$TMPDIR/legacy-managed.json" >/dev/null
+
+            set +e
+            ${configuredStub}/bin/omp config get modelRoles --json \
+              > "$TMPDIR/get.out" 2> "$TMPDIR/get.err"
+            get_status=$?
+            set -e
+            test "$get_status" -eq 2
+            grep -q 'only reads writable machine state' "$TMPDIR/get.err"
+
+            ${configuredStub}/bin/omp config list > "$TMPDIR/list.out" 2> "$TMPDIR/list.err"
+            grep -q 'shows writable machine state' "$TMPDIR/list.err"
+
+            ${configuredStub}/bin/omp setup --help > "$TMPDIR/setup.out" 2> "$TMPDIR/setup.err"
+            printf '%s\n' setup --help > "$TMPDIR/expected"
+            diff -u "$TMPDIR/expected" "$TMPDIR/setup.out"
+            grep -q 'writes writable machine state' "$TMPDIR/setup.err"
+
+            declare -A expected_default_models=(
+              [omp]='openai-codex/gpt-5.6-terra:medium'
+              [ompb]='openai-codex/gpt-5.6-terra:low'
+              [ompf]='anthropic/claude-fable-5:high'
+              [ompg]='openai-codex/gpt-5.6-sol:high'
+              [ompo]='openai-codex/gpt-5.6-sol:high'
+            )
+            policy_home="$TMPDIR/policy-home"
+            policy_project="$TMPDIR/policy-project"
+            mkdir -p "$policy_home" "$policy_project"
+            for command in omp ompb ompf ompg ompo; do
+              HOME="$policy_home" XDG_CONFIG_HOME="$policy_home/.config" \
+                ${configuredStub}/bin/"$command" --cwd "$policy_project" \
+                  config managed --json > "$TMPDIR/$command-policy.json"
+              jq -e --arg expected "''${expected_default_models[$command]}" \
+                '.effectiveManaged.modelRoles.default == $expected' \
+                "$TMPDIR/$command-policy.json" >/dev/null
+            done
+            jq -e '.effectiveManaged.retry.modelFallback == false' \
+              "$TMPDIR/ompf-policy.json" >/dev/null
+            jq -e '
+              .effectiveManaged.providers.anthropic.serverSideFallback == false
+              and (.ownership.presets | index("providers.anthropic.serverSideFallback")) != null
+            ' "$TMPDIR/ompf-policy.json" >/dev/null
+            jq -e '.effectiveManaged.retry.fallbackChains["reviewer-deep"][0] == "anthropic/claude-opus-4-8:xhigh"' \
+              "$TMPDIR/ompo-policy.json" >/dev/null
+
+            for command in omp ompb ompf ompg ompo; do
+              set +e
+              ${configuredStub}/bin/"$command" update \
+                > "$TMPDIR/update.out" 2> "$TMPDIR/update.err"
+              update_status=$?
+              set -e
+              test "$update_status" -eq 2
+              grep -q 'managed by Nix' "$TMPDIR/update.err"
+            done
 
             mkdir "$out"
       '';
@@ -142,6 +642,7 @@ in
       {
         nativeBuildInputs = [
           pkgs.findutils
+          pkgs.flock
           pkgs.gnugrep
           pkgs.jq
           pkgs.yq-go
@@ -149,8 +650,11 @@ in
       }
       ''
             migration=${lib.escapeShellArg (lib.getExe pkgs.agent-tools-migrate)}
-            export HOME="$TMPDIR/home"
 
+            empty_home_files="$TMPDIR/empty-home-files"
+            mkdir -p "$empty_home_files"
+
+            export HOME="$TMPDIR/home"
             mkdir -p \
               "$HOME/.local/bin" \
               "$HOME/.omp/plugins/node_modules/bigpowers" \
@@ -159,21 +663,13 @@ in
               "$HOME/.omp/agent/rules" \
               "$HOME/.omp/agent/managed-skills/ts-react-dead-code-sweep"
 
-            cat > "$HOME/.local/bin/omp" <<'EOF'
-        #!/bin/sh
-        printf '%s\n' 'omp/16.3.14'
-        EOF
-            cat > "$HOME/.local/bin/herdr" <<'EOF'
-        #!/bin/sh
-        printf '%s\n' 'herdr 0.7.3'
-        EOF
+            printf '#!/bin/sh\nexit 0\n' > "$HOME/.local/bin/omp"
+            printf '#!/bin/sh\nexit 0\n' > "$HOME/.local/bin/herdr"
             chmod +x "$HOME/.local/bin/omp" "$HOME/.local/bin/herdr"
-
-            cat > "$HOME/.omp/plugins/package.json" <<'EOF'
-        {"dependencies":{"bigpowers":"2.76.2"}}
-        EOF
+            printf '{"dependencies":{"bigpowers":"2.76.2"}}\n' > "$HOME/.omp/plugins/package.json"
             printf 'legacy\n' > "$HOME/.omp/agent/agents/task.md"
             printf 'legacy\n' > "$HOME/.omp/agent/extensions/herdr-omp-agent-state.ts"
+            printf 'legacy\n' > "$HOME/.omp/agent/extensions/managed-settings-guard.ts"
             printf 'legacy\n' > "$HOME/.omp/agent/rules/no-shell-text-surgery.md"
             printf 'legacy\n' > "$HOME/.omp/agent/gpt56-only.yml"
             printf 'legacy\n' > "$HOME/.omp/agent/managed-skills/ts-react-dead-code-sweep/SKILL.md"
@@ -184,16 +680,20 @@ in
           "disabledServers": ["bigpowers-mcp"]
         }
         EOF
-
             cat > "$HOME/.omp/agent/config.yml" <<'EOF'
         setupVersion: 7
+        "codexResets.autoRedeem": true
         dev:
           autoqa:
             consent: accepted
         modelRoles:
           default: legacy/model
+        providers:
+          anthropic:
+            serverSideFallback: true
         retry:
           enabled: true
+          custom: preserved
         tools:
           approvalMode: yolo
           custom: preserved
@@ -202,47 +702,225 @@ in
           custom: preserved
         custom:
           nested: preserved
+        advisor:
+          enabled: true
+          immuneTurns: 7
+        statusLine:
+          preset: default
+          separator: preserved
+        terminal:
+          showProgress: true
+          showImages: false
+        tui:
+          tight: false
+          renderMermaid: true
+        display:
+          shimmer: classic
+          smoothStreaming: false
+        codexResets:
+          autoRedeem: "no"
+          minBlockedMinutes: 42
+        task:
+          disabledAgents: []
+          maxConcurrency: 3
+        memory:
+          backend: local
+          custom: preserved
+        theme:
+          dark: dark
+          light: light
+        browser:
+          enabled: true
+          custom: preserved
         EOF
 
-            "$migration"
-
+            "$migration" prepare
             state_root="$HOME/.local/state/atyrode/agent-tools-migration"
-            backup_dir="$(find "$state_root" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
-
-            test -n "$backup_dir"
-            test -f "$state_root/migration-v2.complete"
-            test -x "$backup_dir/.local/bin/omp"
-            test -x "$backup_dir/.local/bin/herdr"
-            test -f "$backup_dir/.omp/plugins/package.json"
-            test -f "$backup_dir/.omp/agent/agents/task.md"
-            test -f "$backup_dir/.omp/agent/extensions/herdr-omp-agent-state.ts"
-            test -f "$backup_dir/.omp/agent/rules/no-shell-text-surgery.md"
-            test -f "$backup_dir/.omp/agent/gpt56-only.yml"
-            test -f "$backup_dir/.omp/agent/managed-skills/ts-react-dead-code-sweep/SKILL.md"
-            test -f "$backup_dir/.omp/agent/mcp.json"
-            test -f "$backup_dir/.omp/agent/config.yml"
+            pending="$state_root/migration-v2.pending"
+            complete="$state_root/migration-v2.complete"
+            test -d "$pending"
+            test ! -e "$complete"
+            test -x "$pending/backup/.local/bin/omp"
+            test -f "$pending/backup/.omp/agent/config.yml"
             test ! -e "$HOME/.omp/agent/mcp.json"
-
             test "$(yq eval '.setupVersion' "$HOME/.omp/agent/config.yml")" = "7"
-            test "$(yq eval '.dev.autoqa.consent' "$HOME/.omp/agent/config.yml")" = "accepted"
             test "$(yq eval '.custom.nested' "$HOME/.omp/agent/config.yml")" = "preserved"
             test "$(yq eval '.modelRoles' "$HOME/.omp/agent/config.yml")" = "null"
-            test "$(yq eval '.retry' "$HOME/.omp/agent/config.yml")" = "null"
-            test "$(yq eval '.tools.approvalMode' "$HOME/.omp/agent/config.yml")" = "null"
+            test "$(yq eval '.providers.anthropic.serverSideFallback' "$HOME/.omp/agent/config.yml")" = "null"
+            test "$(yq eval '."codexResets.autoRedeem"' "$HOME/.omp/agent/config.yml")" = "null"
+            test "$(yq eval '.retry.enabled' "$HOME/.omp/agent/config.yml")" = "null"
+            test "$(yq eval '.retry.custom' "$HOME/.omp/agent/config.yml")" = "preserved"
             test "$(yq eval '.tools.custom' "$HOME/.omp/agent/config.yml")" = "preserved"
-            test "$(yq eval '.secrets.enabled' "$HOME/.omp/agent/config.yml")" = "null"
             test "$(yq eval '.secrets.custom' "$HOME/.omp/agent/config.yml")" = "preserved"
+            test "$(yq eval '.advisor.immuneTurns' "$HOME/.omp/agent/config.yml")" = "7"
+            test "$(yq eval '.statusLine.separator' "$HOME/.omp/agent/config.yml")" = "preserved"
+            test "$(yq eval '.terminal.showImages' "$HOME/.omp/agent/config.yml")" = "false"
+            test "$(yq eval '.tui.renderMermaid' "$HOME/.omp/agent/config.yml")" = "true"
+            test "$(yq eval '.display.smoothStreaming' "$HOME/.omp/agent/config.yml")" = "false"
+            test "$(yq eval '.codexResets.minBlockedMinutes' "$HOME/.omp/agent/config.yml")" = "42"
+            test "$(yq eval '.task.maxConcurrency' "$HOME/.omp/agent/config.yml")" = "3"
+            test "$(yq eval '.memory.custom' "$HOME/.omp/agent/config.yml")" = "preserved"
+            test "$(yq eval '.theme.light' "$HOME/.omp/agent/config.yml")" = "light"
+            test "$(yq eval '.browser.custom' "$HOME/.omp/agent/config.yml")" = "preserved"
 
-            backup_count="$(find "$state_root" -mindepth 1 -maxdepth 1 -type d | wc -l)"
-            "$migration"
-            test "$(find "$state_root" -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq "$backup_count"
+            "$migration" finalize "$empty_home_files"
+            test -d "$complete"
+            test ! -e "$pending"
+            test -x "$complete/backup/.local/bin/omp"
+            test -f "$complete/backup/.omp/plugins/package.json"
+            test -f "$complete/backup/.omp/agent/agents/task.md"
+            test -f "$complete/backup/.omp/agent/extensions/managed-settings-guard.ts"
+            test -f "$complete/backup/.omp/agent/mcp.json"
+            test ! -e "$HOME/.omp/agent/agents/task.md"
+            test ! -e "$HOME/.omp/agent/extensions/managed-settings-guard.ts"
+
+            "$migration" prepare
+            "$migration" finalize "$empty_home_files"
+            test "$(find "$state_root" -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1
 
             dry_home="$TMPDIR/dry-home"
             mkdir -p "$dry_home/.local/bin"
-            cp "$backup_dir/.local/bin/omp" "$dry_home/.local/bin/omp"
-            HOME="$dry_home" AGENT_TOOLS_DRY_RUN=1 "$migration"
+            cp "$complete/backup/.local/bin/omp" "$dry_home/.local/bin/omp"
+            HOME="$dry_home" AGENT_TOOLS_DRY_RUN=1 "$migration" prepare >/dev/null
             test -x "$dry_home/.local/bin/omp"
-            test ! -e "$dry_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete"
+            test ! -e "$dry_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
+
+            interrupted_home="$TMPDIR/interrupted-home"
+            mkdir -p "$interrupted_home/.local/bin"
+            printf 'old omp\n' > "$interrupted_home/.local/bin/omp"
+            printf 'old herdr\n' > "$interrupted_home/.local/bin/herdr"
+            if HOME="$interrupted_home" AGENT_TOOLS_MIGRATION_FAILPOINT=after-first-move \
+              "$migration" prepare > "$TMPDIR/interrupted.out" 2> "$TMPDIR/interrupted.err"; then
+              exit 1
+            fi
+            interrupted_pending="$interrupted_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
+            test -d "$interrupted_pending"
+            test -f "$interrupted_pending/backup/.local/bin/omp"
+            test -f "$interrupted_home/.local/bin/herdr"
+            HOME="$interrupted_home" "$migration" prepare
+            test -f "$interrupted_pending/backup/.local/bin/herdr"
+            HOME="$interrupted_home" "$migration" finalize "$empty_home_files"
+            test -d "$interrupted_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete"
+
+            receipt_home="$TMPDIR/receipt-home"
+            mkdir -p "$receipt_home/.local/bin"
+            printf 'old omp\n' > "$receipt_home/.local/bin/omp"
+            if HOME="$receipt_home" AGENT_TOOLS_MIGRATION_FAILPOINT=after-receipt \
+              "$migration" prepare >/dev/null 2>&1; then
+              exit 1
+            fi
+            receipt_pending="$receipt_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
+            test -d "$receipt_pending"
+            test -f "$receipt_home/.local/bin/omp"
+            HOME="$receipt_home" "$migration" prepare
+            HOME="$receipt_home" "$migration" finalize "$empty_home_files"
+            test -d "$receipt_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete"
+
+            config_interrupt_home="$TMPDIR/config-interrupt-home"
+            mkdir -p "$config_interrupt_home/.omp/agent"
+            cat > "$config_interrupt_home/.omp/agent/config.yml" <<'EOF'
+        modelRoles:
+          default: legacy/model
+        custom:
+          preserved: true
+        EOF
+            if HOME="$config_interrupt_home" AGENT_TOOLS_MIGRATION_FAILPOINT=after-config-replace \
+              "$migration" prepare >/dev/null 2>&1; then
+              exit 1
+            fi
+            test -d "$config_interrupt_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
+            test "$(yq eval '.modelRoles' "$config_interrupt_home/.omp/agent/config.yml")" = "null"
+            test "$(yq eval '.custom.preserved' "$config_interrupt_home/.omp/agent/config.yml")" = "true"
+            HOME="$config_interrupt_home" "$migration" prepare
+            HOME="$config_interrupt_home" "$migration" finalize "$empty_home_files"
+            test -d "$config_interrupt_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete"
+
+            yaml_migration_home="$TMPDIR/yaml-migration-home"
+            mkdir -p "$yaml_migration_home/.omp/agent"
+            cat > "$yaml_migration_home/.omp/agent/config.yaml" <<'EOF'
+        theme: dark
+        modelRoles:
+          default: legacy/model
+        custom:
+          preserved: true
+        EOF
+            HOME="$yaml_migration_home" "$migration" prepare
+            yaml_pending="$yaml_migration_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
+            test -f "$yaml_pending/backup/.omp/agent/config.yaml"
+            test ! -e "$yaml_migration_home/.omp/agent/config.yml"
+            test "$(yq eval '.theme' "$yaml_migration_home/.omp/agent/config.yaml")" = "null"
+            test "$(yq eval '.modelRoles' "$yaml_migration_home/.omp/agent/config.yaml")" = "null"
+            test "$(yq eval '.custom.preserved' "$yaml_migration_home/.omp/agent/config.yaml")" = "true"
+            HOME="$yaml_migration_home" "$migration" finalize "$empty_home_files"
+
+            dual_config_home="$TMPDIR/dual-config-home"
+            mkdir -p "$dual_config_home/.omp/agent"
+            printf 'custom: yml\n' > "$dual_config_home/.omp/agent/config.yml"
+            printf 'custom: yaml\n' > "$dual_config_home/.omp/agent/config.yaml"
+            if HOME="$dual_config_home" "$migration" prepare \
+              > "$TMPDIR/dual-config.out" 2> "$TMPDIR/dual-config.err"; then
+              exit 1
+            fi
+            grep -q 'both .*config.yml and .*config.yaml exist' "$TMPDIR/dual-config.err"
+            test -f "$dual_config_home/.omp/agent/config.yml"
+            test -f "$dual_config_home/.omp/agent/config.yaml"
+
+            scalar_theme_home="$TMPDIR/scalar-theme-home"
+            mkdir -p "$scalar_theme_home/.omp/agent"
+            printf 'theme: custom-light\n' > "$scalar_theme_home/.omp/agent/config.yml"
+            if HOME="$scalar_theme_home" "$migration" prepare \
+              > "$TMPDIR/scalar-theme.out" 2> "$TMPDIR/scalar-theme.err"; then
+              exit 1
+            fi
+            grep -q 'legacy scalar custom theme' "$TMPDIR/scalar-theme.err"
+            grep -q '^theme: custom-light$' "$scalar_theme_home/.omp/agent/config.yml"
+
+            transformed_tamper_home="$TMPDIR/transformed-tamper-home"
+            mkdir -p "$transformed_tamper_home/.omp/agent"
+            printf 'modelRoles: {default: legacy/model}\ncustom: preserved\n' \
+              > "$transformed_tamper_home/.omp/agent/config.yml"
+            if HOME="$transformed_tamper_home" AGENT_TOOLS_MIGRATION_FAILPOINT=after-config-transform \
+              "$migration" prepare >/dev/null 2>&1; then
+              exit 1
+            fi
+            transformed_pending="$transformed_tamper_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
+            printf 'custom: tampered\n' > "$transformed_pending/work/config.transformed.yml"
+            if HOME="$transformed_tamper_home" "$migration" prepare \
+              > "$TMPDIR/transformed-tamper.out" 2> "$TMPDIR/transformed-tamper.err"; then
+              exit 1
+            fi
+            grep -q 'does not match the digest-verified original config' \
+              "$TMPDIR/transformed-tamper.err"
+            test "$(yq eval '.modelRoles.default' "$transformed_tamper_home/.omp/agent/config.yml")" = \
+              'legacy/model'
+
+            finalize_interrupt_home="$TMPDIR/finalize-interrupt-home"
+            mkdir -p "$finalize_interrupt_home/.local/bin"
+            printf 'old omp\n' > "$finalize_interrupt_home/.local/bin/omp"
+            HOME="$finalize_interrupt_home" "$migration" prepare
+            if HOME="$finalize_interrupt_home" AGENT_TOOLS_MIGRATION_FAILPOINT=before-finalize \
+              "$migration" finalize "$empty_home_files" >/dev/null 2>&1; then
+              exit 1
+            fi
+            test -d "$finalize_interrupt_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
+            HOME="$finalize_interrupt_home" "$migration" finalize "$empty_home_files"
+            test -d "$finalize_interrupt_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete"
+
+            collision_home="$TMPDIR/collision-home"
+            mkdir -p "$collision_home/.local/bin"
+            printf 'original\n' > "$collision_home/.local/bin/omp"
+            if HOME="$collision_home" AGENT_TOOLS_MIGRATION_FAILPOINT=after-first-move \
+              "$migration" prepare >/dev/null 2>&1; then
+              exit 1
+            fi
+            printf 'replacement\n' > "$collision_home/.local/bin/omp"
+            if HOME="$collision_home" "$migration" prepare > "$TMPDIR/collision.out" 2> "$TMPDIR/collision.err"; then
+              exit 1
+            fi
+            grep -q 'preserve both and resolve the collision' "$TMPDIR/collision.err"
+            grep -q '^replacement$' "$collision_home/.local/bin/omp"
+            grep -q '^original$' \
+              "$collision_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending/backup/.local/bin/omp"
 
             opaque_home="$TMPDIR/opaque-home"
             mkdir -p "$opaque_home/.local/bin"
@@ -251,41 +929,172 @@ in
         touch "$HOME/executed"
         EOF
             chmod +x "$opaque_home/.local/bin/omp"
-
-            HOME="$opaque_home" "$migration"
-            opaque_state="$opaque_home/.local/state/atyrode/agent-tools-migration"
-            opaque_backup="$(find "$opaque_state" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+            HOME="$opaque_home" "$migration" prepare
             test ! -e "$opaque_home/executed"
-            test -x "$opaque_backup/.local/bin/omp"
-            test -f "$opaque_state/migration-v2.complete"
+            HOME="$opaque_home" "$migration" finalize "$empty_home_files"
+            test -x "$opaque_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete/backup/.local/bin/omp"
 
             custom_mcp_home="$TMPDIR/custom-mcp-home"
             mkdir -p "$custom_mcp_home/.omp/agent"
             cat > "$custom_mcp_home/.omp/agent/mcp.json" <<'EOF'
-        {
-          "mcpServers": {
-            "custom": {
-              "command": "custom-mcp"
-            }
-          },
-          "disabledServers": ["bigpowers-mcp"]
-        }
+        {"mcpServers":{"custom":{"command":"custom-mcp"}},"disabledServers":["bigpowers-mcp"]}
         EOF
-
-            HOME="$custom_mcp_home" "$migration"
+            HOME="$custom_mcp_home" "$migration" prepare
+            HOME="$custom_mcp_home" "$migration" finalize "$empty_home_files"
             jq -e '.mcpServers.custom.command == "custom-mcp"' \
               "$custom_mcp_home/.omp/agent/mcp.json" >/dev/null
 
-            unsafe_home="$TMPDIR/unsafe-home"
-            mkdir -p "$unsafe_home/.local/bin/omp"
-
-            if HOME="$unsafe_home" "$migration" > "$TMPDIR/unsafe.out" 2> "$TMPDIR/unsafe.err"; then
+            mixed_plugin_home="$TMPDIR/mixed-plugin-home"
+            mkdir -p \
+              "$mixed_plugin_home/.omp/plugins/node_modules/bigpowers" \
+              "$mixed_plugin_home/.omp/plugins/node_modules/custom-plugin"
+            printf '%s\n' \
+              '{"dependencies":{"bigpowers":"2.76.2","custom-plugin":"1.0.0"}}' \
+              > "$mixed_plugin_home/.omp/plugins/package.json"
+            if HOME="$mixed_plugin_home" "$migration" prepare \
+              > "$TMPDIR/mixed-plugin.out" 2> "$TMPDIR/mixed-plugin.err"; then
               exit 1
             fi
+            grep -q 'mixed or customized plugin state' "$TMPDIR/mixed-plugin.err"
+            test -d "$mixed_plugin_home/.omp/plugins/node_modules/bigpowers"
+            test -d "$mixed_plugin_home/.omp/plugins/node_modules/custom-plugin"
+            test ! -e "$mixed_plugin_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
 
+            stale_store_home="$TMPDIR/stale-store-home"
+            mkdir -p "$stale_store_home/.local/bin"
+            ln -s ${lib.getExe pkgs.hello} "$stale_store_home/.local/bin/omp"
+            HOME="$stale_store_home" "$migration" prepare
+            test ! -e "$stale_store_home/.local/bin/omp"
+            test -L \
+              "$stale_store_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending/backup/.local/bin/omp"
+            HOME="$stale_store_home" "$migration" finalize "$empty_home_files"
+
+            temp_link_home="$TMPDIR/temp-link-home"
+            mkdir -p "$temp_link_home/.omp/agent"
+            printf 'victim\n' > "$temp_link_home/victim"
+            printf 'modelRoles: {default: legacy/model}\n' > "$temp_link_home/.omp/agent/config.yml"
+            ln -s "$temp_link_home/victim" \
+              "$temp_link_home/.omp/agent/config.yml.agent-tools-migration-v2.tmp"
+            HOME="$temp_link_home" "$migration" prepare
+            grep -q '^victim$' "$temp_link_home/victim"
+            test -f "$temp_link_home/.omp/agent/config.yml"
+            test ! -L "$temp_link_home/.omp/agent/config.yml"
+            HOME="$temp_link_home" "$migration" finalize "$empty_home_files"
+
+            receipt_escape_home="$TMPDIR/receipt-escape-home"
+            mkdir -p "$receipt_escape_home/.local/bin" "$receipt_escape_home/escape"
+            printf 'old omp\n' > "$receipt_escape_home/.local/bin/omp"
+            if HOME="$receipt_escape_home" AGENT_TOOLS_MIGRATION_FAILPOINT=after-receipt \
+              "$migration" prepare >/dev/null 2>&1; then
+              exit 1
+            fi
+            escape_pending="$receipt_escape_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
+            rm -rf "$escape_pending/backup"
+            ln -s "$receipt_escape_home/escape" "$escape_pending/backup"
+            if HOME="$receipt_escape_home" "$migration" prepare \
+              > "$TMPDIR/receipt-escape.out" 2> "$TMPDIR/receipt-escape.err"; then
+              exit 1
+            fi
+            grep -q 'not a safe receipt directory' "$TMPDIR/receipt-escape.err"
+            test -f "$receipt_escape_home/.local/bin/omp"
+            test -z "$(find "$receipt_escape_home/escape" -mindepth 1 -print -quit)"
+
+            unsafe_home="$TMPDIR/unsafe-home"
+            mkdir -p "$unsafe_home/.local/bin/omp"
+            if HOME="$unsafe_home" "$migration" prepare > "$TMPDIR/unsafe.out" 2> "$TMPDIR/unsafe.err"; then
+              exit 1
+            fi
             grep -q 'not a regular file or symlink' "$TMPDIR/unsafe.err"
             test -d "$unsafe_home/.local/bin/omp"
-            test ! -e "$unsafe_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete"
+            test ! -e "$unsafe_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
+
+            invalid_home="$TMPDIR/invalid-home"
+            mkdir -p "$invalid_home/.local/bin" "$invalid_home/.omp/agent"
+            printf 'legacy\n' > "$invalid_home/.local/bin/omp"
+            printf '[invalid\n' > "$invalid_home/.omp/agent/config.yml"
+            if HOME="$invalid_home" "$migration" prepare > "$TMPDIR/invalid.out" 2> "$TMPDIR/invalid.err"; then
+              exit 1
+            fi
+            grep -q 'not valid YAML' "$TMPDIR/invalid.err"
+            test -f "$invalid_home/.local/bin/omp"
+            test ! -e "$invalid_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
+            test -z "$(
+              find "$invalid_home/.local/state/atyrode/agent-tools-migration" \
+                -maxdepth 1 -name '.migration-v2.creating.*' -print -quit
+            )"
+
+            corrupt_home="$TMPDIR/corrupt-home"
+            mkdir -p "$corrupt_home/.local/bin"
+            printf 'legacy\n' > "$corrupt_home/.local/bin/omp"
+            if HOME="$corrupt_home" AGENT_TOOLS_MIGRATION_FAILPOINT=after-receipt \
+              "$migration" prepare >/dev/null 2>&1; then
+              exit 1
+            fi
+            corrupt_pending="$corrupt_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending"
+            printf 'invalid\treceipt\n' > "$corrupt_pending/receipt.tsv"
+            if HOME="$corrupt_home" "$migration" prepare \
+              > "$TMPDIR/corrupt.out" 2> "$TMPDIR/corrupt.err"; then
+              exit 1
+            fi
+            grep -q 'unknown record' "$TMPDIR/corrupt.err"
+            test -f "$corrupt_home/.local/bin/omp"
+
+            dual_state_home="$TMPDIR/dual-state-home"
+            mkdir -p "$dual_state_home/.local/bin"
+            printf 'legacy\n' > "$dual_state_home/.local/bin/omp"
+            if HOME="$dual_state_home" AGENT_TOOLS_MIGRATION_FAILPOINT=after-receipt \
+              "$migration" prepare >/dev/null 2>&1; then
+              exit 1
+            fi
+            mkdir "$dual_state_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete"
+            if HOME="$dual_state_home" "$migration" prepare \
+              > "$TMPDIR/dual-state.out" 2> "$TMPDIR/dual-state.err"; then
+              exit 1
+            fi
+            grep -q 'both pending and completed migration state exist' "$TMPDIR/dual-state.err"
+
+            missing_backup_home="$TMPDIR/missing-backup-home"
+            mkdir -p "$missing_backup_home/.local/bin"
+            printf 'legacy\n' > "$missing_backup_home/.local/bin/omp"
+            HOME="$missing_backup_home" "$migration" prepare
+            rm "$missing_backup_home/.local/state/atyrode/agent-tools-migration/migration-v2.pending/backup/.local/bin/omp"
+            if HOME="$missing_backup_home" "$migration" finalize "$empty_home_files" \
+              > "$TMPDIR/missing-backup.out" 2> "$TMPDIR/missing-backup.err"; then
+              exit 1
+            fi
+            grep -q 'planned backup' "$TMPDIR/missing-backup.err"
+
+            legacy_home="$TMPDIR/legacy-home"
+            mkdir -p "$legacy_home/.local/bin" "$legacy_home/.local/state/atyrode/agent-tools-migration"
+            printf 'legacy binary\n' > "$legacy_home/.local/bin/omp"
+            printf 'completed\n' > \
+              "$legacy_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete"
+            HOME="$legacy_home" "$migration" prepare
+            HOME="$legacy_home" "$migration" finalize "$empty_home_files"
+            test -f "$legacy_home/.local/bin/omp"
+
+            locked_home="$TMPDIR/locked-home"
+            locked_state="$locked_home/.local/state/atyrode/agent-tools-migration"
+            mkdir -p "$locked_home/.local/bin" "$locked_state"
+            printf 'legacy\n' > "$locked_home/.local/bin/omp"
+            exec 8< "$locked_state"
+            flock -n 8
+            if HOME="$locked_home" "$migration" prepare > "$TMPDIR/locked.out" 2> "$TMPDIR/locked.err"; then
+              exit 1
+            fi
+            flock -u 8
+            grep -q 'another agent tools migration is running' "$TMPDIR/locked.err"
+            test -f "$locked_home/.local/bin/omp"
+
+            lock_link_home="$TMPDIR/lock-link-home"
+            lock_link_state="$lock_link_home/.local/state/atyrode/agent-tools-migration"
+            mkdir -p "$lock_link_home/.local/bin" "$lock_link_state"
+            printf 'legacy\n' > "$lock_link_home/.local/bin/omp"
+            printf 'victim\n' > "$lock_link_home/victim"
+            ln -s "$lock_link_home/victim" "$lock_link_state/migration-v2.lock"
+            HOME="$lock_link_home" "$migration" prepare
+            grep -q '^victim$' "$lock_link_home/victim"
+            HOME="$lock_link_home" "$migration" finalize "$empty_home_files"
 
             mkdir "$out"
       '';

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -10,14 +10,28 @@ Nix owns:
 
 - the pinned OMP binary and generated Zsh completion;
 - the pinned Herdr flake input and generated OMP integration;
-- the managed OMP base config and model presets;
-- the patched bundled agents, custom deep agents, and global generic skills;
+- the managed OMP defaults, enforced policy, and model presets;
+- the patched bundled agents, custom deep agents, global generic skills, and
+  managed-settings guard extension;
 - the `omp`, `ompb`, `ompf`, `ompg`, and `ompo` launchers; and
 - mise itself, with no globally declared mise tools.
 
 OMP and Herdr continue to own mutable runtime data such as authentication,
 sessions, caches, onboarding state, and machine-local UI state. Secrets never
 belong in this repository or the Nix store.
+
+This subsystem deliberately owns neither a `pi` executable nor a `.pi`
+mutable-state namespace. The bounded Pi experiment in #29 may therefore install
+alongside OMP without an executable collision, shared authentication/session
+state, or any parity requirement. The package check asserts the exact five OMP
+launcher names and verifies that an OMP clean-home startup does not create
+`.pi` state.
+
+Agents, rules, the settings guard, and the Herdr extension are assembled into
+a read-only OMP extension-package root in the Nix store and injected explicitly
+by every managed session. They are not copied into OMP's mutable agent
+directory, so named profiles and custom `PI_CODING_AGENT_DIR` roots receive the
+same platform assets without sharing authentication, sessions, or caches.
 
 The package overlay lives in `flake.nix`, reusable package derivations live in
 `pkgs/`, and Home Manager deployment lives in
@@ -41,18 +55,87 @@ planning, design, architecture, and review where their higher cost is most
 useful. The presets are policy, not provider pricing data; revisit the routes
 when model quality or pricing changes.
 
-Interactive sessions load configuration in this order:
+The balanced routing rationale is:
 
-1. OMP's writable machine config at `~/.omp/agent/config.yml`;
-2. the Nix-managed base config;
-3. optional machine-local overrides at `~/.config/omp/local.yml`;
-4. a quick-command preset, when used; and
-5. explicit command-line flags or extra `--config` arguments.
+| Role or role group | Capability and intended use | Thinking | Cost posture and fallback rationale |
+| --- | --- | --- | --- |
+| `default`, `task` | General implementation on Terra | Medium | Mid-cost default; Sonnet then Sol covers provider or capability failures |
+| `librarian` | Repository and documentation research on Terra | Medium | Sonnet adds cross-provider depth; Luna is the economical final fallback |
+| `advisor`, `smol`, `sonic`, `tiny`, `commit` | Fast review, lookup, naming, and commit-message work on Luna | Minimal–low | Cheapest recurring work; Terra is the first quality step-up |
+| `explore` | Repository exploration on Terra | Low | Keeps discovery economical; Luna or Sonnet can take over when needed |
+| `designer` | Product and interface design on Sonnet | Medium | Pays for stronger visual judgment; Sol and Fable provide cross-provider fallbacks |
+| `reviewer` | High-scrutiny review on Sonnet | High | Higher-cost quality gate; Opus then Sol preserve depth if the primary is unavailable |
+| `Tester` | Test design and adversarial verification on Terra | High | Strong reasoning without defaulting to the most expensive tier; Sonnet and Sol back it up |
+| `plan`, `architect-deep`, `designer-deep` | Architecture, planning, and deep design on Fable | High | Premium reasoning is intentional for decisions with broad downstream impact; Opus or Sol are the escape routes |
+| `slow`, `debugger-deep` | Hard debugging and deliberate reasoning on Sol | Xhigh | Expensive OpenAI reasoning is reserved for difficult failures; Opus and high-thinking Terra provide diversity |
+| `tester-deep` | Exhaustive verification on Sol | High | Sonnet then Opus provide independent Anthropic verification if Sol is unavailable |
+| `reviewer-deep` | Final deep review on Opus | Xhigh | Highest-cost route is restricted to the strongest review pass; Sol and Fable remain available |
 
-Later layers win. OMP maintenance subcommands are passed directly to OMP
-because some subcommand parsers do not accept interactive plugin flags.
+`omp/defaults.yml` is the authoritative role map and fallback-chain definition;
+the preset files intentionally change parts of this table for budget,
+OpenAI-only, Fable-first, and Opus-assisted sessions.
+
+Normal sessions load configuration in this order:
+
+1. OMP's writable machine config at `~/.omp/agent/config.yml`, with
+   `config.yaml` accepted as OMP's legacy fallback when `config.yml` is absent;
+2. the Nix-managed portable defaults;
+3. native project configuration from `<cwd>/.omp/settings.json` followed by
+   `<cwd>/.omp/config.yml`, reapplied after the defaults so a repository can
+   specialize non-security settings;
+4. optional machine-local overrides at `~/.config/omp/local.yml`;
+5. the selected quick-command preset or presets;
+6. one-shot `--config` overlays, in command-line order;
+7. the Nix-managed enforced policy; and
+8. explicit runtime flags such as `--model` or `--approval-mode`.
+
+Later layers win. The enforced policy currently fixes workspace-write approval
+and secret obfuscation for every normal session. A supported runtime flag may
+still override policy for that one process, while machine, project, preset, and
+one-shot config files cannot. `omp acp` receives the same layers in the same
+order, with the overlays placed after the `acp` subcommand as required by OMP's
+parser.
+
+OMP maintenance subcommands are passed directly to OMP because their parsers do
+not consistently accept interactive launch flags. Preset launchers preserve
+that passthrough instead of prepending their preset to a maintenance command.
+`omp setup` warns that it writes lower-priority machine state and points back to
+the effective diagnostic.
 `omp update` and `herdr update` are refused so they cannot shadow the
 Nix-managed versions.
+
+When launched from `$HOME` without `--cwd` or `--allow-home`, the wrapper
+mirrors OMP's safety chdir (`$HOME/tmp`, `/tmp`, `/var/tmp`, then the platform
+temporary directory) before resolving project layers. Relative one-shot
+`--config` paths are resolved from that effective project directory.
+
+Use `omp config managed --json` to inspect the active profile and state path,
+ordered source paths, ownership, and effective managed values for the selected
+launcher. The diagnostic includes the writable machine layer, both native
+project settings files, one-shot overlays, and supported runtime overrides,
+but filters output to Nix-owned keys so credentials and unrelated private
+settings are never printed. OMP-compatible migrations are applied to legacy
+managed values before the diagnostic is merged. `PI_CODING_AGENT_DIR`,
+`PI_CONFIG_DIR`, named profiles, the effective project directory, and the
+`config.yml`/`config.yaml` fallback are reflected in the report.
+
+`omp config set` and `omp config reset` refuse keys supplied by the managed
+defaults, selected presets, or enforced policy, including parent/child paths
+that overlap a managed key. `omp config get` likewise refuses managed keys
+because upstream's command reads only writable machine state; `omp config list`
+prints an explicit warning about that limitation. Edit the repository source,
+or use `~/.config/omp/local.yml` for a machine-only override of a default.
+Local overrides cannot weaken enforced policy.
+
+The managed extension intercepts the normal `/settings` path before OMP opens
+its in-session settings UI and explains the supported edit paths. It also
+watches OMP's writable config and restores Nix-owned paths if another UI path,
+including follow-up submission or setup, tries to persist them; unrelated
+machine edits are retained and the session receives a warning. Managed root
+sessions refuse `--no-extensions`, because upstream would otherwise disable
+this guard together with the managed agents, rules, and Herdr integration. Use
+`omp config managed`, the machine-local file, or the repository sources
+instead.
 
 The readable managed copies are linked under `~/.config/omp/`. Edit their
 sources in this repository instead of editing the links.
@@ -88,33 +171,55 @@ machine-specific assumptions; the first migration only relocates the generic
 
 Before Home Manager checks link targets, the activation hook examines legacy
 paths. Conflicting regular files or symlinks at the OMP and Herdr binary paths,
-the standalone Bigpowers plugin tree, managed agents, the Herdr extension,
-presets, rules, and the old generic skill are moved to a timestamped backup. The
-exact temporary `mcp.json` denylist previously used for `bigpowers-mcp` is also
-retired; MCP configurations containing any custom servers or settings are left
-untouched.
-Legacy binaries are never executed during detection:
+the standalone Bigpowers plugin tree, managed agents, managed extensions,
+presets, rules, and the old generic skill are moved into a pending migration
+receipt. The exact temporary `mcp.json` denylist previously used for
+`bigpowers-mcp` is also retired; MCP configurations containing any custom
+servers or settings are left untouched. Legacy binaries are never executed
+during detection:
 
 ```text
-~/.local/state/atyrode/agent-tools-migration/<timestamp>-<pid>/
+~/.local/state/atyrode/agent-tools-migration/migration-v2.pending/
+├── receipt.tsv
+├── backup/
+└── work/
 ```
 
-The existing writable OMP config is copied into the same backup and only the
-keys now owned by Nix are removed. Onboarding version, consent, unknown keys,
-and other machine-local values remain writable. Invalid YAML, unsupported file
-types at managed binary paths, or a mixed plugin tree stop activation instead
-of guessing.
+The existing writable OMP `config.yml` or fallback `config.yaml` is copied into
+the same backup and only the keys now owned by Nix are removed. A dual-file
+state or ambiguous legacy scalar custom theme is refused for manual review.
+Onboarding version, consent, unknown keys, and other machine-local values remain
+writable. Invalid YAML, unsupported file types at managed binary paths, a mixed
+plugin tree, or a live path that collides with an existing backup stop
+activation instead of guessing. An interrupted activation reuses the pending
+receipt and never creates a second backup. Once
+Home Manager has installed the packages and selected the new generation, a
+finalizer verifies every retired path and transformed config, then atomically
+renames the pending directory to `migration-v2.complete`; the backups remain
+inside it for manual recovery. Existing installations with the former
+`migration-v2.complete` marker
+file remain recognized.
 
-The migration is idempotent and writes
-`~/.local/state/atyrode/agent-tools-migration/migration-v2.complete`.
-Home Manager dry-runs make the migration dry-run too.
+Receipts, backup/work directories, lock handling, and same-directory temporary
+files are validated so symlinks cannot redirect writes outside the transaction.
+The retired plugin cleanup accepts only the exact Bigpowers-only manifest and
+known package-manager files; mixed dependencies or any customized root state
+are preserved for manual review. Stale `~/.local/bin/omp` and `herdr` symlinks
+are backed up even when they target an old Nix store path, preventing them from
+shadowing the Home Manager profile.
+
+The migration is idempotent. It never restores backups automatically because
+that could overwrite a new user file or a managed Home Manager link; resolve a
+reported collision while preserving both copies, then run `zconf` again. Home
+Manager dry-runs inspect and print the plan without creating receipts or moving
+files.
 
 ## Updating
 
 1. Update OMP's version, asset names, and hashes in `pkgs/omp/default.nix`.
 2. Update the Herdr input revision in `flake.nix`, then run
    `nix flake lock --update-input herdr`.
-3. Review model identifiers and routing in `omp/config.yml` and
+3. Review model identifiers and routing in `omp/defaults.yml` and
    `omp/presets/`.
 4. Run `nix flake check --show-trace`.
 5. Apply the profile with `zconf`.

--- a/modules/home/agent-tools.nix
+++ b/modules/home/agent-tools.nix
@@ -7,7 +7,8 @@
 
 let
   cfg = config.atyrode.agentTools;
-  baseConfig = ../../omp/config.yml;
+  defaultsConfig = ../../omp/defaults.yml;
+  policyConfig = ../../omp/policy.yml;
   presets = {
     budget = ../../omp/presets/budget.yml;
     fable = ../../omp/presets/fable-primary.yml;
@@ -47,7 +48,8 @@ in
     ];
 
     xdg.configFile = {
-      "omp/base.yml".source = baseConfig;
+      "omp/defaults.yml".source = defaultsConfig;
+      "omp/policy.yml".source = policyConfig;
       "omp/presets/budget.yml".source = presets.budget;
       "omp/presets/fable-primary.yml".source = presets.fable;
       "omp/presets/gpt56.yml".source = presets.gpt;
@@ -59,25 +61,22 @@ in
         source = ../../agents/skills;
         recursive = true;
       };
-
-      ".omp/agent/agents" = {
-        source = "${cfg.ompAgentsPackage}/share/omp/agents";
-        recursive = true;
-      };
-
-      ".omp/agent/extensions/herdr-omp-agent-state.ts".source =
-        "${cfg.herdrIntegrationPackage}/share/omp/extensions/herdr-omp-agent-state.ts";
-
-      ".omp/agent/rules/no-shell-text-surgery.md".source = ../../omp/rules/no-shell-text-surgery.md;
     };
 
-    home.activation.migrateLegacyAgentTools = lib.mkIf cfg.migrateLegacy (
-      lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
+    home.activation = lib.mkIf cfg.migrateLegacy {
+      migrateLegacyAgentTools = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
         if [[ -v DRY_RUN ]]; then
           export AGENT_TOOLS_DRY_RUN=1
         fi
-        ${lib.getExe cfg.migrationPackage}
-      ''
-    );
+        ${lib.getExe cfg.migrationPackage} prepare
+      '';
+
+      finalizeLegacyAgentTools = lib.hm.dag.entryAfter [ "installPackages" "linkGeneration" ] ''
+        if [[ -v DRY_RUN ]]; then
+          export AGENT_TOOLS_DRY_RUN=1
+        fi
+        ${lib.getExe cfg.migrationPackage} finalize "$newGenPath/home-files"
+      '';
+    };
   };
 }

--- a/omp/defaults.yml
+++ b/omp/defaults.yml
@@ -1,9 +1,3 @@
-tools:
-  approvalMode: write
-
-secrets:
-  enabled: true
-
 providers:
   webSearch: auto
 

--- a/omp/extensions/managed-settings-guard.ts
+++ b/omp/extensions/managed-settings-guard.ts
@@ -1,0 +1,336 @@
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+import {
+	existsSync,
+	readFileSync,
+	renameSync,
+	statSync,
+	unlinkSync,
+	unwatchFile,
+	watchFile,
+	writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+export const MANAGED_PATHS = [
+	"providers.webSearch",
+	"providers.anthropic.serverSideFallback",
+	"symbolPreset",
+	"colorBlindMode",
+	"modelRoles",
+	"retry.enabled",
+	"retry.modelFallback",
+	"retry.fallbackRevertPolicy",
+	"retry.fallbackChains",
+	"personality",
+	"advisor.enabled",
+	"advisor.subagents",
+	"advisor.syncBacklog",
+	"stt.enabled",
+	"branchSummary.enabled",
+	"autolearn.enabled",
+	"autolearn.autoContinue",
+	"github.enabled",
+	"checkpoint.enabled",
+	"statusLine.preset",
+	"statusLine.compactThinkingLevel",
+	"statusLine.transparent",
+	"terminal.showProgress",
+	"tui.tight",
+	"display.shimmer",
+	"display.showTokenUsage",
+	"display.cacheMissMarker",
+	"codexResets.autoRedeem",
+	"task.showResolvedModelBadge",
+	"task.agentModelOverrides",
+	"task.disabledAgents",
+	"memory.backend",
+	"theme.dark",
+	"browser.headless",
+	"browser.enabled",
+	"proseOnlyThinking",
+	"defaultThinkingLevel",
+	"tools.approvalMode",
+	"secrets.enabled",
+] as const;
+
+type ConfigRecord = Record<string, unknown>;
+
+interface ManagedPathNode {
+	terminal: boolean;
+	children: Map<string, ManagedPathNode>;
+}
+
+interface ConfigSlot {
+	hasValue: boolean;
+	value?: unknown;
+}
+
+export interface RestoreResult {
+	config: unknown;
+	changed: boolean;
+}
+
+function isConfigRecord(value: unknown): value is ConfigRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneConfig<T>(value: T): T {
+	return structuredClone(value);
+}
+
+function configEquals(left: unknown, right: unknown): boolean {
+	return Bun.deepEquals(left, right, true);
+}
+
+function buildManagedPathTree(paths: readonly string[]): ManagedPathNode {
+	const root: ManagedPathNode = { terminal: false, children: new Map() };
+
+	for (const path of paths) {
+		let node = root;
+		for (const segment of path.split(".")) {
+			let child = node.children.get(segment);
+			if (!child) {
+				child = { terminal: false, children: new Map() };
+				node.children.set(segment, child);
+			}
+			node = child;
+		}
+		node.terminal = true;
+	}
+
+	return root;
+}
+
+function restoreSlot(
+	current: ConfigSlot,
+	baseline: ConfigSlot,
+	node: ManagedPathNode,
+): ConfigSlot {
+	if (node.terminal) {
+		return baseline.hasValue
+			? { hasValue: true, value: cloneConfig(baseline.value) }
+			: { hasValue: false };
+	}
+
+	if (baseline.hasValue && !isConfigRecord(baseline.value)) {
+		// A scalar or sequence at an ancestor owns the effective value of every
+		// descendant. Restore it wholesale rather than trying to descend through it.
+		return { hasValue: true, value: cloneConfig(baseline.value) };
+	}
+
+	const currentWasRecord = current.hasValue && isConfigRecord(current.value);
+	const restored: ConfigRecord = currentWasRecord
+		? cloneConfig(current.value as ConfigRecord)
+		: {};
+	const baselineRecord =
+		baseline.hasValue && isConfigRecord(baseline.value)
+			? baseline.value
+			: undefined;
+
+	for (const [segment, child] of node.children) {
+		const currentHasChild = Object.hasOwn(restored, segment);
+		const baselineHasChild =
+			baselineRecord !== undefined && Object.hasOwn(baselineRecord, segment);
+		const childResult = restoreSlot(
+			{
+				hasValue: currentHasChild,
+				value: currentHasChild ? restored[segment] : undefined,
+			},
+			{
+				hasValue: baselineHasChild,
+				value: baselineHasChild ? baselineRecord?.[segment] : undefined,
+			},
+			child,
+		);
+
+		if (childResult.hasValue) {
+			restored[segment] = childResult.value;
+		} else {
+			delete restored[segment];
+		}
+	}
+
+	if (currentWasRecord) return { hasValue: true, value: restored };
+	if (Object.keys(restored).length > 0) {
+		return { hasValue: true, value: restored };
+	}
+	if (baseline.hasValue) return { hasValue: true, value: restored };
+	return { hasValue: false };
+}
+
+/**
+ * Restore Nix-owned paths from a startup snapshot while retaining edits outside
+ * those paths. The function is side-effect free and intentionally accepts
+ * unknown YAML roots so malformed ancestor shapes can be repaired safely.
+ */
+export function restoreManagedPaths(
+	currentConfig: unknown,
+	baselineConfig: unknown,
+	managedPaths: readonly string[] = MANAGED_PATHS,
+): RestoreResult {
+	const tree = buildManagedPathTree(managedPaths);
+	const restored = restoreSlot(
+		{ hasValue: true, value: currentConfig },
+		{ hasValue: true, value: baselineConfig },
+		tree,
+	);
+	const config = restored.hasValue ? restored.value : {};
+
+	return {
+		config,
+		changed: !configEquals(config, currentConfig),
+	};
+}
+
+function machineConfigCandidates(
+	env: NodeJS.ProcessEnv = process.env,
+	cwd = process.cwd(),
+): [string, string] {
+	const home = env.HOME || cwd;
+	const configuredAgentDir = env.PI_CODING_AGENT_DIR?.trim();
+	const agentDir = configuredAgentDir
+		? isAbsolute(configuredAgentDir)
+			? configuredAgentDir
+			: resolve(cwd, configuredAgentDir)
+		: join(home, env.PI_CONFIG_DIR || ".omp", "agent");
+
+	return [join(agentDir, "config.yml"), join(agentDir, "config.yaml")];
+}
+
+/** Resolve the same writable machine configuration fallback used by OMP. */
+export function resolveMachineConfigPath(
+	env: NodeJS.ProcessEnv = process.env,
+	cwd = process.cwd(),
+): string {
+	const [ymlPath, yamlPath] = machineConfigCandidates(env, cwd);
+	return existsSync(ymlPath) || !existsSync(yamlPath) ? ymlPath : yamlPath;
+}
+
+function localOverridePath(env: NodeJS.ProcessEnv = process.env): string {
+	const home = env.HOME || process.cwd();
+	const configHome = env.XDG_CONFIG_HOME
+		? isAbsolute(env.XDG_CONFIG_HOME)
+			? env.XDG_CONFIG_HOME
+			: resolve(home, env.XDG_CONFIG_HOME)
+		: join(home, ".config");
+	return join(configHome, "omp", "local.yml");
+}
+
+function settingsMessage(): string {
+	return `Nix-managed settings are locked for this session. Use \`omp config managed\` to inspect effective values, \`${localOverridePath()}\` for machine-only defaults, or edit the dotfiles policy.`;
+}
+
+function parseConfigFile(path: string): unknown {
+	if (!existsSync(path)) return {};
+	const parsed = Bun.YAML.parse(readFileSync(path, "utf8"));
+	return isConfigRecord(parsed) ? parsed : {};
+}
+
+function writeConfigFile(path: string, config: unknown): void {
+	const tempPath = join(
+		dirname(path),
+		`.${path.split("/").at(-1)}.managed-guard-${process.pid}-${Date.now()}`,
+	);
+	const mode = existsSync(path) ? statSync(path).mode & 0o777 : 0o600;
+
+	try {
+		writeFileSync(tempPath, Bun.YAML.stringify(config), {
+			encoding: "utf8",
+			mode,
+			flag: "wx",
+		});
+		renameSync(tempPath, path);
+	} finally {
+		try {
+			unlinkSync(tempPath);
+		} catch {
+			// The atomic rename normally consumes the temporary file.
+		}
+	}
+}
+
+export default function managedSettingsGuard(pi: ExtensionAPI) {
+	const candidates = machineConfigCandidates();
+	const snapshotPath = resolveMachineConfigPath();
+	let baseline: unknown;
+	let baselineError = false;
+	let notify: ((message: string, level: "warning") => void) | undefined;
+	let pendingNotice: "restored" | "error" | undefined;
+	let lastNotice = "";
+	let lastNoticeAt = 0;
+
+	try {
+		baseline = parseConfigFile(snapshotPath);
+	} catch {
+		baseline = {};
+		baselineError = true;
+	}
+
+	const sendNotice = (kind: "restored" | "error") => {
+		const message =
+			kind === "restored"
+				? "A command tried to change Nix-managed OMP settings. Those paths were restored; unmanaged edits were kept."
+				: "The managed-settings guard could not safely read or restore the writable OMP configuration. Fix its YAML before changing settings.";
+		if (!notify) {
+			pendingNotice = kind;
+			return;
+		}
+		const now = Date.now();
+		if (message === lastNotice && now - lastNoticeAt < 1_000) return;
+		lastNotice = message;
+		lastNoticeAt = now;
+		notify(message, "warning");
+	};
+
+	let protecting = false;
+	const protectManagedPaths = () => {
+		if (protecting) return;
+		protecting = true;
+		try {
+			if (baselineError) {
+				sendNotice("error");
+				return;
+			}
+
+			const activePath = resolveMachineConfigPath();
+			const current = parseConfigFile(activePath);
+			const restored = restoreManagedPaths(current, baseline);
+			if (!restored.changed) return;
+
+			writeConfigFile(activePath, restored.config);
+			sendNotice("restored");
+		} catch {
+			sendNotice("error");
+		} finally {
+			protecting = false;
+		}
+	};
+
+	const watcher = () => protectManagedPaths();
+	for (const candidate of candidates) {
+		watchFile(candidate, { interval: 500, persistent: false }, watcher);
+	}
+
+	pi.on("session_start", (_event, ctx) => {
+		notify = (message, level) => ctx.ui.notify(message, level);
+		if (pendingNotice) {
+			const notice = pendingNotice;
+			pendingNotice = undefined;
+			sendNotice(notice);
+		}
+	});
+
+	pi.on("input", (event, ctx) => {
+		const command = event.text.trim().split(/\s+/, 1)[0]?.toLowerCase();
+		if (command !== "/settings") return;
+
+		ctx.ui.notify(settingsMessage(), "warning");
+		return { handled: true };
+	});
+
+	pi.on("session_shutdown", () => {
+		protectManagedPaths();
+		for (const candidate of candidates) unwatchFile(candidate, watcher);
+		notify = undefined;
+	});
+}

--- a/omp/policy.yml
+++ b/omp/policy.yml
@@ -1,0 +1,5 @@
+tools:
+  approvalMode: write
+
+secrets:
+  enabled: true

--- a/pkgs/agent-tools-migrate/default.nix
+++ b/pkgs/agent-tools-migrate/default.nix
@@ -1,5 +1,7 @@
 {
   coreutils,
+  diffutils,
+  flock,
   jq,
   lib,
   writeShellApplication,
@@ -11,6 +13,8 @@ writeShellApplication {
 
   runtimeInputs = [
     coreutils
+    diffutils
+    flock
     jq
     yq-go
   ];

--- a/pkgs/herdr-configured/default.nix
+++ b/pkgs/herdr-configured/default.nix
@@ -9,12 +9,15 @@ let
   wrapper = writeShellApplication {
     name = "herdr";
     text = ''
-      case "''${1:-}" in
-        update)
+      for arg in "$@"; do
+        if [[ "$arg" == -- ]]; then
+          break
+        fi
+        if [[ "$arg" == update ]]; then
           printf '%s\n' 'Herdr is managed by Nix. Update the flake input, then run zconf.' >&2
           exit 2
-          ;;
-      esac
+        fi
+      done
 
       exec ${lib.escapeShellArg (lib.getExe herdr)} "$@"
     '';

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1,63 +1,931 @@
 {
+  jq,
   lib,
+  herdr-omp-integration,
   omp,
+  omp-agents,
   runCommand,
   writeShellApplication,
+  yq-go,
 }:
 
 let
-  baseConfig = ../../omp/config.yml;
+  defaultsConfig = ../../omp/defaults.yml;
+  policyConfig = ../../omp/policy.yml;
+  platformRoot = runCommand "omp-managed-platform-${lib.getVersion omp}" { } ''
+    mkdir -p "$out/agents" "$out/extensions" "$out/rules"
+    cp ${omp-agents}/share/omp/agents/*.md "$out/agents/"
+    cp ${herdr-omp-integration}/share/omp/extensions/herdr-omp-agent-state.ts "$out/extensions/"
+    cp ${../../omp/extensions/managed-settings-guard.ts} "$out/extensions/managed-settings-guard.ts"
+    cp ${../../omp/rules/no-shell-text-surgery.md} "$out/rules/no-shell-text-surgery.md"
+    cat > "$out/package.json" <<'EOF'
+    {
+      "name": "atyrode-managed-omp-platform",
+      "private": true,
+      "type": "module",
+      "omp": {
+        "extensions": [
+          "./extensions/herdr-omp-agent-state.ts",
+          "./extensions/managed-settings-guard.ts"
+        ]
+      }
+    }
+    EOF
+  '';
   presets = {
     budget = ../../omp/presets/budget.yml;
     fable = ../../omp/presets/fable-primary.yml;
     gpt = ../../omp/presets/gpt56.yml;
     opusFallback = ../../omp/presets/opus-fallback.yml;
   };
-  ompWrapper = writeShellApplication {
-    name = "omp";
-    text = ''
-      raw_omp=${lib.escapeShellArg (lib.getExe omp)}
 
-      case "''${1:-}" in
-        update)
-          printf '%s\n' 'OMP is managed by Nix. Update the pinned derivation, then run zconf.' >&2
-          exit 2
-          ;;
-      esac
+  managedDefaultPaths = [
+    "providers.webSearch"
+    "symbolPreset"
+    "colorBlindMode"
+    "modelRoles"
+    "retry.enabled"
+    "retry.modelFallback"
+    "retry.fallbackRevertPolicy"
+    "retry.fallbackChains"
+    "personality"
+    "advisor.enabled"
+    "advisor.subagents"
+    "advisor.syncBacklog"
+    "stt.enabled"
+    "branchSummary.enabled"
+    "autolearn.enabled"
+    "autolearn.autoContinue"
+    "github.enabled"
+    "checkpoint.enabled"
+    "statusLine.preset"
+    "statusLine.compactThinkingLevel"
+    "statusLine.transparent"
+    "terminal.showProgress"
+    "tui.tight"
+    "display.shimmer"
+    "display.showTokenUsage"
+    "display.cacheMissMarker"
+    "codexResets.autoRedeem"
+    "task.showResolvedModelBadge"
+    "task.agentModelOverrides"
+    "task.disabledAgents"
+    "memory.backend"
+    "theme.dark"
+    "browser.headless"
+    "browser.enabled"
+    "proseOnlyThinking"
+    "defaultThinkingLevel"
+  ];
+  managedPresetPaths = [
+    "providers.anthropic.serverSideFallback"
+  ];
+  enforcedPolicyPaths = [
+    "tools.approvalMode"
+    "secrets.enabled"
+  ];
+  managedOwnedPaths = managedDefaultPaths ++ managedPresetPaths;
+  allManagedPaths = managedOwnedPaths ++ enforcedPolicyPaths;
 
-      case "''${1:-}" in
-        __complete|acp|agents|auth-broker|auth-gateway|bench|commit|completions|config|dry-balance|gallery|gc|grep|grievances|install|join|models|plugin|read|say|search|setup|shell|ssh|stats|tiny-models|token|ttsr|update|usage|worktree)
-          exec "$raw_omp" "$@"
-          ;;
-      esac
-
-      managed_args=(
-        --config ${lib.escapeShellArg (toString baseConfig)}
-      )
-      local_config="''${XDG_CONFIG_HOME:-$HOME/.config}/omp/local.yml"
-      if [[ -f "$local_config" ]]; then
-        managed_args+=(--config "$local_config")
-      fi
-
-      exec "$raw_omp" "''${managed_args[@]}" "$@"
-    '';
-  };
-
-  mkPresetCommand =
-    name: presetArgs:
+  mkOmpCommand =
+    name: presetConfigs:
     writeShellApplication {
       inherit name;
+      runtimeInputs = [
+        jq
+        yq-go
+      ];
       text = ''
-        exec ${lib.escapeShellArg (lib.getExe ompWrapper)} ${
-          lib.concatMapStringsSep " " (path: "--config ${lib.escapeShellArg (toString path)}") presetArgs
-        } "$@"
+        raw_omp=${lib.escapeShellArg (lib.getExe omp)}
+        launcher=${lib.escapeShellArg name}
+        defaults_config='${defaultsConfig}'
+        policy_config='${policyConfig}'
+        platform_root='${platformRoot}'
+        local_config="''${XDG_CONFIG_HOME:-$HOME/.config}/omp/local.yml"
+
+        preset_configs=( ${lib.concatMapStringsSep " " (path: "'${path}'") presetConfigs} )
+        managed_default_paths=( ${lib.escapeShellArgs managedDefaultPaths} )
+        managed_preset_paths=( ${lib.escapeShellArgs managedPresetPaths} )
+        enforced_policy_paths=( ${lib.escapeShellArgs enforcedPolicyPaths} )
+        managed_default_paths_json=${lib.escapeShellArg (builtins.toJSON managedDefaultPaths)}
+        managed_preset_paths_json=${lib.escapeShellArg (builtins.toJSON managedPresetPaths)}
+        enforced_policy_paths_json=${lib.escapeShellArg (builtins.toJSON enforcedPolicyPaths)}
+        all_managed_paths_json=${lib.escapeShellArg (builtins.toJSON allManagedPaths)}
+        preset_paths_json=${lib.escapeShellArg (builtins.toJSON (map toString presetConfigs))}
+
+        takes_required_value() {
+          case "$1" in
+            --alias|--api-key|--append-system-prompt|--approval-mode|--config|--cwd|--export|--extension|-e|--fork|--hook|--max-time|--mode|--model|--models|--plan|--plugin-dir|--profile|--provider|--provider-session-id|--session-dir|--skills|--slow|--smol|--system-prompt|--thinking|--tools)
+              return 0
+              ;;
+            *)
+              return 1
+              ;;
+          esac
+        }
+
+        takes_optional_value() {
+          case "$1" in
+            --resume|-r|--session)
+              return 0
+              ;;
+            *)
+              return 1
+              ;;
+          esac
+        }
+
+        is_known_boolean() {
+          case "$1" in
+            --advisor|--allow-home|--auto-approve|--continue|-c|--hide-thinking|--no-extensions|--no-lsp|--no-pty|--no-rules|--no-session|--no-skills|--no-title|--no-tools|--print|-p|--print-thoughts|--yolo)
+              return 0
+              ;;
+            *)
+              return 1
+              ;;
+          esac
+        }
+
+        is_known_subcommand() {
+          case "$1" in
+            __complete|acp|agents|auth-broker|auth-gateway|bench|commit|completions|config|dry-balance|gallery|gc|grep|grievances|install|join|models|plugin|read|say|search|setup|shell|ssh|stats|tiny-models|token|ttsr|update|usage|worktree)
+              return 0
+              ;;
+            *)
+              return 1
+              ;;
+          esac
+        }
+
+        paths_overlap() {
+          local key="$1"
+          local owner="$2"
+          [[ "$key" == "$owner" || "$key" == "$owner".* || "$owner" == "$key".* ]]
+        }
+
+        contains_managed_path() {
+          local key="$1"
+          shift
+          local candidate
+          for candidate in "$@"; do
+            if paths_overlap "$key" "$candidate"; then
+              return 0
+            fi
+          done
+          return 1
+        }
+
+        json_array() {
+          if (( $# == 0 )); then
+            printf '[]\n'
+            return 0
+          fi
+          printf '%s\n' "$@" | jq -Rsc 'split("\n")[:-1]'
+        }
+
+        normalize_profile() {
+          local raw="$1"
+          local strict="$2"
+          local value="$raw"
+          value="''${value#"''${value%%[![:space:]]*}"}"
+          value="''${value%"''${value##*[![:space:]]}"}"
+
+          normalized_profile=""
+          if [[ -z "$value" || "$value" == default ]]; then
+            return 0
+          fi
+          if [[ "$value" == . || "$value" == .. || "$value" == *. ]] ||
+            [[ ! "$value" =~ ^[a-z0-9][a-z0-9._-]{0,63}$ ]] ||
+            [[ "$value" =~ ^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$ ]]; then
+            if [[ "$strict" == true ]]; then
+              printf '%s\n' \
+                "Error: Invalid OMP profile '$raw'. Profile names must match ^[a-z0-9][a-z0-9._-]{0,63}$, cannot be '.', '..', end in '.', or use a Windows reserved device name." >&2
+            fi
+            return 1
+          fi
+          normalized_profile="$value"
+        }
+
+        resolve_path_from_cwd() {
+          local value="$1"
+          local base="$2"
+          case "$value" in
+            "~") value="$HOME" ;;
+            \~/*) value="$HOME/''${value:2}" ;;
+            /*) ;;
+            *) value="$base/$value" ;;
+          esac
+          if [[ -d "$value" ]]; then
+            value="$(cd "$value" && pwd -P)"
+          fi
+          printf '%s\n' "$value"
+        }
+
+        discover_runtime_context() {
+          launch_cwd="$PWD"
+          if [[ -v OMP_PROFILE ]]; then
+            active_profile="$OMP_PROFILE"
+          elif [[ -v PI_PROFILE ]]; then
+            active_profile="$PI_PROFILE"
+          else
+            active_profile=default
+          fi
+          runtime_approval_mode=""
+          runtime_model=""
+          runtime_thinking=""
+          runtime_advisor=false
+          runtime_smol="''${PI_SMOL_MODEL:-}"
+          runtime_slow="''${PI_SLOW_MODEL:-}"
+          runtime_plan="''${PI_PLAN_MODEL:-}"
+          explicit_cwd=false
+          allow_home=false
+
+          local i arg
+          for ((i = 0; i < ''${#original_args[@]}; i++)); do
+            arg="''${original_args[$i]}"
+            case "$arg" in
+              --)
+                break
+                ;;
+              --cwd=*)
+                launch_cwd="''${arg#--cwd=}"
+                explicit_cwd=true
+                ;;
+              --cwd)
+                if (( i + 1 < ''${#original_args[@]} )); then
+                  i=$((i + 1))
+                  launch_cwd="''${original_args[$i]}"
+                  explicit_cwd=true
+                fi
+                ;;
+              --profile=*)
+                active_profile="''${arg#--profile=}"
+                ;;
+              --profile)
+                if (( i + 1 < ''${#original_args[@]} )); then
+                  i=$((i + 1))
+                  active_profile="''${original_args[$i]}"
+                fi
+                ;;
+              --approval-mode=*)
+                runtime_approval_mode="''${arg#--approval-mode=}"
+                ;;
+              --approval-mode)
+                if (( i + 1 < ''${#original_args[@]} )); then
+                  i=$((i + 1))
+                  runtime_approval_mode="''${original_args[$i]}"
+                fi
+                ;;
+              --auto-approve | --yolo)
+                runtime_approval_mode=yolo
+                ;;
+              --model=*)
+                runtime_model="''${arg#--model=}"
+                ;;
+              --model)
+                if (( i + 1 < ''${#original_args[@]} )); then
+                  i=$((i + 1))
+                  runtime_model="''${original_args[$i]}"
+                fi
+                ;;
+              --smol=*)
+                runtime_smol="''${arg#--smol=}"
+                ;;
+              --smol)
+                if (( i + 1 < ''${#original_args[@]} )); then
+                  i=$((i + 1))
+                  runtime_smol="''${original_args[$i]}"
+                fi
+                ;;
+              --slow=*)
+                runtime_slow="''${arg#--slow=}"
+                ;;
+              --slow)
+                if (( i + 1 < ''${#original_args[@]} )); then
+                  i=$((i + 1))
+                  runtime_slow="''${original_args[$i]}"
+                fi
+                ;;
+              --plan=*)
+                runtime_plan="''${arg#--plan=}"
+                ;;
+              --plan)
+                if (( i + 1 < ''${#original_args[@]} )); then
+                  i=$((i + 1))
+                  runtime_plan="''${original_args[$i]}"
+                fi
+                ;;
+              --thinking=*)
+                runtime_thinking="''${arg#--thinking=}"
+                ;;
+              --thinking)
+                if (( i + 1 < ''${#original_args[@]} )); then
+                  i=$((i + 1))
+                  runtime_thinking="''${original_args[$i]}"
+                fi
+                ;;
+              --advisor)
+                runtime_advisor=true
+                ;;
+              --allow-home)
+                allow_home=true
+                ;;
+              --*=*)
+                ;;
+              *)
+                if takes_required_value "$arg"; then
+                  if (( i + 1 < ''${#original_args[@]} )); then
+                    i=$((i + 1))
+                  fi
+                elif takes_optional_value "$arg"; then
+                  if (( i + 1 < ''${#original_args[@]} )) &&
+                    [[ "''${original_args[$((i + 1))]}" != -* ]]; then
+                    i=$((i + 1))
+                  fi
+                fi
+                ;;
+            esac
+          done
+
+          case "$launch_cwd" in
+            /*) ;;
+            *) launch_cwd="$PWD/$launch_cwd" ;;
+          esac
+          if [[ -d "$launch_cwd" ]]; then
+            launch_cwd="$(cd "$launch_cwd" && pwd -P)"
+          fi
+
+          local canonical_home="$HOME"
+          if [[ -d "$canonical_home" ]]; then
+            canonical_home="$(cd "$canonical_home" && pwd -P)"
+          fi
+          if [[ "$explicit_cwd" == false && "$allow_home" == false && "$launch_cwd" == "$canonical_home" ]]; then
+            local candidate fallback
+            for candidate in "$HOME/tmp" /tmp /var/tmp; do
+              if [[ -d "$candidate" ]]; then
+                launch_cwd="$(cd "$candidate" && pwd -P)"
+                break
+              fi
+            done
+            if [[ "$launch_cwd" == "$canonical_home" ]]; then
+              fallback="''${TMPDIR:-''${TMP:-''${TEMP:-/tmp}}}"
+              if [[ -d "$fallback" ]]; then
+                fallback="$(cd "$fallback" && pwd -P)"
+                if [[ "$fallback" != "$canonical_home" ]]; then
+                  launch_cwd="$fallback"
+                fi
+              fi
+            fi
+          fi
+
+          project_settings="$launch_cwd/.omp/settings.json"
+          project_config="$launch_cwd/.omp/config.yml"
+          if ! normalize_profile "$active_profile" true; then
+            exit 1
+          fi
+          active_profile="$normalized_profile"
+          if [[ -z "$active_profile" ]]; then
+            active_profile=default
+            local inherited_profile=""
+            if normalize_profile "''${PI_PROFILE:-}" false; then
+              inherited_profile="$normalized_profile"
+            fi
+            local config_root="$HOME/''${PI_CONFIG_DIR:-.omp}"
+            local inherited_agent_dir=""
+            if [[ -n "$inherited_profile" ]]; then
+              inherited_agent_dir="$config_root/profiles/$inherited_profile/agent"
+            fi
+            if [[ -n "''${PI_CODING_AGENT_DIR:-}" && "$PI_CODING_AGENT_DIR" != "$inherited_agent_dir" ]]; then
+              state_path="$PI_CODING_AGENT_DIR"
+              case "$state_path" in
+                "~") state_path="$HOME" ;;
+                \~/*) state_path="$HOME/''${state_path:2}" ;;
+                /*) ;;
+                *) state_path="$PWD/$state_path" ;;
+              esac
+            else
+              state_path="$config_root/agent"
+            fi
+          else
+            state_path="$HOME/''${PI_CONFIG_DIR:-.omp}/profiles/$active_profile/agent"
+          fi
+          if [[ -d "$state_path" ]]; then
+            state_path="$(cd "$state_path" && pwd -P)"
+          fi
+          machine_config="$state_path/config.yml"
+          if [[ ! -e "$machine_config" && -e "$state_path/config.yaml" ]]; then
+            machine_config="$state_path/config.yaml"
+          fi
+        }
+
+        subcommand=""
+        subcommand_index=-1
+
+        classify_invocation() {
+          local -a argv=( "$@" )
+          local i=0
+          local arg flag next
+
+          while (( i < ''${#argv[@]} )); do
+            arg="''${argv[$i]}"
+
+            case "$arg" in
+              --)
+                return 0
+                ;;
+              --help|-h|--version|-v)
+                subcommand="__passthrough__"
+                return 0
+                ;;
+            esac
+
+            if [[ "$arg" == --*=* ]]; then
+              flag="''${arg%%=*}"
+              if takes_required_value "$flag" || takes_optional_value "$flag"; then
+                i=$((i + 1))
+                continue
+              fi
+            fi
+
+            if takes_required_value "$arg"; then
+              if (( i + 1 >= ''${#argv[@]} )); then
+                return 0
+              fi
+              i=$((i + 2))
+              continue
+            fi
+
+            if takes_optional_value "$arg"; then
+              next="''${argv[$((i + 1))]:-}"
+              if [[ -n "$next" && "$next" != -* ]]; then
+                i=$((i + 2))
+              else
+                i=$((i + 1))
+              fi
+              continue
+            fi
+
+            if is_known_boolean "$arg"; then
+              i=$((i + 1))
+              continue
+            fi
+
+            if is_known_subcommand "$arg"; then
+              subcommand="$arg"
+              subcommand_index="$i"
+              return 0
+            fi
+
+            # The first unknown flag or positional belongs to a root session.
+            return 0
+          done
+        }
+
+        normalize_layer_json() {
+          local file="$1"
+          yq eval -o=json -I=0 '.' "$file" | jq -c '
+            if (.theme | type) == "string" then
+              if .theme == "light" or .theme == "dark" then
+                del(.theme)
+              else
+                .theme = { dark: .theme }
+              end
+            else . end
+            | if (.codexResets | type) == "object" and (.codexResets.autoRedeem | type) == "boolean" then
+                .codexResets.autoRedeem = (if .codexResets.autoRedeem then "yes" else "no" end)
+              else . end
+            | if (."codexResets.autoRedeem" | type) == "boolean" then
+                ."codexResets.autoRedeem" = (if ."codexResets.autoRedeem" then "yes" else "no" end)
+              else . end
+            | if (.memory | type) != "object" then .memory = {} else . end
+            | if ((.memory.backend | type) != "string")
+                and ((.memories | type) == "object")
+                and ((.memories.enabled | type) == "boolean") then
+                .memory.backend = (if .memories.enabled then "local" else "off" end)
+              else . end
+            | if .memory.backend == "mnemosyne" then .memory.backend = "mnemopi" else . end
+            | if (.memory | length) == 0 then del(.memory) else . end
+            | if ((.task | type) == "object")
+                and ((.task.isolation | type) == "object")
+                and ((.task.isolation.enabled | type) == "boolean") then
+                .task.isolation.mode = (if .task.isolation.enabled then "auto" else "none" end)
+                | del(.task.isolation.enabled)
+              else . end
+            | if (try .task.isolation.mode catch null) == "worktree" then .task.isolation.mode = "rcopy"
+              elif (try .task.isolation.mode catch null) == "fuse-overlay" then .task.isolation.mode = "overlayfs"
+              elif (try .task.isolation.mode catch null) == "fuse-projfs" then .task.isolation.mode = "projfs"
+              else . end
+          '
+        }
+
+        emit_managed_config() {
+          local json_output="$1"
+          local local_present=false
+          local machine_present=false
+          local project_settings_present=false
+          local project_config_present=false
+          local -a layer_files=()
+          local preset
+
+          if [[ -e "$machine_config" ]]; then
+            machine_present=true
+            layer_files+=( "$machine_config" )
+          fi
+          layer_files+=( "$defaults_config" )
+          if [[ -e "$project_settings" ]]; then
+            project_settings_present=true
+            layer_files+=( "$project_settings" )
+          fi
+          if [[ -e "$project_config" ]]; then
+            project_config_present=true
+            layer_files+=( "$project_config" )
+          fi
+
+          if [[ -f "$local_config" ]]; then
+            local_present=true
+            layer_files+=( "$local_config" )
+          fi
+          for preset in "''${preset_configs[@]}"; do
+            layer_files+=( "$preset" )
+          done
+          extract_one_shot_configs "''${original_args[@]}"
+          local one_shot
+          local -a resolved_one_shot_configs=()
+          for one_shot in "''${one_shot_configs[@]}"; do
+            one_shot="$(resolve_path_from_cwd "$one_shot" "$launch_cwd")"
+            resolved_one_shot_configs+=( "$one_shot" )
+            layer_files+=( "$one_shot" )
+          done
+          layer_files+=( "$policy_config" )
+
+          local merged_json effective_managed policy_json diagnostic_json one_shots_json runtime_overrides
+          merged_json='{}'
+          local layer_json layer_file
+          for layer_file in "''${layer_files[@]}"; do
+            layer_json="$(normalize_layer_json "$layer_file")"
+            merged_json="$(printf '%s\n%s\n' "$merged_json" "$layer_json" | jq -cs '.[0] * .[1]')"
+          done
+          effective_managed="$(
+            # shellcheck disable=SC2016
+            jq -c --argjson paths "$all_managed_paths_json" '
+              . as $source
+              | reduce $paths[] as $key ({};
+                  ($key | split(".")) as $path
+                  | (try ($source | getpath($path)) catch null) as $value
+                  | if $value == null then . else setpath($path; $value) end
+                )
+            ' <<<"$merged_json"
+          )"
+          runtime_overrides="$(
+            jq -n \
+              --arg approvalMode "$runtime_approval_mode" \
+              --arg model "$runtime_model" \
+              --arg thinking "$runtime_thinking" \
+              --arg smol "$runtime_smol" \
+              --arg slow "$runtime_slow" \
+              --arg plan "$runtime_plan" \
+              --argjson advisor "$runtime_advisor" '
+                {
+                  approvalMode: (if $approvalMode == "" then null else $approvalMode end),
+                  model: (if $model == "" then null else $model end),
+                  thinking: (if $thinking == "" then null else $thinking end),
+                  smol: (if $smol == "" then null else $smol end),
+                  slow: (if $slow == "" then null else $slow end),
+                  plan: (if $plan == "" then null else $plan end),
+                  advisor: (if $advisor then true else null end)
+                }
+                | with_entries(select(.value != null))
+              '
+          )"
+          if [[ -n "$runtime_approval_mode" ]]; then
+            effective_managed="$(
+              jq -c --arg value "$runtime_approval_mode" '.tools.approvalMode = $value' <<<"$effective_managed"
+            )"
+          fi
+          if [[ -n "$runtime_thinking" ]]; then
+            effective_managed="$(
+              jq -c --arg value "$runtime_thinking" '.defaultThinkingLevel = $value' <<<"$effective_managed"
+            )"
+          fi
+          if [[ "$runtime_advisor" == true ]]; then
+            effective_managed="$(jq -c '.advisor.enabled = true' <<<"$effective_managed")"
+          fi
+          if [[ -n "$runtime_model" ]]; then
+            effective_managed="$(jq -c --arg value "$runtime_model" '.modelRoles.default = $value' <<<"$effective_managed")"
+          fi
+          if [[ -n "$runtime_smol" ]]; then
+            effective_managed="$(jq -c --arg value "$runtime_smol" '.modelRoles.smol = $value' <<<"$effective_managed")"
+          fi
+          if [[ -n "$runtime_slow" ]]; then
+            effective_managed="$(jq -c --arg value "$runtime_slow" '.modelRoles.slow = $value' <<<"$effective_managed")"
+          fi
+          if [[ -n "$runtime_plan" ]]; then
+            effective_managed="$(jq -c --arg value "$runtime_plan" '.modelRoles.plan = $value' <<<"$effective_managed")"
+          fi
+          policy_json="$(yq eval -o=json -I=0 '.' "$policy_config")"
+          one_shots_json="$(json_array "''${resolved_one_shot_configs[@]}")"
+
+          diagnostic_json="$(
+            # shellcheck disable=SC2016
+            jq -n \
+              --arg launcher "$launcher" \
+              --arg profile "$active_profile" \
+              --arg statePath "$state_path" \
+              --arg effectiveCwd "$launch_cwd" \
+              --arg machine "$machine_config" \
+              --argjson machinePresent "$machine_present" \
+              --arg defaults "$defaults_config" \
+              --arg projectSettings "$project_settings" \
+              --argjson projectSettingsPresent "$project_settings_present" \
+              --arg project "$project_config" \
+              --argjson projectConfigPresent "$project_config_present" \
+              --arg local "$local_config" \
+              --argjson localPresent "$local_present" \
+              --arg policy "$policy_config" \
+              --argjson presets "$preset_paths_json" \
+              --argjson oneShots "$one_shots_json" \
+              --argjson defaultKeys "$managed_default_paths_json" \
+              --argjson presetKeys "$managed_preset_paths_json" \
+              --argjson policyKeys "$enforced_policy_paths_json" \
+              --argjson effectiveManaged "$effective_managed" \
+              --argjson enforcedPolicy "$policy_json" \
+              --argjson runtimeOverrides "$runtime_overrides" '
+                {
+                  launcher: $launcher,
+                  profile: $profile,
+                  statePath: $statePath,
+                  effectiveCwd: $effectiveCwd,
+                  sources: (
+                    [
+                      { kind: "writable-machine-state", managed: false, implicit: true, path: $machine, present: $machinePresent },
+                      { kind: "managed-defaults", managed: true, path: $defaults },
+                      { kind: "native-project", format: "settings.json", managed: false, path: $projectSettings, present: $projectSettingsPresent },
+                      { kind: "native-project", format: "config.yml", managed: false, path: $project, present: $projectConfigPresent },
+                      { kind: "machine-local", managed: false, path: $local, present: $localPresent }
+                    ]
+                    + ($presets | map({ kind: "preset", managed: true, path: . }))
+                    + ($oneShots | map({ kind: "one-shot-config", managed: false, invocationSpecific: true, path: . }))
+                    + [
+                      { kind: "managed-policy", managed: true, enforced: true, path: $policy },
+                      { kind: "runtime-flags", managed: false, invocationSpecific: true, overrides: $runtimeOverrides }
+                    ]
+                  ),
+                  ownership: {
+                    defaults: $defaultKeys,
+                    presets: $presetKeys,
+                    policy: $policyKeys
+                  },
+                  effectiveManaged: $effectiveManaged,
+                  enforcedPolicy: $enforcedPolicy,
+                  runtimeOverrides: $runtimeOverrides
+                }
+              '
+          )"
+
+          if [[ "$json_output" == true ]]; then
+            jq '.' <<<"$diagnostic_json"
+            return 0
+          fi
+
+          printf 'Managed OMP configuration (%s)\n\nSource order:\n' "$launcher"
+          jq -r '
+            .sources
+            | to_entries[]
+            | "  \(.key + 1). \(.value.kind)"
+              + (if .value.path then " - " + .value.path else "" end)
+              + (if .value.present == false then " (not present)" else "" end)
+          ' <<<"$diagnostic_json"
+          printf '\nEffective managed settings:\n'
+          jq '.effectiveManaged' <<<"$diagnostic_json"
+        }
+
+        handle_config_command() {
+          local -a positionals=()
+          local json_output=false
+          local show_help=false
+          local unsupported_flag=""
+          local after_separator=false
+          local i arg
+
+          for ((i = subcommand_index + 1; i < ''${#original_args[@]}; i++)); do
+            arg="''${original_args[$i]}"
+            if [[ "$after_separator" == true ]]; then
+              positionals+=( "$arg" )
+              continue
+            fi
+            case "$arg" in
+              --)
+                after_separator=true
+                ;;
+              --json)
+                json_output=true
+                ;;
+              --help|-h)
+                show_help=true
+                ;;
+              -*)
+                unsupported_flag="$arg"
+                ;;
+              *)
+                positionals+=( "$arg" )
+                ;;
+            esac
+          done
+
+          local action="''${positionals[0]:-list}"
+          local key="''${positionals[1]:-}"
+
+          if [[ "$action" == managed ]]; then
+            if [[ "$show_help" == true ]]; then
+              printf 'Usage: omp config managed [--json]\n'
+              exit 0
+            fi
+            if [[ -n "$unsupported_flag" || ''${#positionals[@]} -ne 1 ]]; then
+              printf 'Usage: omp config managed [--json]\n' >&2
+              exit 2
+            fi
+            emit_managed_config "$json_output"
+            exit 0
+          fi
+
+          if [[ "$action" == set || "$action" == reset ]]; then
+            if contains_managed_path "$key" "''${enforced_policy_paths[@]}"; then
+              printf '%s\n' \
+                "OMP setting '$key' is enforced by Nix policy. Edit the dotfiles policy and run zconf; machine, project, preset, and --config values are intentionally shadowed." >&2
+              exit 2
+            fi
+            if contains_managed_path "$key" "''${managed_default_paths[@]}"; then
+              printf '%s\n' \
+                "OMP setting '$key' is a Nix-managed default. Edit the dotfiles defaults, or override it in $local_config, then run zconf." >&2
+              exit 2
+            fi
+            if contains_managed_path "$key" "''${managed_preset_paths[@]}"; then
+              printf '%s\n' \
+                "OMP setting '$key' is owned by a Nix-managed preset. Edit the preset or choose a launcher that does not select it, then run zconf." >&2
+              exit 2
+            fi
+          fi
+
+          if [[ "$action" == get ]] &&
+            { contains_managed_path "$key" "''${enforced_policy_paths[@]}" ||
+              contains_managed_path "$key" "''${managed_default_paths[@]}"; }; then
+            printf '%s\n' \
+              "OMP setting '$key' has Nix-managed layers. 'omp config get' only reads writable machine state; use 'omp config managed --json' for the effective value." >&2
+            exit 2
+          fi
+          if [[ "$action" == get ]] && contains_managed_path "$key" "''${managed_preset_paths[@]}"; then
+            printf '%s\n' \
+              "OMP setting '$key' is owned by a Nix-managed preset. 'omp config get' only reads writable machine state; use 'omp config managed --json' for the effective value." >&2
+            exit 2
+          fi
+
+          if [[ "$action" == list ]]; then
+            printf '%s\n' \
+              "Note: 'omp config list' shows writable machine state, not Nix overlays. Use 'omp config managed' for effective managed values." >&2
+          fi
+
+          exec "$raw_omp" "''${original_args[@]}"
+        }
+
+        extract_one_shot_configs() {
+          one_shot_configs=()
+          session_args=()
+          local -a argv=( "$@" )
+          local i=0
+          local arg next
+          local after_separator=false
+
+          while (( i < ''${#argv[@]} )); do
+            arg="''${argv[$i]}"
+            if [[ "$after_separator" == true ]]; then
+              session_args+=( "$arg" )
+              i=$((i + 1))
+              continue
+            fi
+            if [[ "$arg" == -- ]]; then
+              after_separator=true
+              session_args+=( "$arg" )
+              i=$((i + 1))
+              continue
+            fi
+            if [[ "$arg" == --config=* ]]; then
+              one_shot_configs+=( "''${arg#--config=}" )
+              i=$((i + 1))
+              continue
+            fi
+            if [[ "$arg" == --config ]]; then
+              if (( i + 1 >= ''${#argv[@]} )); then
+                printf '%s\n' 'OMP --config requires a path.' >&2
+                return 2
+              fi
+              one_shot_configs+=( "''${argv[$((i + 1))]}" )
+              i=$((i + 2))
+              continue
+            fi
+            if takes_required_value "$arg"; then
+              session_args+=( "$arg" )
+              if (( i + 1 < ''${#argv[@]} )); then
+                session_args+=( "''${argv[$((i + 1))]}" )
+                i=$((i + 2))
+              else
+                i=$((i + 1))
+              fi
+              continue
+            fi
+            if takes_optional_value "$arg"; then
+              session_args+=( "$arg" )
+              next="''${argv[$((i + 1))]:-}"
+              if [[ -n "$next" && "$next" != -* ]]; then
+                session_args+=( "$next" )
+                i=$((i + 2))
+              else
+                i=$((i + 1))
+              fi
+              continue
+            fi
+            session_args+=( "$arg" )
+            i=$((i + 1))
+          done
+        }
+
+        original_args=( "$@" )
+        classify_invocation "''${original_args[@]}"
+        discover_runtime_context
+
+        case "$subcommand" in
+          __passthrough__)
+            exec "$raw_omp" "''${original_args[@]}"
+            ;;
+          update)
+            printf '%s\n' 'OMP is managed by Nix. Update the pinned derivation, then run zconf.' >&2
+            exit 2
+            ;;
+          config)
+            handle_config_command
+            ;;
+          setup)
+            printf '%s\n' \
+              "Note: 'omp setup' writes writable machine state. Nix-owned values remain governed by managed overlays; use 'omp config managed' afterward to inspect the effective session." >&2
+            exec "$raw_omp" "''${original_args[@]}"
+            ;;
+          acp|"")
+            ;;
+          *)
+            exec "$raw_omp" "''${original_args[@]}"
+            ;;
+        esac
+
+        for arg in "''${original_args[@]}"; do
+          if [[ "$arg" == --no-extensions ]]; then
+            printf '%s\n' \
+              'OMP --no-extensions is unavailable for managed sessions because it disables the Nix-owned settings guard, agents, rules, and Herdr integration. Use a dedicated restricted launcher instead.' >&2
+            exit 2
+          fi
+        done
+
+        launch_args=()
+        if [[ "$subcommand" == acp ]]; then
+          for ((i = 0; i < ''${#original_args[@]}; i++)); do
+            if (( i != subcommand_index )); then
+              launch_args+=( "''${original_args[$i]}" )
+            fi
+          done
+        else
+          launch_args=( "''${original_args[@]}" )
+        fi
+
+        extract_one_shot_configs "''${launch_args[@]}"
+
+        managed_args=( --extension "$platform_root" --config "$defaults_config" )
+        if [[ -e "$project_settings" ]]; then
+          managed_args+=( --config "$project_settings" )
+        fi
+        if [[ -e "$project_config" ]]; then
+          managed_args+=( --config "$project_config" )
+        fi
+        if [[ -f "$local_config" ]]; then
+          managed_args+=( --config "$local_config" )
+        fi
+        for preset in "''${preset_configs[@]}"; do
+          managed_args+=( --config "$preset" )
+        done
+        for one_shot in "''${one_shot_configs[@]}"; do
+          managed_args+=( --config "$one_shot" )
+        done
+        managed_args+=( --config "$policy_config" )
+
+        if [[ "$subcommand" == acp ]]; then
+          exec "$raw_omp" acp "''${managed_args[@]}" "''${session_args[@]}"
+        fi
+        exec "$raw_omp" "''${managed_args[@]}" "''${session_args[@]}"
       '';
     };
 
-  ompBudget = mkPresetCommand "ompb" [ presets.budget ];
-  ompFable = mkPresetCommand "ompf" [ presets.fable ];
-  ompGpt = mkPresetCommand "ompg" [ presets.gpt ];
-  ompOpus = mkPresetCommand "ompo" [
+  ompDefault = mkOmpCommand "omp" [ ];
+  ompBudget = mkOmpCommand "ompb" [ presets.budget ];
+  ompFable = mkOmpCommand "ompf" [ presets.fable ];
+  ompGpt = mkOmpCommand "ompg" [ presets.gpt ];
+  ompOpus = mkOmpCommand "ompo" [
     presets.gpt
     presets.opusFallback
   ];
@@ -69,8 +937,15 @@ runCommand "omp-configured-${lib.getVersion omp}"
 
     passthru = {
       inherit
-        baseConfig
+        allManagedPaths
+        defaultsConfig
+        enforcedPolicyPaths
+        managedDefaultPaths
+        managedOwnedPaths
+        managedPresetPaths
         omp
+        platformRoot
+        policyConfig
         presets
         ;
     };
@@ -82,7 +957,7 @@ runCommand "omp-configured-${lib.getVersion omp}"
   }
   ''
     mkdir -p "$out/bin" "$out/share/zsh/site-functions"
-    ln -s ${lib.getExe ompWrapper} "$out/bin/omp"
+    ln -s ${lib.getExe ompDefault} "$out/bin/omp"
     ln -s ${lib.getExe ompBudget} "$out/bin/ompb"
     ln -s ${lib.getExe ompFable} "$out/bin/ompf"
     ln -s ${lib.getExe ompGpt} "$out/bin/ompg"

--- a/scripts/agent-tools-migrate.sh
+++ b/scripts/agent-tools-migrate.sh
@@ -1,80 +1,242 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+migration_name="migration-v2"
 state_root="${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/agent-tools-migration"
-marker="$state_root/migration-v2.complete"
+pending="$state_root/$migration_name.pending"
+complete="$state_root/$migration_name.complete"
 dry_run="${AGENT_TOOLS_DRY_RUN:-0}"
-backup_dir=""
+failpoint="${AGENT_TOOLS_MIGRATION_FAILPOINT:-}"
+transient_dirs=()
+transient_files=()
+
+cleanup_transients() {
+  local path
+  for path in "${transient_files[@]}"; do
+    if [[ -f "$path" && ! -L "$path" ]]; then
+      rm -f -- "$path"
+    fi
+  done
+  for path in "${transient_dirs[@]}"; do
+    if [[ -d "$path" && ! -L "$path" ]]; then
+      rm -rf -- "$path"
+    fi
+  done
+}
+
+trap cleanup_transients EXIT
 
 fail() {
   printf 'Agent tools migration refused: %s\n' "$*" >&2
   exit 1
 }
 
-is_nix_link() {
-  local path="$1"
-  [[ -L "$path" ]] || return 1
-  local target
-  target="$(readlink "$path")"
-  [[ "$target" == /nix/store/* ]]
-}
-
 path_exists() {
   [[ -e "$1" || -L "$1" ]]
 }
 
-ensure_backup_dir() {
-  [[ -n "$backup_dir" ]] && return 0
-  backup_dir="$state_root/$(date -u +%Y%m%dT%H%M%SZ)-$$"
-  if [[ "$dry_run" != "1" ]]; then
-    mkdir -p "$backup_dir"
-    chmod 700 "$state_root" "$backup_dir"
+is_home_manager_link() {
+  local path="$1"
+  [[ -L "$path" ]] || return 1
+  local target
+  target="$(readlink "$path")"
+  [[ "$target" == /nix/store/*-home-manager-files/* ]]
+}
+
+maybe_fail() {
+  local phase="$1"
+  if [[ "$failpoint" == "$phase" ]]; then
+    printf 'Agent tools migration interrupted at test failpoint: %s\n' "$phase" >&2
+    exit 75
   fi
 }
 
-backup_move() {
+ensure_state_root() {
+  if [[ -L "$state_root" ]]; then
+    fail "$state_root is a symlink"
+  fi
+  mkdir -p "$state_root"
+  chmod 700 "$state_root"
+}
+
+acquire_lock() {
+  ensure_state_root
+  exec 9<"$state_root"
+  flock -n 9 || fail "another agent tools migration is running"
+}
+
+source_identity() {
   local source="$1"
-  local relative="${source#"$HOME"/}"
-  ensure_backup_dir
-  printf 'Backing up %s -> %s/%s\n' "$source" "$backup_dir" "$relative"
-  if [[ "$dry_run" == "1" ]]; then
+  local digest
+  if [[ -L "$source" ]]; then
+    digest="$(readlink "$source" | sha256sum)"
+    printf 'symlink:%s\n' "${digest%% *}"
+  elif [[ -f "$source" ]]; then
+    digest="$(sha256sum "$source")"
+    printf 'file:%s\n' "${digest%% *}"
+  elif [[ -d "$source" ]]; then
+    printf 'directory\n'
+  else
+    fail "$source has an unsupported type"
+  fi
+}
+
+ensure_safe_backup_parent() {
+  local transaction_dir="$1"
+  local relative="$2"
+  local current="$transaction_dir/backup"
+  local parent="${relative%/*}"
+  local component
+  local -a components=()
+  IFS=/ read -r -a components <<<"$parent"
+  for component in "${components[@]}"; do
+    [[ -n "$component" && "$component" != . && "$component" != .. ]] ||
+      fail "receipt contains an unsafe backup path"
+    current="$current/$component"
+    if path_exists "$current"; then
+      [[ -d "$current" && ! -L "$current" ]] || fail "$current is not a safe receipt directory"
+    else
+      mkdir "$current"
+      chmod 700 "$current"
+    fi
+  done
+}
+
+is_allowed_link_path() {
+  case "$1" in
+    .omp/agent/agents/architect-deep.md | .omp/agent/agents/debugger-deep.md | \
+      .omp/agent/agents/designer.md | .omp/agent/agents/designer-deep.md | \
+      .omp/agent/agents/explore.md | .omp/agent/agents/librarian.md | \
+      .omp/agent/agents/plan.md | .omp/agent/agents/reviewer.md | \
+      .omp/agent/agents/reviewer-deep.md | .omp/agent/agents/sonic.md | \
+      .omp/agent/agents/task.md | .omp/agent/agents/Tester.md | \
+      .omp/agent/agents/tester-deep.md | \
+      .omp/agent/extensions/herdr-omp-agent-state.ts | \
+      .omp/agent/extensions/managed-settings-guard.ts | \
+      .omp/agent/rules/no-shell-text-surgery.md)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+is_allowed_absent_path() {
+  case "$1" in
+    .local/bin/omp | .local/bin/herdr | .omp/plugins | .omp/agent/mcp.json | \
+      .omp/agent/gpt56-only.yml | .omp/agent/gpt56-opus-fallback.yml | \
+      .omp/agent/fable-only.yml | .omp/agent/agents/architect-deep.md | \
+      .omp/agent/agents/debugger-deep.md | .omp/agent/agents/designer.md | \
+      .omp/agent/agents/designer-deep.md | .omp/agent/agents/explore.md | \
+      .omp/agent/agents/librarian.md | .omp/agent/agents/plan.md | \
+      .omp/agent/agents/reviewer.md | .omp/agent/agents/reviewer-deep.md | \
+      .omp/agent/agents/sonic.md | .omp/agent/agents/task.md | \
+      .omp/agent/agents/Tester.md | .omp/agent/agents/tester-deep.md | \
+      .omp/agent/extensions/herdr-omp-agent-state.ts | \
+      .omp/agent/extensions/managed-settings-guard.ts | \
+      .omp/agent/rules/no-shell-text-surgery.md | \
+      .omp/agent/managed-skills/ts-react-dead-code-sweep)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+validate_receipt() {
+  local transaction_dir="$1"
+  local receipt="$transaction_dir/receipt.tsv"
+  [[ -d "$transaction_dir" && ! -L "$transaction_dir" ]] ||
+    fail "$transaction_dir is not a migration receipt directory"
+  [[ -f "$receipt" && ! -L "$receipt" ]] || fail "$receipt is missing or unsafe"
+  local receipt_dir
+  for receipt_dir in "$transaction_dir/backup" "$transaction_dir/work"; do
+    [[ -d "$receipt_dir" && ! -L "$receipt_dir" ]] ||
+      fail "$receipt_dir is not a safe receipt directory"
+  done
+
+  local version_count=0
+  local config_count=0
+  local record kind final relative detail extra
+  local -A seen=()
+  while IFS=$'\t' read -r record kind final relative detail extra; do
+    case "$record" in
+      version)
+        [[ "$kind" == "1" && -z "$final$relative$detail$extra" ]] ||
+          fail "$receipt has an unsupported version record"
+        version_count=$((version_count + 1))
+        ;;
+      action)
+        [[ -z "$extra" && -n "$relative" && -z "${seen[$relative]:-}" ]] ||
+          fail "$receipt has a duplicate or malformed action"
+        seen[$relative]=1
+        case "$kind:$final" in
+          move:link)
+            is_allowed_link_path "$relative" || fail "$receipt contains an unsafe link path"
+            [[ "$detail" == directory || "$detail" =~ ^(file|symlink):[0-9a-f]{64}$ ]] ||
+              fail "$receipt has an invalid link action"
+            ;;
+          move:absent)
+            is_allowed_absent_path "$relative" || fail "$receipt contains an unsafe retired path"
+            [[ "$detail" == directory || "$detail" =~ ^(file|symlink):[0-9a-f]{64}$ ]] ||
+              fail "$receipt has an invalid retired-path action"
+            ;;
+          config:transform)
+            [[ "$relative" =~ ^\.omp/agent/config\.ya?ml$ && "$detail" =~ ^[0-9a-f]{64}$ ]] ||
+              fail "$receipt has an invalid config transform"
+            config_count=$((config_count + 1))
+            ;;
+          config:absent)
+            [[ "$relative" =~ ^\.omp/agent/config\.ya?ml$ && "$detail" == "-" ]] ||
+              fail "$receipt has an invalid absent-config record"
+            config_count=$((config_count + 1))
+            ;;
+          *)
+            fail "$receipt contains an unknown action"
+            ;;
+        esac
+        ;;
+      *)
+        fail "$receipt contains an unknown record"
+        ;;
+    esac
+  done < "$receipt"
+
+  [[ "$version_count" -eq 1 && "$config_count" -eq 1 ]] ||
+    fail "$receipt is incomplete"
+}
+
+validate_terminal_state() {
+  if path_exists "$pending" && path_exists "$complete"; then
+    fail "both pending and completed migration state exist under $state_root"
+  fi
+
+  if path_exists "$complete"; then
+    if [[ -f "$complete" && ! -L "$complete" ]]; then
+      [[ "$(cat "$complete")" == "completed" ]] || fail "$complete is not a recognized legacy marker"
+    else
+      validate_receipt "$complete"
+    fi
     return 0
   fi
-  mkdir -p "$backup_dir/${relative%/*}"
-  mv "$source" "$backup_dir/$relative"
+
+  return 1
 }
 
-backup_copy() {
-  local source="$1"
-  local relative="${source#"$HOME"/}"
-  ensure_backup_dir
-  printf 'Backing up %s -> %s/%s\n' "$source" "$backup_dir" "$relative"
-  if [[ "$dry_run" == "1" ]]; then
-    return 0
-  fi
-  mkdir -p "$backup_dir/${relative%/*}"
-  cp -p "$source" "$backup_dir/$relative"
-}
-
-retire_bigpowers_mcp_workaround() {
-  local config="$HOME/.omp/agent/mcp.json"
-  [[ -f "$config" && ! -L "$config" ]] || return 0
-
-  jq -e '
-    (.mcpServers // {}) == {} and
-    (.disabledServers // []) == ["bigpowers-mcp"] and
-    ((keys - ["$schema", "mcpServers", "disabledServers"]) | length) == 0
-  ' "$config" >/dev/null 2>&1 || return 0
-
-  backup_move "$config"
+check_for_orphaned_legacy_backup() {
+  local candidate
+  shopt -s nullglob
+  for candidate in "$state_root"/[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]T[0-9][0-9][0-9][0-9][0-9][0-9]Z-*; do
+    if [[ -d "$candidate" ]]; then
+      shopt -u nullglob
+      fail "found an unfinished legacy backup at $candidate; review it before retrying"
+    fi
+  done
+  shopt -u nullglob
 }
 
 preflight_binary() {
   local name="$1"
   local path="$HOME/.local/bin/$name"
   path_exists "$path" || return 0
-  is_nix_link "$path" && return 0
-
   [[ -f "$path" || -L "$path" ]] ||
     fail "$path is not a regular file or symlink; move it manually"
 }
@@ -84,123 +246,455 @@ preflight_bigpowers() {
   local package="$plugin_root/node_modules/bigpowers"
   path_exists "$package" || return 0
 
-  [[ ! -L "$plugin_root" ]] || fail "$plugin_root is a symlink"
-  [[ -f "$plugin_root/package.json" ]] || fail "$package exists without a plugin package manifest"
-
+  [[ -d "$plugin_root" && ! -L "$plugin_root" ]] || fail "$plugin_root is not a safe directory"
+  [[ -d "$package" && ! -L "$package" ]] || fail "$package is not a safe package directory"
+  [[ -f "$plugin_root/package.json" && ! -L "$plugin_root/package.json" ]] ||
+    fail "$package exists without a safe plugin package manifest"
   jq -e '
+    type == "object" and
     ((.dependencies // {}) | keys | sort) == ["bigpowers"] and
     ((.devDependencies // {}) | length) == 0 and
-    ((.optionalDependencies // {}) | length) == 0
+    ((.optionalDependencies // {}) | length) == 0 and
+    ((keys - ["dependencies", "devDependencies", "optionalDependencies"]) | length) == 0
   ' "$plugin_root/package.json" >/dev/null ||
-    fail "$plugin_root contains Bigpowers alongside other top-level plugins"
+    fail "$plugin_root contains mixed or customized plugin state"
+
+  local entry
+  shopt -s dotglob nullglob
+  for entry in "$plugin_root"/*; do
+    case "${entry##*/}" in
+      node_modules | package.json | bun.lock | bun.lockb | package-lock.json | omp-plugins.lock.json) ;;
+      *)
+        shopt -u dotglob nullglob
+        fail "$plugin_root contains mixed or customized plugin state"
+        ;;
+    esac
+  done
+  shopt -u dotglob nullglob
 }
 
-preflight_config() {
-  local config="$HOME/.omp/agent/config.yml"
-  [[ -f "$marker" || ! -f "$config" ]] && return 0
-  yq eval '.' "$config" >/dev/null || fail "$config is not valid YAML"
+is_exact_bigpowers_mcp_workaround() {
+  local config="$HOME/.omp/agent/mcp.json"
+  [[ -f "$config" && ! -L "$config" ]] || return 1
+  jq -e '
+    (.mcpServers // {}) == {} and
+    (.disabledServers // []) == ["bigpowers-mcp"] and
+    ((keys - ["$schema", "mcpServers", "disabledServers"]) | length) == 0
+  ' "$config" >/dev/null 2>&1
 }
 
-preflight_binary omp
-preflight_binary herdr
-preflight_bigpowers
-preflight_config
-
-for name in omp herdr; do
-  path="$HOME/.local/bin/$name"
-  if path_exists "$path" && ! is_nix_link "$path"; then
-    backup_move "$path"
+record_move_if_needed() {
+  local receipt="$1"
+  local final="$2"
+  local relative="$3"
+  local source="$HOME/$relative"
+  if path_exists "$source" && ! is_home_manager_link "$source"; then
+    printf 'action\tmove\t%s\t%s\t%s\n' \
+      "$final" "$relative" "$(source_identity "$source")" >> "$receipt"
   fi
-done
+}
 
-plugin_root="$HOME/.omp/plugins"
-if path_exists "$plugin_root/node_modules/bigpowers"; then
-  backup_move "$plugin_root"
+discover_plan() {
+  local receipt="$1"
+  preflight_binary omp
+  preflight_binary herdr
+  preflight_bigpowers
+
+  printf 'version\t1\n' > "$receipt"
+  record_move_if_needed "$receipt" absent .local/bin/omp
+  record_move_if_needed "$receipt" absent .local/bin/herdr
+
+  if path_exists "$HOME/.omp/plugins/node_modules/bigpowers"; then
+    record_move_if_needed "$receipt" absent .omp/plugins
+  fi
+  if is_exact_bigpowers_mcp_workaround; then
+    record_move_if_needed "$receipt" absent .omp/agent/mcp.json
+  fi
+
+  local name
+  for name in \
+    architect-deep debugger-deep designer designer-deep explore librarian plan \
+    reviewer reviewer-deep sonic task Tester tester-deep
+  do
+    record_move_if_needed "$receipt" absent ".omp/agent/agents/$name.md"
+  done
+
+  record_move_if_needed "$receipt" absent .omp/agent/extensions/herdr-omp-agent-state.ts
+  record_move_if_needed "$receipt" absent .omp/agent/extensions/managed-settings-guard.ts
+  record_move_if_needed "$receipt" absent .omp/agent/rules/no-shell-text-surgery.md
+  record_move_if_needed "$receipt" absent .omp/agent/gpt56-only.yml
+  record_move_if_needed "$receipt" absent .omp/agent/gpt56-opus-fallback.yml
+  record_move_if_needed "$receipt" absent .omp/agent/fable-only.yml
+  record_move_if_needed "$receipt" absent .omp/agent/managed-skills/ts-react-dead-code-sweep
+
+  local config_yml="$HOME/.omp/agent/config.yml"
+  local config_yaml="$HOME/.omp/agent/config.yaml"
+  if path_exists "$config_yml" && path_exists "$config_yaml"; then
+    fail "both $config_yml and $config_yaml exist; preserve both and resolve the legacy fallback manually"
+  fi
+  local config="$config_yml"
+  local config_relative=".omp/agent/config.yml"
+  if ! path_exists "$config" && path_exists "$config_yaml"; then
+    config="$config_yaml"
+    config_relative=".omp/agent/config.yaml"
+  fi
+  if path_exists "$config"; then
+    [[ -f "$config" && ! -L "$config" ]] || fail "$config is not a regular file"
+    yq eval '.' "$config" >/dev/null || fail "$config is not valid YAML"
+    local legacy_theme
+    legacy_theme="$(yq eval '.theme | select(tag == "!!str")' "$config")"
+    if [[ -n "$legacy_theme" && "$legacy_theme" != dark && "$legacy_theme" != light ]]; then
+      fail "$config uses a legacy scalar custom theme; rewrite it as theme.dark or theme.light before retrying"
+    fi
+    local digest
+    digest="$(sha256sum "$config")"
+    digest="${digest%% *}"
+    printf 'action\tconfig\ttransform\t%s\t%s\n' "$config_relative" "$digest" >> "$receipt"
+  else
+    printf 'action\tconfig\tabsent\t.omp/agent/config.yml\t-\n' >> "$receipt"
+  fi
+
+  chmod 600 "$receipt"
+  validate_receipt "$(dirname "$receipt")"
+}
+
+for_each_action() {
+  local transaction_dir="$1"
+  local callback="$2"
+  local record kind final relative detail extra
+  while IFS=$'\t' read -r record kind final relative detail extra; do
+    [[ "$record" == "action" ]] || continue
+    "$callback" "$transaction_dir" "$kind" "$final" "$relative" "$detail"
+  done < "$transaction_dir/receipt.tsv"
+}
+
+render_transformed_config() {
+  local source="$1"
+  local destination="$2"
+  local theme_path=".theme.dark"
+  if [[ "$(yq eval '.theme | tag' "$source")" == "!!str" ]]; then
+    theme_path=".theme"
+  fi
+  yq eval "
+    del(
+      .providers.webSearch,
+      .providers.anthropic.serverSideFallback,
+      .tools.approvalMode,
+      .secrets.enabled,
+      .symbolPreset,
+      .colorBlindMode,
+      .modelRoles,
+      .retry.enabled,
+      .retry.modelFallback,
+      .retry.fallbackRevertPolicy,
+      .retry.fallbackChains,
+      .personality,
+      .advisor.enabled,
+      .advisor.subagents,
+      .advisor.syncBacklog,
+      .stt.enabled,
+      .branchSummary.enabled,
+      .autolearn.enabled,
+      .autolearn.autoContinue,
+      .github.enabled,
+      .checkpoint.enabled,
+      .statusLine.preset,
+      .statusLine.compactThinkingLevel,
+      .statusLine.transparent,
+      .terminal.showProgress,
+      .tui.tight,
+      .display.shimmer,
+      .display.showTokenUsage,
+      .display.cacheMissMarker,
+      .codexResets.autoRedeem,
+      .[\"codexResets.autoRedeem\"],
+      .task.showResolvedModelBadge,
+      .task.agentModelOverrides,
+      .task.disabledAgents,
+      .memory.backend,
+      $theme_path,
+      .browser.headless,
+      .browser.enabled,
+      .proseOnlyThinking,
+      .defaultThinkingLevel
+    )
+  " "$source" > "$destination"
+  yq eval '.' "$destination" >/dev/null
+  chmod 600 "$destination"
+}
+
+validate_transformed_config() {
+  local transaction_dir="$1"
+  local relative="$2"
+  local original="$transaction_dir/backup/$relative"
+  local transformed="$transaction_dir/work/config.transformed.yml"
+  [[ -f "$original" && ! -L "$original" && -f "$transformed" && ! -L "$transformed" ]] ||
+    fail "the transformed config receipt is missing or unsafe"
+  local expected
+  expected="$(mktemp "$transaction_dir/work/config.expected.XXXXXX")"
+  transient_files+=("$expected")
+  render_transformed_config "$original" "$expected"
+  cmp -s "$transformed" "$expected" ||
+    fail "$transformed does not match the digest-verified original config"
+  rm -f -- "$expected"
+}
+
+validate_pending_action() {
+  local transaction_dir="$1"
+  local kind="$2"
+  local final="$3"
+  local relative="$4"
+  local detail="$5"
+  local source="$HOME/$relative"
+  local backup="$transaction_dir/backup/$relative"
+
+  if [[ "$kind" == "move" ]]; then
+    ensure_safe_backup_parent "$transaction_dir" "$relative"
+    if path_exists "$backup"; then
+      [[ "$(source_identity "$backup")" == "$detail" ]] ||
+        fail "$backup changed while migration was pending"
+      if ! path_exists "$source"; then
+        return 0
+      fi
+      if [[ "$final" == "link" ]] && is_home_manager_link "$source"; then
+        return 0
+      fi
+      fail "$source and its migration backup both exist; preserve both and resolve the collision"
+    fi
+    path_exists "$source" || fail "$source and its planned migration backup are both missing"
+    [[ "$(source_identity "$source")" == "$detail" ]] ||
+      fail "$source changed after the migration receipt was created"
+    if [[ "$relative" == .omp/plugins ]]; then
+      preflight_bigpowers
+    fi
+    local backup_parent="$transaction_dir/backup/${relative%/*}"
+    [[ "$(stat -c %d "$(dirname "$source")")" == "$(stat -c %d "$backup_parent")" ]] ||
+      fail "$source cannot be backed up atomically because the state directory is on another filesystem"
+    return 0
+  fi
+
+  if [[ "$final" == "absent" ]]; then
+    path_exists "$source" && fail "$source appeared after the migration receipt was created"
+    return 0
+  fi
+
+  local original="$transaction_dir/backup/$relative"
+  local transformed="$transaction_dir/work/config.transformed.yml"
+  ensure_safe_backup_parent "$transaction_dir" "$relative"
+  [[ ! -L "$transformed" ]] || fail "$transformed is an unsafe symlink"
+  if path_exists "$original"; then
+    [[ -f "$original" && ! -L "$original" && -f "$source" && ! -L "$source" ]] ||
+      fail "$source or its config backup has an unsafe type"
+    local original_digest
+    original_digest="$(sha256sum "$original")"
+    original_digest="${original_digest%% *}"
+    [[ "$original_digest" == "$detail" ]] || fail "$original no longer matches its receipt digest"
+    if [[ -f "$transformed" ]]; then
+      validate_transformed_config "$transaction_dir" "$relative"
+      cmp -s "$source" "$original" || cmp -s "$source" "$transformed" ||
+        fail "$source changed while migration was pending; preserve both versions and resolve it manually"
+    else
+      cmp -s "$source" "$original" ||
+        fail "$source changed while migration was pending; preserve both versions and resolve it manually"
+    fi
+  else
+    [[ -f "$source" && ! -L "$source" ]] || fail "$source disappeared while migration was pending"
+    local current_digest
+    current_digest="$(sha256sum "$source")"
+    current_digest="${current_digest%% *}"
+    [[ "$current_digest" == "$detail" ]] ||
+      fail "$source changed after the migration receipt was created"
+  fi
+}
+
+move_count=0
+execute_pending_action() {
+  local transaction_dir="$1"
+  local kind="$2"
+  local final="$3"
+  local relative="$4"
+  local detail="$5"
+  local source="$HOME/$relative"
+  local backup="$transaction_dir/backup/$relative"
+
+  if [[ "$kind" == "move" ]]; then
+    ensure_safe_backup_parent "$transaction_dir" "$relative"
+    if ! path_exists "$backup"; then
+      printf 'Backing up %s -> %s\n' "$source" "$backup"
+      mv "$source" "$backup"
+      move_count=$((move_count + 1))
+      if [[ "$move_count" -eq 1 ]]; then
+        maybe_fail after-first-move
+      fi
+    fi
+    return 0
+  fi
+
+  [[ "$final" == "transform" ]] || return 0
+  local original="$transaction_dir/backup/$relative"
+  local transformed="$transaction_dir/work/config.transformed.yml"
+  ensure_safe_backup_parent "$transaction_dir" "$relative"
+  [[ -d "$transaction_dir/work" && ! -L "$transaction_dir/work" ]] ||
+    fail "$transaction_dir/work is not a safe receipt directory"
+  [[ ! -L "$original" && ! -L "$transformed" ]] || fail "the config receipt contains an unsafe symlink"
+  if ! path_exists "$original"; then
+    local backup_tmp
+    backup_tmp="$(mktemp "$original.tmp.XXXXXX")"
+    transient_files+=("$backup_tmp")
+    cp -p "$source" "$backup_tmp"
+    cmp -s "$source" "$backup_tmp" || fail "could not verify the config backup"
+    mv "$backup_tmp" "$original"
+  fi
+  if [[ ! -f "$transformed" ]]; then
+    local transformed_tmp
+    transformed_tmp="$(mktemp "$transformed.tmp.XXXXXX")"
+    transient_files+=("$transformed_tmp")
+    render_transformed_config "$original" "$transformed_tmp"
+    mv "$transformed_tmp" "$transformed"
+    maybe_fail after-config-transform
+  fi
+  if cmp -s "$source" "$original"; then
+    printf 'Trimming Nix-managed settings from %s\n' "$source"
+    local live_tmp
+    live_tmp="$(mktemp "$source.agent-tools-migration-v2.XXXXXX")"
+    transient_files+=("$live_tmp")
+    cp "$transformed" "$live_tmp"
+    chmod 600 "$live_tmp"
+    mv "$live_tmp" "$source"
+    maybe_fail after-config-replace
+  fi
+}
+
+create_pending_receipt() {
+  check_for_orphaned_legacy_backup
+  local staging="$state_root/.$migration_name.creating.$$"
+  [[ ! -e "$staging" ]] || fail "$staging already exists"
+  mkdir "$staging"
+  transient_dirs+=("$staging")
+  mkdir "$staging/backup" "$staging/work"
+  chmod 700 "$staging" "$staging/backup" "$staging/work"
+  discover_plan "$staging/receipt.tsv"
+  mv "$staging" "$pending"
+  transient_dirs=()
+  maybe_fail after-receipt
+}
+
+prepare_migration() {
+  if [[ "$dry_run" == "1" ]]; then
+    if validate_terminal_state; then
+      return 0
+    fi
+    if path_exists "$pending"; then
+      validate_receipt "$pending"
+      printf 'Would resume pending agent tools migration at %s\n' "$pending"
+      return 0
+    fi
+    local dry_dir
+    dry_dir="$(mktemp -d)"
+    transient_dirs+=("$dry_dir")
+    mkdir "$dry_dir/backup" "$dry_dir/work"
+    chmod 700 "$dry_dir" "$dry_dir/backup" "$dry_dir/work"
+    discover_plan "$dry_dir/receipt.tsv"
+    printf 'Would prepare agent tools migration receipt with these actions:\n'
+    sed -n '/^action/p' "$dry_dir/receipt.tsv"
+    rm -rf "$dry_dir"
+    transient_dirs=()
+    return 0
+  fi
+
+  acquire_lock
+  if validate_terminal_state; then
+    return 0
+  fi
+  if path_exists "$pending"; then
+    validate_receipt "$pending"
+  else
+    create_pending_receipt
+  fi
+
+  for_each_action "$pending" validate_pending_action
+  move_count=0
+  for_each_action "$pending" execute_pending_action
+}
+
+validate_final_action() {
+  local transaction_dir="$1"
+  local kind="$2"
+  local final="$3"
+  local relative="$4"
+  local _detail="$5"
+  local source="$HOME/$relative"
+  local backup="$transaction_dir/backup/$relative"
+
+  if [[ "$kind" == "move" ]]; then
+    ensure_safe_backup_parent "$transaction_dir" "$relative"
+    path_exists "$backup" || fail "the planned backup for $source is missing"
+    [[ "$(source_identity "$backup")" == "$_detail" ]] ||
+      fail "$backup changed while migration was pending"
+    if [[ "$final" == "absent" ]]; then
+      path_exists "$source" && fail "$source should remain retired"
+      return 0
+    fi
+    local expected="$final_home_files/$relative"
+    [[ -e "$expected" && -L "$source" ]] || fail "$source was not linked by Home Manager"
+    [[ "$(readlink -e "$source")" == "$(readlink -e "$expected")" ]] ||
+      fail "$source does not point to the selected Home Manager generation"
+    return 0
+  fi
+
+  if [[ "$final" == "absent" ]]; then
+    path_exists "$source" && fail "$source appeared while the migration was pending"
+    return 0
+  fi
+  local original="$transaction_dir/backup/$relative"
+  local transformed="$transaction_dir/work/config.transformed.yml"
+  [[ -f "$original" && -f "$transformed" && -f "$source" ]] ||
+    fail "$source or its migration copies are missing"
+  [[ ! -L "$original" && ! -L "$transformed" && ! -L "$source" ]] ||
+    fail "$source or its migration copies have an unsafe type"
+  local original_digest
+  original_digest="$(sha256sum "$original")"
+  original_digest="${original_digest%% *}"
+  [[ "$original_digest" == "$_detail" ]] || fail "$original no longer matches its receipt digest"
+  validate_transformed_config "$transaction_dir" "$relative"
+  cmp -s "$source" "$transformed" || fail "$source no longer matches the migrated config"
+}
+
+final_home_files=""
+finalize_migration() {
+  final_home_files="${1:-}"
+  if [[ "$dry_run" == "1" ]]; then
+    printf 'Would finalize a pending agent tools migration after Home Manager linking.\n'
+    return 0
+  fi
+  [[ -n "$final_home_files" && -d "$final_home_files" ]] ||
+    fail "finalize requires the selected Home Manager home-files directory"
+
+  acquire_lock
+  if validate_terminal_state; then
+    return 0
+  fi
+  path_exists "$pending" || fail "no pending migration receipt exists"
+  validate_receipt "$pending"
+  for_each_action "$pending" validate_final_action
+  maybe_fail before-finalize
+  mv "$pending" "$complete"
+}
+
+command="${1:-prepare}"
+if [[ $# -gt 0 ]]; then
+  shift
 fi
-
-retire_bigpowers_mcp_workaround
-
-managed_agent_names=(
-  architect-deep
-  debugger-deep
-  designer
-  designer-deep
-  explore
-  librarian
-  plan
-  reviewer
-  reviewer-deep
-  sonic
-  task
-  Tester
-  tester-deep
-)
-
-for name in "${managed_agent_names[@]}"; do
-  path="$HOME/.omp/agent/agents/$name.md"
-  if path_exists "$path" && ! is_nix_link "$path"; then
-    backup_move "$path"
-  fi
-done
-
-managed_paths=(
-  "$HOME/.omp/agent/extensions/herdr-omp-agent-state.ts"
-  "$HOME/.omp/agent/rules/no-shell-text-surgery.md"
-  "$HOME/.omp/agent/gpt56-only.yml"
-  "$HOME/.omp/agent/gpt56-opus-fallback.yml"
-  "$HOME/.omp/agent/fable-only.yml"
-  "$HOME/.omp/agent/managed-skills/ts-react-dead-code-sweep"
-)
-
-for path in "${managed_paths[@]}"; do
-  if path_exists "$path" && ! is_nix_link "$path"; then
-    backup_move "$path"
-  fi
-done
-
-config="$HOME/.omp/agent/config.yml"
-if [[ ! -f "$marker" && -f "$config" ]]; then
-  backup_copy "$config"
-  printf 'Trimming Nix-managed settings from %s\n' "$config"
-  if [[ "$dry_run" != "1" ]]; then
-    temporary="$config.agent-tools-migration.$$"
-    yq eval '
-      del(
-        .providers.webSearch,
-        .tools.approvalMode,
-        .secrets.enabled,
-        .symbolPreset,
-        .colorBlindMode,
-        .modelRoles,
-        .retry,
-        .personality,
-        .advisor,
-        .stt,
-        .branchSummary,
-        .autolearn,
-        .github,
-        .checkpoint,
-        .statusLine,
-        .terminal,
-        .tui,
-        .display,
-        .codexResets,
-        .task,
-        .memory,
-        .theme,
-        .browser,
-        .proseOnlyThinking,
-        .defaultThinkingLevel
-      )
-    ' "$config" > "$temporary"
-    chmod 600 "$temporary"
-    mv "$temporary" "$config"
-  fi
-fi
-
-if [[ "$dry_run" != "1" ]]; then
-  mkdir -p "$state_root"
-  chmod 700 "$state_root"
-  printf 'completed\n' > "$marker"
-  chmod 600 "$marker"
-fi
+case "$command" in
+  prepare)
+    [[ $# -eq 0 ]] || fail "prepare does not accept arguments"
+    prepare_migration
+    ;;
+  finalize)
+    [[ $# -eq 1 ]] || fail "finalize requires one home-files directory"
+    finalize_migration "$1"
+    ;;
+  *)
+    fail "unknown command: $command"
+    ;;
+esac


### PR DESCRIPTION
## Summary

- split portable OMP defaults from the enforced security overlay and make normal, preset, and ACP launch paths share the documented precedence
- add profile-aware managed diagnostics, schema-compatible migration handling, guarded writable settings, and recoverable migration receipts
- deploy agents, rules, the settings guard, and Herdr as a profile-independent Nix-owned OMP extension package
- harden self-update refusal and document the full role-routing and migration contracts

## Validation

- focused wrapper, migration, and real OMP/ACP/RPC integration checks
- direct builds for OMP, configured OMP, OMP agents, Herdr integration, and migration
- Home Manager activation evaluation
- nix flake check path:. --show-trace
- nix flake check path:. --all-systems --no-build --show-trace
- Zsh syntax, ShellCheck, actionlint, nixfmt, and git diff --check

Closes #6