### PR TITLE
refactor: define agent-ready package ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,25 +52,25 @@ exec zsh
 - **tree** - Directory tree viewer
 
 ### Development Tools
-- **Python 3** + **uv** - Project and agent Python runtime tooling
-- **Node.js 24** + **Bun** + **Deno** - JavaScript/TypeScript runtimes
 - **Git** - Pre-configured with useful aliases
-- **GCC** - Native compiler for Rust/C build scripts
 - **tmux** - Terminal multiplexer
-- **Rust tooling** - cargo, rustc, rustfmt, clippy, and rust-analyzer
-- **Nix tooling** - nixd and nixfmt
+- **Nix/shell quality tooling** - nixd, nixfmt, ShellCheck, and shfmt
 - **OMP** - Pinned coding agent, model presets, agents, and skills
 - **Herdr** - Persistent terminal workspaces for AI coding agents
 - **mise** - Declaratively installed runtime/version manager
+- **Project-owned runtimes** - Python/uv, JavaScript runtimes, Go, Rust, and
+  native compilers come from committed dev shells, `mise.toml`, or native
+  manifests instead of every host's global profile
 
 ### System & Containers
 - **btop** - Modern system monitor
 - **dua** - Disk usage analyzer
-- **Docker** + **docker-compose** - Container tools on Linux configs
+- **Docker** + **docker-compose** - Linux clients in the `containers` capability
 - **OrbStack** - Docker/Linux runtime on macOS
 - **dive** - Docker image inspector
 - **fastfetch** - System info on startup
-- **ffmpeg**, **Android tools**, **scrcpy**, **nmap**, **socat**, and **clamav**
+- **Explicit capabilities** - ffmpeg (`media`), Android tools/scrcpy (`mobile`),
+  and nmap/socat/ClamAV (`security`)
 
 ### macOS Apps
 - **Nix app bundles** - ChatGPT, Godot, Lichess, Obsidian, OrbStack, Postman,
@@ -199,6 +199,10 @@ add/rename/retire workflow.
 [The `atyrode` CLI](docs/atyrode.md) documents deterministic application,
 machine-readable capability discovery, diagnostics, and the `zconf`
 compatibility boundary.
+
+[Package ownership](docs/package-ownership.md) records the checked agent
+baseline, optional capabilities, project-owned runtimes, harness boundaries,
+and closure review workflow.
 
 For this Mac, the manual switch command is:
 

--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -40,6 +40,14 @@ pkgs.runCommand "check-atyrode-cli"
     atyrode capabilities list --json | jq -e 'index("base") and index("server")' >/dev/null
     atyrode capabilities show alex-linux --json | jq -e '.host == "alex-x86_64-linux"' >/dev/null
     atyrode doctor host --json | jq -e '.ok and .registered.id == "alex-x86_64-linux"' >/dev/null
+    tools="$(atyrode doctor tools --json || true)"
+    jq -e '
+      any(.[]; .name == "OMP"
+        and .capability == "agent-tools"
+        and (.launchModes | index("untrusted"))
+        and (.versionOwner | length > 0))
+      and all(.[]; .status != "missing" or (.remediation | contains("do not install globally")))
+    ' <<< "$tools" >/dev/null
     atyrode apply --repo "$HOME/nix-dotfiles" --plan --json | jq -e '
       .host == "alex-x86_64-linux"
       and .backend == "nh-home"

--- a/checks/package-ownership.nix
+++ b/checks/package-ownership.nix
@@ -1,0 +1,50 @@
+{
+  hostConfigs,
+  lib,
+  pkgs,
+}:
+
+let
+  matrix = ../inventory/packages.json;
+  serverPackages = map lib.getName hostConfigs."alex@ubuntu-4gb-nbg1-1".config.home.packages;
+  forbiddenServerPackages = [
+    "android-tools"
+    "arduino-ide"
+    "bun"
+    "deno"
+    "ffmpeg"
+    "gcc"
+    "godot"
+    "go"
+    "nodejs"
+    "parsec-bin"
+    "python"
+    "rustc"
+    "scrcpy"
+    "steam"
+    "uv"
+    "vscode"
+  ];
+  leakedServerPackages = lib.intersectLists serverPackages forbiddenServerPackages;
+in
+assert lib.assertMsg (leakedServerPackages == [ ]) "server capability leaked workstation packages";
+pkgs.runCommand "check-package-ownership"
+  {
+    nativeBuildInputs = [ pkgs.jq ];
+  }
+  ''
+    jq -e '
+      length > 0
+      and all(.[];
+        (.owner | type == "string" and length > 0)
+        and (.deliveryLayer | type == "string" and length > 0)
+        and (.selectedBy | type == "array")
+        and (.consumer | type == "string" and length > 0)
+        and (.versionOwner | type == "string" and length > 0)
+        and (.mutableState | type == "string" and length > 0)
+        and (.closureClass | type == "string" and length > 0)
+        and (.packages | type == "array" and length > 0))
+      and ([.[].packages[]] | length == (unique | length))
+    ' ${matrix} >/dev/null
+    mkdir "$out"
+  ''

--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -10,8 +10,6 @@
 }:
 
 {
-  nixpkgs.config.allowUnfree = true;
-
   system = {
     primaryUser = username;
     stateVersion = 7;

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -11,17 +11,22 @@ points; OMP and Codex profiles remain harness-specific mutable-state boundaries.
 
 ## Current capabilities
 
-- `base`: shell, Git, mise, and Home Manager itself.
-- `development`: the current shared CLI and development package set.
+- `base`: shell, Git/GitHub, search, direnv/nix-direnv, mise, on-demand lookup,
+  diagnostics, and Home Manager itself.
+- `development`: cross-repository Nix and shell quality tools, not project
+  language runtimes.
 - `agent-tools`: Codex, OMP, Herdr, managed agents, and their configuration.
-- `desktop`: desktop-only additions; currently selects the Linux desktop module.
+- `desktop`: operator-selected graphical applications.
+- `mobile`: Android device tooling.
+- `media`: audio/video conversion and inspection.
+- `containers`: container clients and inspection tools; the daemon is
+  system-owned.
+- `security`: declared scanning and network diagnostics.
 - `server`: marks the reviewed headless composition consumed by #28.
 
-Issue #18 owns the next package-placement pass. Until it lands, some packages
-inside `development` remain broader than their eventual mobile, media,
-container, security, or project-owned capabilities. The registry records the
-composition boundary now without claiming that package classification is
-already complete.
+Project compilers and runtimes are owned by committed dev shells, `mise.toml`,
+and native manifests. See [Package ownership](package-ownership.md) for the
+checked matrix and harness boundaries.
 
 Each activated Home Manager configuration exposes its canonical identity in
 `$ATYRODE_HOST`, its comma-separated capability set in

--- a/docs/package-ownership.md
+++ b/docs/package-ownership.md
@@ -1,0 +1,70 @@
+# Package ownership
+
+The checked source of truth is [`inventory/packages.json`](../inventory/packages.json).
+Every package has one delivery owner, a demonstrated consumer, a version owner,
+a mutable-state boundary, and a coarse closure class. The flake rejects duplicate
+entries and rejects workstation runtimes, mobile/media tools, and GUI packages
+from the server composition.
+
+## Delivery layers
+
+- `base` is the small operator/agent shell contract: Git/GitHub, search, JSON,
+  direnv with nix-direnv, mise, diagnostics, `nh`, nix-index, and comma.
+- `development` contains cross-repository Nix and shell quality tools. It does
+  not provide application language versions.
+- `agent-tools` owns Codex, OMP, Herdr, their launch adapters, tmux, and the
+  Linux isolation backend. Authentication, sessions, trust, and caches remain
+  mutable and harness-owned outside derivations.
+- `desktop`, `mobile`, `media`, `containers`, and `security` are explicit host
+  capabilities. Container daemons and Homebrew application state remain
+  system-owned.
+- Python/Pillow/uv, Node/Bun/Deno, Go, Rust, and GCC are project-owned. A Nix
+  project commits a dev shell and `.envrc`; other projects commit `mise.toml`
+  plus their native manifest. Nix and mise must not own the same project runtime.
+- Infrequent commands use comma or an explicit `nix shell`; diagnostics direct
+  missing tools back to the owning capability instead of suggesting a global
+  install.
+
+Desktop applications are retained as an operator-use decision, separate from
+the agent platform. Pi and Zed remain absent, coherent experiments owned by #29
+and #30; neither is pulled into the baseline for harness symmetry.
+
+## Harness and surface contract
+
+| Harness/surface | Hosts | Version owner | Mutable state | Supported launch modes |
+|---|---|---|---|---|
+| Codex CLI | `agent-tools` | pinned nixpkgs | `~/.codex`, isolated profiles | interactive, exec |
+| OMP | `agent-tools` | repository derivation | profile-scoped auth, sessions, MCP, caches | normal, preset, untrusted, ACP |
+| Herdr + tmux adapter | `agent-tools` | repository derivation + pinned nixpkgs | workspace registry and tmux server | workspace, agent |
+| bubblewrap backend | Linux `agent-tools` | pinned nixpkgs | none | OMP task isolation |
+| comma + nix-index | `base` | pinned flake input | immutable index/shared store | lookup, on-demand command |
+| Pi/extensions | none pending #29 | unassigned | must be isolated | evaluation only |
+| Zed/ACP surface | none pending #30 | unassigned | editor-owned | evaluation only |
+
+`atyrode doctor tools --json` reports these versions, launch modes, paths,
+owners, and missing-capability remediation without reading authentication state.
+
+## Closure review
+
+The matrix records a stable coarse contribution so large additions are visible
+in review. Exact sizes vary by platform and nixpkgs revision. Measure the pinned
+host closure without activating it:
+
+```sh
+nix build --no-link .#homeConfigurations.alex-x86_64-linux.activationPackage
+nix path-info -Sh .#homeConfigurations.alex-x86_64-linux.activationPackage
+
+nix build --no-link '.#homeConfigurations.alex@ubuntu-4gb-nbg1-1.activationPackage'
+nix path-info -Sh '.#homeConfigurations.alex@ubuntu-4gb-nbg1-1.activationPackage'
+```
+
+Use the same commands for each canonical host before accepting a large package
+or capability. The shared Nix store deduplicates identical dependencies across
+hosts and workspaces; a binary cache can be added without changing ownership.
+
+At the pinned 2026-07-10 revision, realized x86_64-linux closures measure 2.5
+GiB for `alex-x86_64-linux` and 3.1 GiB for the server composition. The server
+delta is the declared `containers` and `security` capabilities, chiefly Docker
+clients and ClamAV—not workstation language stacks or desktop software. Darwin
+and aarch64 sizes must be measured on compatible builders; CI evaluates those
+compositions structurally on every change.

--- a/flake.lock
+++ b/flake.lock
@@ -128,6 +128,26 @@
         "type": "github"
       }
     },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783414108,
+        "narHash": "sha256-RY8e+gR2/DhXsYDxGDL6Hhe9+POD9u4+llwxMBqMQDs=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "96d6de10eb281b98f5cfcd1841394c03da5df77c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1783224372,
@@ -152,6 +172,7 @@
         "homebrew-core": "homebrew-core",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
+        "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,9 @@
 
     nix-homebrew.url = "github:zhaofengli/nix-homebrew";
 
+    nix-index-database.url = "github:nix-community/nix-index-database";
+    nix-index-database.inputs.nixpkgs.follows = "nixpkgs";
+
     homebrew-core = {
       url = "github:homebrew/homebrew-core";
       flake = false;
@@ -34,6 +37,7 @@
       herdr,
       nix-darwin,
       nix-homebrew,
+      nix-index-database,
       homebrew-core,
       homebrew-cask,
       ...
@@ -50,11 +54,37 @@
 
       forAllSystems = lib.genAttrs systems;
 
+      # Each name corresponds to a reviewed package in a selected capability.
+      # Homebrew casks are governed independently by the nix-darwin module.
+      allowedUnfreePackages = [
+        "arduino-ide"
+        "chatgpt"
+        "codex"
+        "obsidian"
+        "orbstack"
+        "parsec-bin"
+        "postman"
+        "reaper"
+        "signal-desktop"
+        "spotify"
+        "steam"
+        "steam-original"
+        "steam-unwrapped"
+        "steamcmd"
+        "vital"
+        "vscode"
+        "whatsapp-for-mac"
+      ];
+
       capabilityModules = {
         base = ./home/profiles/base.nix;
         development = ./home/profiles/development.nix;
         agent-tools = ./home/profiles/agent-tools.nix;
         desktop = ./home/profiles/desktop.nix;
+        containers = ./home/profiles/containers.nix;
+        media = ./home/profiles/media.nix;
+        mobile = ./home/profiles/mobile.nix;
+        security = ./home/profiles/security.nix;
         server = ./home/profiles/server.nix;
       };
       knownCapabilities = builtins.attrNames capabilityModules;
@@ -140,7 +170,14 @@
       modulesForHost =
         name: host:
         map (capability: capabilityModules.${capability}) host.capabilities
-        ++ [ (mkHostIdentityModule name host) ];
+        ++ [
+          nix-index-database.homeModules.default
+          {
+            programs.nix-index-database.comma.enable = true;
+            programs.nix-index.enable = true;
+          }
+          (mkHostIdentityModule name host)
+        ];
 
       agentToolsOverlay = lib.composeManyExtensions [
         herdr.overlays.default
@@ -161,7 +198,7 @@
         system:
         import nixpkgs {
           inherit system;
-          config.allowUnfree = true;
+          config.allowUnfreePredicate = package: builtins.elem (lib.getName package) allowedUnfreePackages;
           overlays = [ agentToolsOverlay ];
         };
 
@@ -198,6 +235,8 @@
             {
               nixpkgs.hostPlatform = host.system;
               nixpkgs.overlays = [ agentToolsOverlay ];
+              nixpkgs.config.allowUnfreePredicate =
+                package: builtins.elem (lib.getName package) allowedUnfreePackages;
             }
           ];
         };
@@ -299,6 +338,10 @@
           atyrode-cli = import ./checks/atyrode-cli.nix { inherit pkgs; };
           home-evaluation = homeEvaluation;
           host-registry = registryCheck;
+          package-ownership = import ./checks/package-ownership.nix {
+            inherit lib pkgs;
+            hostConfigs = canonicalHomeConfigs;
+          };
         }
         // lib.optionalAttrs (lib.hasSuffix "-darwin" system) {
           darwin-evaluation = darwinEvaluation;

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -454,103 +454,15 @@ EOF
     '';
   };
 
-  lichess = import ./pkgs/lichess.nix {
-    inherit lib pkgs;
-  };
-
-  cliPackages = with pkgs; [
-    # File navigation & search
-    zoxide
-    fzf
-    fd
-    bat
-    tree
-    ripgrep
-    unzip
-
-    # System monitoring
-    btop
-    dua
-    fastfetch
-
-    # Shell helpers
-    direnv
-    shellcheck
-    shfmt
-  ];
-
-  pythonPackages = with pkgs; [
-    # Python tooling
-    (python3.withPackages (ps: with ps; [
-      pillow
-    ]))
-    uv
-  ];
-
-  javascriptPackages = with pkgs; [
-    # JavaScript/TypeScript tooling
-    nodejs_24
-    bun
-    deno
-  ];
-
-  developmentPackages = with pkgs; [
-    # Development tools
-    git
-    gh
-    tmux
-    jq
-    ffmpeg
-    go
-    nmap
-    socat
-    android-tools
-    scrcpy
-    dive
-    clamav
-    cargo
-    rustc
-    rustfmt
-    clippy
-    rust-analyzer
-    nixd
-    nixfmt
-    codex
-    codex-use
-  ];
-
-  darwinPackages = with pkgs; [
-    chatgpt
-    godot
-    lichess
-    obsidian
-    orbstack
-    postman
-    prismlauncher
-    reaper
-    signal-desktop
-    spotify
-    vlc-bin
-    vscode
-    whatsapp-for-mac
-  ];
-
-  linuxPackages = with pkgs; [
-    # Container tools
-    docker
-    docker-compose
-
-    # Linux-only development tools
-    gcc
-    bubblewrap
-  ];
 in
 {
+  # Harness packages and state tooling belong to the agent-tools capability.
+  # Language runtimes and project compilers intentionally do not live here.
   home.packages =
-    cliPackages
-    ++ pythonPackages
-    ++ javascriptPackages
-    ++ developmentPackages
-    ++ lib.optionals pkgs.stdenv.isDarwin darwinPackages
-    ++ lib.optionals pkgs.stdenv.isLinux linuxPackages;
+    (with pkgs; [
+      codex
+      codex-use
+      tmux
+    ])
+    ++ lib.optionals pkgs.stdenv.isLinux [ pkgs.bubblewrap ];
 }

--- a/home/profiles/agent-tools.nix
+++ b/home/profiles/agent-tools.nix
@@ -2,6 +2,7 @@
   imports = [
     ../../modules/home/agent-tools.nix
     ../codex.nix
+    ../packages.nix
   ];
 
   atyrode.agentTools.enable = true;

--- a/home/profiles/base.nix
+++ b/home/profiles/base.nix
@@ -13,5 +13,27 @@
 
   programs.home-manager.enable = true;
 
-  home.packages = [ pkgs.atyrode ];
+  home.packages = with pkgs; [
+    atyrode
+    bat
+    btop
+    direnv
+    dua
+    fd
+    fastfetch
+    gh
+    git
+    jq
+    ripgrep
+    tree
+    unzip
+  ];
+
+  programs.direnv = {
+    enable = true;
+    nix-direnv.enable = true;
+  };
+
+  programs.fzf.enable = true;
+  programs.zoxide.enable = true;
 }

--- a/home/profiles/containers.nix
+++ b/home/profiles/containers.nix
@@ -1,0 +1,15 @@
+{ lib, pkgs, ... }:
+{
+  # This capability installs clients and inspection tools only. Daemon and
+  # desktop-engine ownership remains with the system/desktop layers.
+  home.packages = [
+    pkgs.dive
+  ]
+  ++ lib.optionals pkgs.stdenv.isLinux (
+    with pkgs;
+    [
+      docker
+      docker-compose
+    ]
+  );
+}

--- a/home/profiles/desktop.nix
+++ b/home/profiles/desktop.nix
@@ -1,6 +1,29 @@
+{ lib, pkgs, ... }:
+let
+  lichess = import ../pkgs/lichess.nix {
+    inherit lib pkgs;
+  };
+in
 {
-  # Darwin desktop packages currently live in home/packages.nix and
-  # darwin/default.nix. Issue #18 will finish package ownership; this module
-  # already makes the Linux desktop selection explicit and composable.
   imports = [ ../linux-desktop.nix ];
+
+  # Retention of desktop applications reflects operator use, not the agent
+  # baseline. Homebrew-owned applications remain in the nix-darwin module.
+  home.packages = lib.optionals pkgs.stdenv.isDarwin (
+    (with pkgs; [
+      chatgpt
+      godot
+      obsidian
+      orbstack
+      postman
+      prismlauncher
+      reaper
+      signal-desktop
+      spotify
+      vlc-bin
+      vscode
+      whatsapp-for-mac
+    ])
+    ++ [ lichess ]
+  );
 }

--- a/home/profiles/development.nix
+++ b/home/profiles/development.nix
@@ -1,3 +1,11 @@
+{ pkgs, ... }:
 {
-  imports = [ ../packages.nix ];
+  # Cross-repository quality tools that interactive agents may assume. Project
+  # language versions and compilers belong to dev shells or mise manifests.
+  home.packages = with pkgs; [
+    nixd
+    nixfmt
+    shellcheck
+    shfmt
+  ];
 }

--- a/home/profiles/media.nix
+++ b/home/profiles/media.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = [ pkgs.ffmpeg ];
+}

--- a/home/profiles/mobile.nix
+++ b/home/profiles/mobile.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    android-tools
+    scrcpy
+  ];
+}

--- a/home/profiles/security.nix
+++ b/home/profiles/security.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    clamav
+    nmap
+    socat
+  ];
+}

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -9,6 +9,9 @@
       "development"
       "agent-tools"
       "desktop"
+      "mobile"
+      "media"
+      "containers"
     ];
     aliases = [ "alex-darwin" ];
   };
@@ -23,6 +26,9 @@
       "development"
       "agent-tools"
       "desktop"
+      "mobile"
+      "media"
+      "containers"
     ];
     aliases = [ ];
   };
@@ -66,6 +72,9 @@
       "development"
       "agent-tools"
       "desktop"
+      "mobile"
+      "media"
+      "containers"
     ];
     aliases = [ "alex-linux-desktop" ];
   };
@@ -81,6 +90,8 @@
       "development"
       "agent-tools"
       "server"
+      "containers"
+      "security"
     ];
     aliases = [ ];
   };

--- a/inventory/packages.json
+++ b/inventory/packages.json
@@ -1,0 +1,112 @@
+[
+  {
+    "owner": "base",
+    "deliveryLayer": "home-manager",
+    "selectedBy": ["base"],
+    "consumer": "operator and agent shell baseline",
+    "versionOwner": "pinned nixpkgs",
+    "mutableState": "tool-specific XDG caches only",
+    "closureClass": "small/shared",
+    "packages": ["atyrode", "bat", "btop", "comma", "direnv", "dua", "fastfetch", "fd", "fzf", "gh", "git", "jq", "mise", "nix-index", "ripgrep", "tree", "unzip", "zoxide"]
+  },
+  {
+    "owner": "development",
+    "deliveryLayer": "home-manager",
+    "selectedBy": ["development"],
+    "consumer": "cross-repository agent linting and Nix editing",
+    "versionOwner": "pinned nixpkgs",
+    "mutableState": "language-server caches",
+    "closureClass": "medium",
+    "packages": ["nixd", "nixfmt", "shellcheck", "shfmt"]
+  },
+  {
+    "owner": "agent-tools",
+    "deliveryLayer": "home-manager and repository overlays",
+    "selectedBy": ["agent-tools"],
+    "consumer": "Codex, OMP isolation, and Herdr workspaces",
+    "versionOwner": "pinned nixpkgs or repository package derivation",
+    "mutableState": "separate harness-owned auth, sessions, MCP state, and caches under the user home",
+    "closureClass": "large",
+    "packages": ["bubblewrap", "codex", "codex-use", "herdr-configured", "omp-configured", "tmux"]
+  },
+  {
+    "owner": "desktop",
+    "deliveryLayer": "home-manager",
+    "selectedBy": ["desktop"],
+    "consumer": "operator-selected graphical applications",
+    "versionOwner": "pinned nixpkgs",
+    "mutableState": "application-owned user data and caches",
+    "closureClass": "very-large",
+    "packages": ["arduino-ide", "chatgpt", "godot", "lichess", "obsidian", "orbstack", "parsec-bin", "plugdata", "postman", "prismlauncher", "reaper", "signal-desktop", "spotify", "steam", "steamcmd", "vital", "vlc", "vlc-bin", "vscode", "whatsapp-for-mac"]
+  },
+  {
+    "owner": "mobile",
+    "deliveryLayer": "home-manager",
+    "selectedBy": ["mobile"],
+    "consumer": "interactive Android device workflows",
+    "versionOwner": "pinned nixpkgs",
+    "mutableState": "ADB host keys and device state",
+    "closureClass": "medium",
+    "packages": ["android-tools", "scrcpy"]
+  },
+  {
+    "owner": "media",
+    "deliveryLayer": "home-manager",
+    "selectedBy": ["media"],
+    "consumer": "desktop audio/video inspection and conversion",
+    "versionOwner": "pinned nixpkgs",
+    "mutableState": "none beyond project files",
+    "closureClass": "large",
+    "packages": ["ffmpeg"]
+  },
+  {
+    "owner": "containers",
+    "deliveryLayer": "home-manager clients; system-owned daemon",
+    "selectedBy": ["containers"],
+    "consumer": "containerized project and server operations",
+    "versionOwner": "pinned nixpkgs",
+    "mutableState": "daemon-owned images and volumes outside Home Manager",
+    "closureClass": "medium",
+    "packages": ["dive", "docker", "docker-compose"]
+  },
+  {
+    "owner": "security",
+    "deliveryLayer": "home-manager",
+    "selectedBy": ["security"],
+    "consumer": "declared server diagnostics and scanning",
+    "versionOwner": "pinned nixpkgs",
+    "mutableState": "ClamAV signatures and tool caches",
+    "closureClass": "large",
+    "packages": ["clamav", "nmap", "socat"]
+  },
+  {
+    "owner": "project",
+    "deliveryLayer": "committed dev shell, mise.toml, or native manifest",
+    "selectedBy": [],
+    "consumer": "only repositories that declare the runtime or compiler",
+    "versionOwner": "project manifest",
+    "mutableState": "project and mise caches",
+    "closureClass": "not-global",
+    "packages": ["bun", "cargo", "clippy", "deno", "gcc", "go", "nodejs", "pillow", "python", "rust-analyzer", "rustc", "rustfmt", "uv"]
+  },
+  {
+    "owner": "system",
+    "deliveryLayer": "nix-darwin managed Homebrew cask",
+    "selectedBy": ["desktop", "darwin"],
+    "consumer": "operator-selected macOS graphical applications",
+    "versionOwner": "immutable Homebrew taps pinned by the flake",
+    "mutableState": "application-owned user data; Homebrew state outside Nix derivations",
+    "closureClass": "outside-nix-store",
+    "packages": ["bitwarden", "codex-app", "display-pilot", "discord", "parsec", "sonos", "zen"]
+  },
+  {
+    "owner": "experimental",
+    "deliveryLayer": "not installed",
+    "selectedBy": [],
+    "consumer": "evaluation issues #29 and #30",
+    "versionOwner": "unassigned until admitted",
+    "mutableState": "must remain isolated if introduced",
+    "closureClass": "absent",
+    "packages": ["pi", "pi-extensions", "zed"]
+  }
+]

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 readonly registry='@registry@'
+readonly tool_inventory='@tools@'
 readonly EX_USAGE=64 EX_DATAERR=65 EX_NOINPUT=66 EX_UNAVAILABLE=69 EX_SOFTWARE=70
 
 die() {
@@ -136,15 +137,29 @@ capabilities() {
 }
 
 doctor_tools() {
-  local json=0 tool rows='[]' status path
+  local json=0 rows='[]' status path entry command capability platform host data expected remediation
   [[ "${1:-}" != --json ]] || json=1
-  for tool in nix nh git jq zsh; do
-    if path="$(command -v "$tool" 2>/dev/null)"; then status=ok; else status=missing; path=''; fi
-    rows="$(jq -c --arg name "$tool" --arg status "$status" --arg path "$path" \
-      '. + [{name:$name,status:$status,path:$path}]' <<<"$rows")"
-  done
+  host="$(resolve_host)"
+  data="$(host_json "$host")"
+  while IFS= read -r entry; do
+    command="$(jq -r '.command' <<<"$entry")"
+    capability="$(jq -r '.capability' <<<"$entry")"
+    platform="$(jq -r '.platform // empty' <<<"$entry")"
+    expected=false
+    if jq -e --arg capability "$capability" '.capabilities | index($capability)' <<<"$data" >/dev/null \
+      && [[ -z "$platform" || "$platform" == "$(jq -r '.platform' <<<"$data")" ]]; then
+      expected=true
+    fi
+    if path="$(command -v "$command" 2>/dev/null)"; then status=ok
+    else status=missing; path=''; fi
+    remediation="enable the $capability capability and apply the registered host; do not install globally"
+    rows="$(jq -c --argjson entry "$entry" --arg status "$status" --arg path "$path" \
+      --argjson expected "$expected" --arg remediation "$remediation" \
+      '. + [$entry + {status:$status,path:$path,expected:$expected,remediation:(if $status == "missing" then $remediation else null end)}]' <<<"$rows")"
+  done < <(jq -c '.[]' "$tool_inventory")
   if [[ "$json" == 1 ]]; then printf '%s\n' "$rows"
-  else jq -r '.[] | "\(.name): \(.status)\(if .path == "" then "" else " (\(.path))" end)"' <<<"$rows"; fi
+  else jq -r '.[] | "\(.name): \(.status) [\(.capability)]\(if .path == "" then "" else " (\(.path))" end)"' <<<"$rows"; fi
+  jq -e 'all(.[]; (.expected | not) or .status == "ok")' <<<"$rows" >/dev/null
 }
 
 apply_config() {

--- a/pkgs/atyrode/default.nix
+++ b/pkgs/atyrode/default.nix
@@ -1,18 +1,144 @@
 {
+  bubblewrap,
+  codex,
   coreutils,
   gitMinimal,
+  herdr-configured,
   hostname,
   hostRegistry,
   jq,
   lib,
   makeWrapper,
   nh,
+  nix,
+  omp-configured,
   runtimeShell,
   stdenvNoCC,
+  tmux,
+  zsh,
 }:
 
 let
   registry = builtins.toFile "atyrode-host-registry.json" (builtins.toJSON hostRegistry);
+  tools = builtins.toFile "atyrode-tool-inventory.json" (
+    builtins.toJSON [
+      {
+        name = "Nix";
+        command = "nix";
+        capability = "base";
+        version = lib.getVersion nix;
+        versionOwner = "pinned nixpkgs/system installer";
+        mutableState = "shared Nix store and user evaluation caches";
+        launchModes = [
+          "build"
+          "develop"
+          "shell"
+        ];
+      }
+      {
+        name = "nh";
+        command = "nh";
+        capability = "base";
+        version = lib.getVersion nh;
+        versionOwner = "pinned nixpkgs";
+        mutableState = "none beyond Nix state";
+        launchModes = [
+          "home"
+          "darwin"
+        ];
+      }
+      {
+        name = "Codex";
+        command = "codex";
+        capability = "agent-tools";
+        version = lib.getVersion codex;
+        versionOwner = "pinned nixpkgs";
+        mutableState = "~/.codex and ~/.codex-profiles";
+        launchModes = [
+          "interactive"
+          "exec"
+        ];
+      }
+      {
+        name = "OMP";
+        command = "omp";
+        capability = "agent-tools";
+        version = lib.getVersion omp-configured;
+        versionOwner = "repository package derivation";
+        mutableState = "profile-scoped auth, sessions, MCP state, and caches";
+        launchModes = [
+          "normal"
+          "preset"
+          "untrusted"
+          "acp"
+        ];
+      }
+      {
+        name = "Herdr";
+        command = "herdr";
+        capability = "agent-tools";
+        version = lib.getVersion herdr-configured;
+        versionOwner = "repository package derivation";
+        mutableState = "Herdr workspace registry";
+        launchModes = [
+          "workspace"
+          "agent"
+        ];
+      }
+      {
+        name = "tmux adapter";
+        command = "tmux";
+        capability = "agent-tools";
+        version = lib.getVersion tmux;
+        versionOwner = "pinned nixpkgs";
+        mutableState = "tmux server sockets and sessions";
+        launchModes = [
+          "Herdr backend"
+          "interactive"
+        ];
+      }
+      {
+        name = "bubblewrap isolation backend";
+        command = "bwrap";
+        capability = "agent-tools";
+        platform = "linux";
+        version = lib.getVersion bubblewrap;
+        versionOwner = "pinned nixpkgs";
+        mutableState = "none";
+        launchModes = [ "OMP task isolation" ];
+      }
+      {
+        name = "comma";
+        command = ",";
+        capability = "base";
+        version = "nix-index-database input";
+        versionOwner = "pinned flake input";
+        mutableState = "shared Nix store";
+        launchModes = [ "on-demand command" ];
+      }
+      {
+        name = "nix-index";
+        command = "nix-locate";
+        capability = "base";
+        version = "nix-index-database input";
+        versionOwner = "pinned flake input";
+        mutableState = "immutable packaged index";
+        launchModes = [ "lookup" ];
+      }
+      {
+        name = "Zsh";
+        command = "zsh";
+        capability = "base";
+        version = lib.getVersion zsh;
+        versionOwner = "pinned nixpkgs";
+        mutableState = "history and completion cache";
+        launchModes = [
+          "interactive"
+          "login"
+        ];
+      }
+    ]
+  );
 in
 stdenvNoCC.mkDerivation {
   pname = "atyrode";
@@ -25,7 +151,8 @@ stdenvNoCC.mkDerivation {
     install -D -m755 "$src" "$out/bin/atyrode"
     substituteInPlace "$out/bin/atyrode" \
       --replace-fail '@shell@' '${runtimeShell}' \
-      --replace-fail '@registry@' '${registry}'
+      --replace-fail '@registry@' '${registry}' \
+      --replace-fail '@tools@' '${tools}'
     wrapProgram "$out/bin/atyrode" \
       --prefix PATH : ${
         lib.makeBinPath [


### PR DESCRIPTION
## Summary
- split the global package buffet into base, development, agent-tools, desktop, mobile, media, containers, and security capabilities
- move Python, JavaScript, Go, Rust, and GCC toolchains to project-owned manifests instead of every host
- add direnv/nix-direnv plus nix-index-database/comma, and replace global allowUnfree with a reviewed predicate
- add a checked package matrix, server leakage assertion, harness/version diagnostics, and closure audit documentation

## Validation
- nix flake check --show-trace
- nix flake check --all-systems --no-build --show-trace
- built alex-x86_64-linux and alex@ubuntu-4gb-nbg1-1 activation packages without activation
- nix build .#checks.x86_64-linux.atyrode-cli -L
- nix build .#checks.x86_64-linux.package-ownership -L
- bash -n and ShellCheck for pkgs/atyrode/atyrode
- Zsh syntax checks
- jq inventory validation
- git diff --check

Representative realized closures at this pin: 2.5 GiB baseline and 3.1 GiB server (containers + security).

Closes #18