### PR TITLE
feat(hosts): add capability registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,15 @@ alex-x86_64-darwin
 alex-aarch64-linux
 alex-x86_64-linux
 alex-x86_64-linux-desktop
+alex@ubuntu-4gb-nbg1-1
 ```
+
+These outputs are generated from the authoritative host registry and
+composable `base`, `development`, `agent-tools`, `desktop`, and `server`
+capabilities. Compatibility aliases such as `alex`, `alex-linux`,
+`alex-darwin`, and `alex-linux-desktop` remain available. See
+[Hosts and capabilities](docs/hosts.md) for the identity contract and the
+add/rename/retire workflow.
 
 For this Mac, the manual switch command is:
 

--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   homeDirectory,
+  homeModules,
   homebrew-cask,
   homebrew-core,
   pkgs,
@@ -24,7 +25,7 @@
     backupFileExtension = "backup";
 
     users.${username} = {
-      imports = [ ../home ];
+      imports = homeModules;
 
       home = {
         inherit username homeDirectory;

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -1,0 +1,61 @@
+# Hosts and capabilities
+
+`hosts/default.nix` is the authoritative registry for supported dotfiles
+configurations. A host entry contains stable, non-secret facts: its canonical
+configuration ID, system, platform, user, home directory, optional hostname,
+compatibility aliases, and selected capabilities.
+
+Capabilities are declarative Home Manager modules, not imperative `nix
+profile` state. Home Manager generations remain activation history and rollback
+points; OMP and Codex profiles remain harness-specific mutable-state boundaries.
+
+## Current capabilities
+
+- `base`: shell, Git, mise, and Home Manager itself.
+- `development`: the current shared CLI and development package set.
+- `agent-tools`: Codex, OMP, Herdr, managed agents, and their configuration.
+- `desktop`: desktop-only additions; currently selects the Linux desktop module.
+- `server`: marks the reviewed headless composition consumed by #28.
+
+Issue #18 owns the next package-placement pass. Until it lands, some packages
+inside `development` remain broader than their eventual mobile, media,
+container, security, or project-owned capabilities. The registry records the
+composition boundary now without claiming that package classification is
+already complete.
+
+Each activated Home Manager configuration exposes its canonical identity in
+`$ATYRODE_HOST`, its comma-separated capability set in
+`$ATYRODE_CAPABILITIES`, and a non-secret JSON projection at
+`~/.config/atyrode/host.json`. The same pure projection is available to flake
+consumers as `lib.hostRegistry`; `lib.capabilities` lists valid capability
+names.
+
+## Adding a host
+
+1. Add one canonical entry to `hosts/default.nix`.
+2. Declare a supported `system`, matching `platform`, non-empty `username`,
+   absolute `homeDirectory`, and at least one valid capability.
+3. Add only compatibility names that must remain accepted to `aliases`.
+4. Add or reuse capability modules under `home/profiles/`; do not put
+   host-specific packages directly in the registry.
+5. Run `nix flake check --all-systems --no-build --show-trace`. The aggregate
+   home and Darwin checks evaluate every canonical host on its native system.
+
+Registry evaluation refuses unsupported systems, platform mismatches, empty
+users, relative home directories, missing base capabilities, server/desktop
+conflicts, duplicate or unknown capabilities, duplicate aliases, and aliases
+that collide with canonical host IDs.
+
+## Renaming or retiring a host
+
+For a rename, create the new canonical entry and keep the former public name as
+an alias for a documented compatibility period. Aliases resolve to the new
+canonical configuration, so diagnostics and the generated JSON report the new
+identity. Remove the alias only after active-configuration state and automation
+no longer reference it.
+
+For retirement, first remove callers and machine state that select the host,
+then remove its canonical registry entry and aliases together. Never reuse an
+old host ID for a different machine or security boundary. Mutable sessions,
+credentials, trust state, and secrets are not registry data and require their
+own retirement procedure.

--- a/flake.nix
+++ b/flake.nix
@@ -26,200 +26,282 @@
     };
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    home-manager,
-    herdr,
-    nix-darwin,
-    nix-homebrew,
-    homebrew-core,
-    homebrew-cask,
-    ...
-  }:
-  let
-    lib = nixpkgs.lib;
-
-    defaultUsername = "alex";
-
-    hostAliases = {
-      "ubuntu-4gb-nbg1-1" = "x86_64-linux";
-    };
-
-    systems = [
-      "aarch64-darwin"
-      "x86_64-darwin"
-      "aarch64-linux"
-      "x86_64-linux"
-    ];
-
-    darwinSystems = [
-      "aarch64-darwin"
-      "x86_64-darwin"
-    ];
-
-    # Safe fallback for bare `home-manager --flake .` invocations.
-    # Shell helpers should still select an explicit system-specific config.
-    defaultSystem = "x86_64-linux";
-    defaultDarwinSystem = "aarch64-darwin";
-
-    forAllSystems = lib.genAttrs systems;
-
-    agentToolsOverlay = lib.composeManyExtensions [
-      herdr.overlays.default
-      (final: _previous: {
-        agent-tools-migrate = final.callPackage ./pkgs/agent-tools-migrate { };
-        herdr-configured = final.callPackage ./pkgs/herdr-configured { };
-        herdr-omp-integration = final.callPackage ./pkgs/herdr-omp-integration { };
-        omp = final.callPackage ./pkgs/omp { };
-        omp-agents = final.callPackage ./pkgs/omp-agents { };
-        omp-configured = final.callPackage ./pkgs/omp-configured { };
-      })
-    ];
-
-    pkgsFor = system:
-      import nixpkgs {
-        inherit system;
-        config.allowUnfree = true;
-        overlays = [ agentToolsOverlay ];
-      };
-
-    homeDirectoryFor = system: username:
-      if lib.hasSuffix "-darwin" system
-      then "/Users/${username}"
-      else "/home/${username}";
-
-    # Helper function to create home configuration
-    mkHomeConfig = {
-      system,
-      username ? defaultUsername,
-      homeDirectory ? homeDirectoryFor system username,
-      extraModules ? [ ],
+  outputs =
+    {
+      self,
+      nixpkgs,
+      home-manager,
+      herdr,
+      nix-darwin,
+      nix-homebrew,
+      homebrew-core,
+      homebrew-cask,
+      ...
     }:
-      home-manager.lib.homeManagerConfiguration {
-        pkgs = pkgsFor system;
+    let
+      lib = nixpkgs.lib;
 
-        modules =
-          [
-            ./home
-            {
-              home.username = username;
-              home.homeDirectory = homeDirectory;
-            }
-          ]
-          ++ extraModules;
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      forAllSystems = lib.genAttrs systems;
+
+      capabilityModules = {
+        base = ./home/profiles/base.nix;
+        development = ./home/profiles/development.nix;
+        agent-tools = ./home/profiles/agent-tools.nix;
+        desktop = ./home/profiles/desktop.nix;
+        server = ./home/profiles/server.nix;
       };
+      knownCapabilities = builtins.attrNames capabilityModules;
+      rawHosts = import ./hosts;
 
-    mkDarwinConfig = { system, username ? defaultUsername, homeDirectory ? homeDirectoryFor system username }:
-      nix-darwin.lib.darwinSystem {
-        specialArgs = {
-          inherit
-            homeDirectory
-            homebrew-cask
-            homebrew-core
-            username
-            ;
+      validateHost =
+        name: host:
+        let
+          expectedPlatform = if lib.hasSuffix "-darwin" host.system then "darwin" else "linux";
+          capabilities = host.capabilities or [ ];
+          aliases = host.aliases or [ ];
+        in
+        assert lib.assertMsg (builtins.elem host.system systems)
+          "host ${name} uses unsupported system ${host.system}";
+        assert lib.assertMsg (
+          host.platform == expectedPlatform
+        ) "host ${name} platform ${host.platform} does not match ${host.system}";
+        assert lib.assertMsg (
+          builtins.isString host.username && host.username != ""
+        ) "host ${name} must declare a non-empty username";
+        assert lib.assertMsg (
+          builtins.isString host.homeDirectory && lib.hasPrefix "/" host.homeDirectory
+        ) "host ${name} must declare an absolute homeDirectory";
+        assert lib.assertMsg (capabilities != [ ]) "host ${name} must select at least one capability";
+        assert lib.assertMsg (builtins.elem "base" capabilities)
+          "host ${name} must select the base capability";
+        assert lib.assertMsg (
+          !(builtins.elem "server" capabilities && builtins.elem "desktop" capabilities)
+        ) "host ${name} cannot combine server and desktop capabilities";
+        assert lib.assertMsg (
+          builtins.length capabilities == builtins.length (lib.unique capabilities)
+        ) "host ${name} declares duplicate capabilities";
+        assert lib.assertMsg (lib.all (
+          capability: builtins.hasAttr capability capabilityModules
+        ) capabilities) "host ${name} declares an unknown capability";
+        assert lib.assertMsg (
+          builtins.length aliases == builtins.length (lib.unique aliases)
+        ) "host ${name} declares duplicate aliases";
+        host
+        // {
+          inherit aliases capabilities;
+          hostname = host.hostname or null;
         };
 
-        modules = [
-          home-manager.darwinModules.home-manager
-          nix-homebrew.darwinModules.nix-homebrew
-          ./darwin
-          {
-            nixpkgs.hostPlatform = system;
-            nixpkgs.overlays = [ agentToolsOverlay ];
-          }
-        ];
-      };
+      validatedHosts = lib.mapAttrs validateHost rawHosts;
+      canonicalHostNames = builtins.attrNames validatedHosts;
+      allHostAliases = lib.concatMap (name: validatedHosts.${name}.aliases) canonicalHostNames;
+      hosts =
+        assert lib.assertMsg (
+          builtins.length allHostAliases == builtins.length (lib.unique allHostAliases)
+        ) "host aliases must be globally unique";
+        assert lib.assertMsg (lib.all (
+          alias: !(builtins.hasAttr alias validatedHosts)
+        ) allHostAliases) "host aliases must not collide with canonical host names";
+        validatedHosts;
 
-    configs = forAllSystems (system: mkHomeConfig { inherit system; });
-    linuxDesktopConfigs = {
-      "x86_64-linux" = mkHomeConfig {
-        system = "x86_64-linux";
-        extraModules = [ ./home/linux-desktop.nix ];
-      };
-    };
-    darwinConfigs = lib.genAttrs darwinSystems (system: mkDarwinConfig { inherit system; });
-  in {
-    homeConfigurations =
-      {
-        # Default configuration for bare Home Manager invocations.
-        ${defaultUsername} = configs.${defaultSystem};
-      }
-      // lib.mapAttrs' (
-        system: config:
-          lib.nameValuePair "${defaultUsername}-${system}" config
-      ) configs
-      // lib.mapAttrs' (
-        hostname: system:
-          lib.nameValuePair "${defaultUsername}@${hostname}" configs.${system}
-      ) hostAliases
-      // {
-        "${defaultUsername}-darwin" = configs.${defaultDarwinSystem};
-        "${defaultUsername}-linux" = configs."x86_64-linux";
-        "${defaultUsername}-linux-desktop" = linuxDesktopConfigs."x86_64-linux";
-        "${defaultUsername}-x86_64-linux-desktop" = linuxDesktopConfigs."x86_64-linux";
-      };
-
-    darwinConfigurations =
-      lib.mapAttrs' (
-        system: config:
-          lib.nameValuePair "${defaultUsername}-${system}" config
-      ) darwinConfigs
-      // {
-        "${defaultUsername}-darwin" = darwinConfigs.${defaultDarwinSystem};
-      };
-
-    overlays.default = agentToolsOverlay;
-
-    homeManagerModules.agent-tools = import ./modules/home/agent-tools.nix;
-
-    packages = forAllSystems (
-      system:
-      let
-        pkgs = pkgsFor system;
-      in
-      {
-        inherit (pkgs)
-          agent-tools-migrate
-          herdr
-          herdr-configured
-          herdr-omp-integration
-          omp
-          omp-agents
-          omp-configured
+      publicHost = name: host: {
+        id = name;
+        inherit (host)
+          aliases
+          capabilities
+          homeDirectory
+          hostname
+          platform
+          system
+          username
           ;
-      }
-    );
+      };
+      publicHosts = lib.mapAttrs publicHost hosts;
+      hostRegistryJson = builtins.toJSON publicHosts;
 
-    checks = forAllSystems (
-      system:
-      let
-        pkgs = pkgsFor system;
-        homeEvaluation = builtins.deepSeq configs.${system}.activationPackage.drvPath (
-          pkgs.runCommand "check-home-evaluation-${system}" { } ''
-            mkdir "$out"
-          ''
-        );
-        darwinEvaluation = builtins.deepSeq darwinConfigs.${system}.system.drvPath (
-          pkgs.runCommand "check-darwin-evaluation-${system}" { } ''
-            mkdir "$out"
-          ''
-        );
-      in
-      import ./checks/agent-tools.nix { inherit lib pkgs; }
-      // {
-        home-evaluation = homeEvaluation;
-      }
-      // lib.optionalAttrs (lib.hasSuffix "-darwin" system) {
-        darwin-evaluation = darwinEvaluation;
-      }
-    );
+      mkHostIdentityModule = name: host: {
+        home.sessionVariables = {
+          ATYRODE_HOST = name;
+          ATYRODE_CAPABILITIES = lib.concatStringsSep "," host.capabilities;
+        };
 
-    formatter = forAllSystems (system: (pkgsFor system).nixfmt);
+        xdg.configFile."atyrode/host.json".text = builtins.toJSON (publicHost name host);
+      };
 
-    apps = forAllSystems (
-      system:
+      modulesForHost =
+        name: host:
+        map (capability: capabilityModules.${capability}) host.capabilities
+        ++ [ (mkHostIdentityModule name host) ];
+
+      agentToolsOverlay = lib.composeManyExtensions [
+        herdr.overlays.default
+        (final: _previous: {
+          agent-tools-migrate = final.callPackage ./pkgs/agent-tools-migrate { };
+          herdr-configured = final.callPackage ./pkgs/herdr-configured { };
+          herdr-omp-integration = final.callPackage ./pkgs/herdr-omp-integration { };
+          omp = final.callPackage ./pkgs/omp { };
+          omp-agents = final.callPackage ./pkgs/omp-agents { };
+          omp-configured = final.callPackage ./pkgs/omp-configured { };
+        })
+      ];
+
+      pkgsFor =
+        system:
+        import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+          overlays = [ agentToolsOverlay ];
+        };
+
+      mkHomeConfig =
+        name: host:
+        home-manager.lib.homeManagerConfiguration {
+          pkgs = pkgsFor host.system;
+
+          modules = modulesForHost name host ++ [
+            {
+              home.username = host.username;
+              home.homeDirectory = host.homeDirectory;
+            }
+          ];
+        };
+
+      mkDarwinConfig =
+        name: host:
+        nix-darwin.lib.darwinSystem {
+          specialArgs = {
+            inherit
+              homebrew-cask
+              homebrew-core
+              ;
+            homeDirectory = host.homeDirectory;
+            homeModules = modulesForHost name host;
+            username = host.username;
+          };
+
+          modules = [
+            home-manager.darwinModules.home-manager
+            nix-homebrew.darwinModules.nix-homebrew
+            ./darwin
+            {
+              nixpkgs.hostPlatform = host.system;
+              nixpkgs.overlays = [ agentToolsOverlay ];
+            }
+          ];
+        };
+
+      canonicalHomeConfigs = lib.mapAttrs mkHomeConfig hosts;
+      darwinHosts = lib.filterAttrs (_name: host: host.platform == "darwin") hosts;
+      canonicalDarwinConfigs = lib.mapAttrs mkDarwinConfig darwinHosts;
+
+      aliasesFor =
+        selectedHosts: configs:
+        lib.foldl' (
+          aliases: name:
+          aliases
+          // builtins.listToAttrs (
+            map (alias: lib.nameValuePair alias configs.${name}) selectedHosts.${name}.aliases
+          )
+        ) { } (builtins.attrNames selectedHosts);
+    in
+    {
+      homeConfigurations = canonicalHomeConfigs // aliasesFor hosts canonicalHomeConfigs;
+
+      darwinConfigurations = canonicalDarwinConfigs // aliasesFor darwinHosts canonicalDarwinConfigs;
+
+      lib = {
+        capabilities = knownCapabilities;
+        hostRegistry = publicHosts;
+      };
+
+      overlays.default = agentToolsOverlay;
+
+      homeManagerModules.agent-tools = import ./modules/home/agent-tools.nix;
+
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          inherit (pkgs)
+            agent-tools-migrate
+            herdr
+            herdr-configured
+            herdr-omp-integration
+            omp
+            omp-agents
+            omp-configured
+            ;
+        }
+      );
+
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          systemHomeConfigs = lib.filterAttrs (
+            name: _config: hosts.${name}.system == system
+          ) canonicalHomeConfigs;
+          systemDarwinConfigs = lib.filterAttrs (
+            name: _config: darwinHosts.${name}.system == system
+          ) canonicalDarwinConfigs;
+          homeEvaluationPaths = lib.mapAttrsToList (
+            _name: config: config.activationPackage.drvPath
+          ) systemHomeConfigs;
+          darwinEvaluationPaths = lib.mapAttrsToList (
+            _name: config: config.system.drvPath
+          ) systemDarwinConfigs;
+          homeEvaluation = builtins.deepSeq homeEvaluationPaths (
+            pkgs.runCommand "check-home-evaluation-${system}" { } ''
+              mkdir "$out"
+            ''
+          );
+          darwinEvaluation = builtins.deepSeq darwinEvaluationPaths (
+            pkgs.runCommand "check-darwin-evaluation-${system}" { } ''
+              mkdir "$out"
+            ''
+          );
+          registryFile = pkgs.writeText "atyrode-host-registry.json" hostRegistryJson;
+          registryCheck =
+            pkgs.runCommand "check-host-registry-${system}"
+              {
+                nativeBuildInputs = [ pkgs.jq ];
+              }
+              ''
+                jq -e '
+                  length >= 6
+                  and all(.[];
+                    (.id | type == "string")
+                    and (.system | type == "string")
+                    and (.username | type == "string")
+                    and (.homeDirectory | startswith("/"))
+                    and (.capabilities | length > 0))
+                ' ${registryFile} >/dev/null
+                mkdir "$out"
+              '';
+        in
+        import ./checks/agent-tools.nix { inherit lib pkgs; }
+        // {
+          home-evaluation = homeEvaluation;
+          host-registry = registryCheck;
+        }
+        // lib.optionalAttrs (lib.hasSuffix "-darwin" system) {
+          darwin-evaluation = darwinEvaluation;
+        }
+      );
+
+      formatter = forAllSystems (system: (pkgsFor system).nixfmt);
+
+      apps = forAllSystems (
+        system:
         {
           home-manager = {
             type = "app";
@@ -232,6 +314,6 @@
             program = "${nix-darwin.packages.${system}.darwin-rebuild}/bin/darwin-rebuild";
           };
         }
-    );
-  };
+      );
+    };
 }

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,21 +1,7 @@
-{ pkgs, ... }:
-
 {
   imports = [
-    ../modules/home/agent-tools.nix
-    ./codex.nix
-    ./packages.nix
-    ./mise.nix
-    ./zsh.nix
-    ./git.nix
+    ./profiles/agent-tools.nix
+    ./profiles/base.nix
+    ./profiles/development.nix
   ];
-
-  atyrode.agentTools.enable = true;
-
-  # Home Manager uses this as a compatibility marker for stateful defaults.
-  # Keep it fixed after first activation unless you explicitly review the
-  # release notes for every version being skipped.
-  home.stateVersion = "26.05";
-
-  programs.home-manager.enable = true;
 }

--- a/home/linux-desktop.nix
+++ b/home/linux-desktop.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 
 let
   lichess = import ./pkgs/lichess.nix {
@@ -6,7 +6,7 @@ let
     lib = pkgs.lib;
   };
 in
-{
+lib.mkIf pkgs.stdenv.isLinux {
   home.packages = with pkgs; [
     arduino-ide
     lichess

--- a/home/profiles/agent-tools.nix
+++ b/home/profiles/agent-tools.nix
@@ -1,0 +1,8 @@
+{
+  imports = [
+    ../../modules/home/agent-tools.nix
+    ../codex.nix
+  ];
+
+  atyrode.agentTools.enable = true;
+}

--- a/home/profiles/base.nix
+++ b/home/profiles/base.nix
@@ -1,0 +1,14 @@
+{
+  imports = [
+    ../git.nix
+    ../mise.nix
+    ../zsh.nix
+  ];
+
+  # Home Manager uses this as a compatibility marker for stateful defaults.
+  # Keep it fixed after first activation unless every skipped release note has
+  # been reviewed explicitly.
+  home.stateVersion = "26.05";
+
+  programs.home-manager.enable = true;
+}

--- a/home/profiles/desktop.nix
+++ b/home/profiles/desktop.nix
@@ -1,0 +1,6 @@
+{
+  # Darwin desktop packages currently live in home/packages.nix and
+  # darwin/default.nix. Issue #18 will finish package ownership; this module
+  # already makes the Linux desktop selection explicit and composable.
+  imports = [ ../linux-desktop.nix ];
+}

--- a/home/profiles/development.nix
+++ b/home/profiles/development.nix
@@ -1,0 +1,3 @@
+{
+  imports = [ ../packages.nix ];
+}

--- a/home/profiles/server.nix
+++ b/home/profiles/server.nix
@@ -1,0 +1,4 @@
+{
+  # Marker for the reviewed headless composition. Issue #18 owns package
+  # placement and #28 owns the exported NixOS/Home Manager server interface.
+}

--- a/home/shell/nix.zsh
+++ b/home/shell/nix.zsh
@@ -21,6 +21,11 @@ _dotfiles_config() {
     return 0
   fi
 
+  if [[ -n "${ATYRODE_HOST:-}" ]]; then
+    echo "$ATYRODE_HOST"
+    return 0
+  fi
+
   local system
   system="$(_dotfiles_system)" || return 1
 

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -1,0 +1,87 @@
+{
+  "alex-aarch64-darwin" = {
+    system = "aarch64-darwin";
+    platform = "darwin";
+    username = "alex";
+    homeDirectory = "/Users/alex";
+    capabilities = [
+      "base"
+      "development"
+      "agent-tools"
+      "desktop"
+    ];
+    aliases = [ "alex-darwin" ];
+  };
+
+  "alex-x86_64-darwin" = {
+    system = "x86_64-darwin";
+    platform = "darwin";
+    username = "alex";
+    homeDirectory = "/Users/alex";
+    capabilities = [
+      "base"
+      "development"
+      "agent-tools"
+      "desktop"
+    ];
+    aliases = [ ];
+  };
+
+  "alex-aarch64-linux" = {
+    system = "aarch64-linux";
+    platform = "linux";
+    username = "alex";
+    homeDirectory = "/home/alex";
+    capabilities = [
+      "base"
+      "development"
+      "agent-tools"
+    ];
+    aliases = [ ];
+  };
+
+  "alex-x86_64-linux" = {
+    system = "x86_64-linux";
+    platform = "linux";
+    username = "alex";
+    homeDirectory = "/home/alex";
+    capabilities = [
+      "base"
+      "development"
+      "agent-tools"
+    ];
+    aliases = [
+      "alex"
+      "alex-linux"
+    ];
+  };
+
+  "alex-x86_64-linux-desktop" = {
+    system = "x86_64-linux";
+    platform = "linux";
+    username = "alex";
+    homeDirectory = "/home/alex";
+    capabilities = [
+      "base"
+      "development"
+      "agent-tools"
+      "desktop"
+    ];
+    aliases = [ "alex-linux-desktop" ];
+  };
+
+  "alex@ubuntu-4gb-nbg1-1" = {
+    system = "x86_64-linux";
+    platform = "linux";
+    username = "alex";
+    homeDirectory = "/home/alex";
+    hostname = "ubuntu-4gb-nbg1-1";
+    capabilities = [
+      "base"
+      "development"
+      "agent-tools"
+      "server"
+    ];
+    aliases = [ ];
+  };
+}


### PR DESCRIPTION
## Summary

- add one validated registry for every supported host/configuration
- compose Home Manager and nix-darwin outputs from real base, development, agent-tools, desktop, and server capability modules
- preserve existing public flake names as compatibility aliases
- expose canonical host/capability identity through environment variables, per-host JSON, and the pure flake lib projection
- evaluate every canonical host in aggregate checks and document add/rename/retire workflows

Package classification remains owned by #18; this establishes the composition boundary without claiming the current development closure is final.

## Validation

- focused host-registry and aggregate Home Manager checks
- compatibility-alias identity evaluation
- full native `nix flake check --show-trace -L`
- `nix flake check --all-systems --no-build --show-trace`
- Zsh syntax and diff integrity checks

Closes #9