### PR TITLE
feat(bootstrap): harden installation and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,41 +4,25 @@ Personal dotfiles managed with Nix and Home Manager for shell and developer tool
 
 ## 🚀 Quick Start
 
-**From this checkout:**
+**From a reviewed checkout:**
 
 ```bash
-cd ~/code/dotfiles
-./install.sh
+cd ~/nix-dotfiles
+./install.sh plan --config alex-x86_64-linux
+./install.sh apply --config alex-x86_64-linux
 ```
 
-**One command installation from GitHub:**
+**Supported fresh-machine command:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/atyrode/dotfiles/main/install.sh | bash
+git clone https://github.com/atyrode/dotfiles.git "$HOME/nix-dotfiles" && "$HOME/nix-dotfiles/install.sh" apply --config alex-x86_64-linux
 ```
 
-Or manually:
-
-```bash
-# 1. Install Nix (if not installed)
-sh <(curl -L https://nixos.org/nix/install) --daemon
-. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-
-# 2. Enable flakes
-mkdir -p ~/.config/nix
-echo "extra-experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
-
-# 3. Clone and setup
-git clone https://github.com/atyrode/dotfiles.git ~/dotfiles
-cd ~/dotfiles
-if [ -L ~/.zshrc ]; then mv ~/.zshrc ~/.zshrc.backup.$(date +%Y%m%d%H%M%S); fi
-sudo -H nix run .#darwin-rebuild -- switch --flake .#alex-aarch64-darwin
-
-# 4. Restart shell
-exec zsh
-```
-
-**That's it!** Your shell is now configured. Run `atyrode` to see all available tools.
+Replace the example host with the exact entry from `hosts/default.nix`; bootstrap
+will not guess between desktop, development, server, or Mac profiles. It uses
+explicit preflight, plan, apply, verify, and rollback phases, verifies a pinned
+upstream Nix artifact when Nix is absent, and preserves recoverable migration
+receipts. See [Bootstrap and migrations](docs/bootstrap.md).
 
 ---
 
@@ -125,14 +109,14 @@ git ci        # git commit
 
 **Update dotfiles:**
 ```bash
-cd ~/code/dotfiles  # or your dotfiles checkout
+cd ~/nix-dotfiles
 git pull
 zconf
 ```
 
 **Update Nix packages:**
 ```bash
-cd ~/code/dotfiles  # or your dotfiles checkout
+cd ~/nix-dotfiles
 nix flake update
 zconf
 ```
@@ -153,7 +137,7 @@ dotfiles/
 │   └── default.nix        # macOS system and cask definitions
 ├── docs/                    # Architecture and maintenance guides
 ├── flake.nix              # Main flake configuration
-├── install.sh             # Quick install script
+├── install.sh             # Phased, transactional bootstrap
 ├── modules/                 # Reusable Home Manager modules
 ├── omp/                     # Managed config, presets, agents, and rules
 ├── pkgs/                    # Pinned custom derivations and wrappers
@@ -228,16 +212,17 @@ For Linux desktop machines that need Steam, SteamCMD, and VLC:
 HOME_MANAGER_BACKUP_EXT=backup nix run .#home-manager -- switch --flake .#alex-x86_64-linux-desktop
 ```
 
-You can also set `DOTFILES_CONFIG=alex-x86_64-linux-desktop` before running
-`zconf` on a Linux desktop. Successful `zconf` and `install.sh` runs record
-the active configuration so helper commands such as `atyrode` only show what
-applies to the current setup.
+You can also set `ATYRODE_HOST=alex-x86_64-linux-desktop` before running
+`zconf` on a Linux desktop. Successful `zconf` and `install.sh apply` runs
+record the active configuration so helper commands such as `atyrode` only show
+what applies to the current setup.
 
 ### Change Username
 
-Edit `flake.nix` and replace `defaultUsername = "alex"` with your username.
-
-If you want to keep the username but force a config, set `FLAKE_CONFIG` before running the installer.
+Edit the owning entry in `hosts/default.nix`, including its username and home
+directory, then follow the validation workflow in [Hosts and
+capabilities](docs/hosts.md). Select a bootstrap host with `--config`; the
+`FLAKE_CONFIG` environment variable is the equivalent non-interactive input.
 
 ### Add Packages
 
@@ -258,7 +243,7 @@ Edit files in `home/shell/` - they're organized by category for easy maintenance
 
 **"Path is not tracked by Git" error:**
 ```bash
-cd ~/dotfiles
+cd ~/nix-dotfiles
 git add <file>
 zconf
 ```
@@ -278,9 +263,15 @@ git status
 zconf
 ```
 
-If the error says an existing symlink such as `~/.zshrc` would be clobbered,
-run `./install.sh` instead of the manual switch command. The installer backs up
-symlinked shell entrypoints before activation.
+If the error says an existing path such as `~/.zshrc` would be clobbered, run
+the bootstrap plan and apply phases for the registered host. The versioned
+migration backs up file and symlink entrypoints before activation and restores
+them automatically if activation fails.
+
+```sh
+./install.sh plan --config <host>
+./install.sh apply --config <host>
+```
 
 **macOS Homebrew activation fails:**
 ```bash
@@ -294,7 +285,7 @@ The macOS configuration installs Homebrew through nix-homebrew and then applies 
 ## 📝 Requirements
 
 - macOS or Linux with Nix support
-- Git
+- Git, Bash, `curl`, `tar`, and either `sha256sum` or `shasum` for a fresh machine
 - Internet connection (for initial install)
 
 Nix will be installed automatically if not present.

--- a/checks/bootstrap.nix
+++ b/checks/bootstrap.nix
@@ -1,0 +1,594 @@
+{ pkgs }:
+
+let
+  system = pkgs.stdenv.hostPlatform.system;
+  expectedHash =
+    {
+      "aarch64-darwin" = "1e18301c4ea78c667f2753159156b5bdb899993720e8aa7bcca97e8312d3d6b";
+      "x86_64-darwin" = "bf3dadfd65be182ad3141b1224bbc82e0f2a61d4f36781938b5e6ede029c2a37";
+      "aarch64-linux" = "1cee64ae7a02330c6421924c28f597c41813f2214ff108622087d8056378b088";
+      "x86_64-linux" = "eafe5042404e818505e28c5ca3d0885f3ec45c31f955489a25bb38258f87560ef";
+    }
+    .${system};
+in
+pkgs.runCommand "check-bootstrap-${system}"
+  {
+    nativeBuildInputs = [
+      pkgs.bash
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.git
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.shellcheck
+    ];
+  }
+  ''
+    set -euo pipefail
+
+    bootstrap=${../install.sh}
+    migration=${../scripts/bootstrap-migrate.sh}
+    real_git=${pkgs.git}/bin/git
+    base_path="$PATH"
+    host="alex-${system}"
+    tool_root="$TMPDIR/tools"
+    fresh_tools="$tool_root/fresh"
+    managed_tools="$tool_root/managed"
+    fake_nix_template="$tool_root/fake-nix"
+    fake_installer_template="$tool_root/fake-installer"
+
+    bash -n "$bootstrap"
+    bash -n "$migration"
+    shellcheck -x "$bootstrap" "$migration"
+    if grep -Eq 'mapfile|declare -A|local -n|\[\[ -v |\$\{[^}]+,,\}|flock|stat -c' \
+      "$bootstrap" "$migration"; then
+      echo 'bootstrap uses a construct unavailable before Nix or on Bash 3.2' >&2
+      exit 1
+    fi
+
+    mkdir -p "$fresh_tools" "$managed_tools"
+
+    cat > "$tool_root/git" <<'EOF'
+    #!${pkgs.runtimeShell}
+    if [ -n "''${FAKE_GIT_UPDATE_REPO:-}" ]; then
+      worktree=""
+      previous=""
+      is_fetch=0
+      for argument in "$@"; do
+        if [ "$previous" = -C ]; then
+          worktree="$argument"
+        fi
+        if [ "$argument" = fetch ]; then
+          is_fetch=1
+        fi
+        previous="$argument"
+      done
+      if [ "$is_fetch" = 1 ]; then
+        exec ${pkgs.git}/bin/git -C "$worktree" fetch \
+          "$FAKE_GIT_UPDATE_REPO" +main:refs/remotes/origin/main
+      fi
+    fi
+    if [ "''${FAKE_GIT_FETCH_FAIL:-0}" = 1 ]; then
+      for argument in "$@"; do
+        if [ "$argument" = fetch ]; then
+          exit 69
+        fi
+      done
+    fi
+    exec ${pkgs.git}/bin/git "$@"
+    EOF
+
+    cat > "$tool_root/curl" <<'EOF'
+    #!${pkgs.runtimeShell}
+    if [ "''${FAKE_CURL_FAIL:-0}" = 1 ]; then
+      exit 69
+    fi
+    output=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = --output ]; then
+        output="$2"
+        shift 2
+      else
+        shift
+      fi
+    done
+    [ -n "$output" ] || exit 64
+    printf 'verified fixture archive\n' > "$output"
+    EOF
+
+    cat > "$tool_root/sha256sum" <<'EOF'
+    #!${pkgs.runtimeShell}
+    case "$1" in
+      */nix.tar.xz)
+        if [ "''${FAKE_BAD_SHA:-0}" = 1 ]; then
+          printf '%064d  %s\n' 0 "$1"
+        else
+          printf '%s  %s\n' "$EXPECTED_NIX_SHA" "$1"
+        fi
+        ;;
+      *) exec "$REAL_SHA256SUM" "$1" ;;
+    esac
+    EOF
+
+    cat > "$tool_root/shasum" <<'EOF'
+    #!${pkgs.runtimeShell}
+    if [ "$1" = -a ]; then
+      shift 2
+    fi
+    exec "$FAKE_SHA256SUM" "$@"
+    EOF
+
+    cat > "$fake_installer_template" <<'EOF'
+    #!${pkgs.runtimeShell}
+    set -eu
+    : > "$FAKE_INSTALL_EXECUTED"
+    if [ "''${FAKE_INSTALLER_FAIL_AFTER_START:-0}" = 1 ]; then
+      exit 71
+    fi
+    mkdir -p "$HOME/.nix-profile/bin" "$HOME/.nix-profile/etc/profile.d"
+    cp "$FAKE_NIX_TEMPLATE" "$HOME/.nix-profile/bin/nix"
+    chmod +x "$HOME/.nix-profile/bin/nix"
+    printf '%s\n' 'export PATH="$HOME/.nix-profile/bin:$PATH"' \
+      > "$HOME/.nix-profile/etc/profile.d/nix.sh"
+    EOF
+
+    cat > "$tool_root/tar" <<'EOF'
+    #!${pkgs.runtimeShell}
+    set -eu
+    destination=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = -C ]; then
+        destination="$2"
+        shift 2
+      else
+        shift
+      fi
+    done
+    [ -n "$destination" ] || exit 64
+    extracted="$destination/nix-2.34.7-$FAKE_SYSTEM"
+    mkdir -p "$extracted"
+    cp "$FAKE_INSTALLER_TEMPLATE" "$extracted/install"
+    chmod +x "$extracted/install"
+    EOF
+
+    cat > "$fake_nix_template" <<'EOF'
+    #!${pkgs.runtimeShell}
+    set -eu
+    printf '%s\n' "$*" >> "$FAKE_LOG"
+    case " $* " in
+      *" -- apply "*)
+        case " $* " in
+          *" --plan "*) exit 0 ;;
+        esac
+        if [ "''${FAKE_ACTIVATION_FAIL:-0}" = 1 ]; then
+          exit 70
+        fi
+        want_config=0
+        config=""
+        for argument in "$@"; do
+          if [ "$want_config" = 1 ]; then
+            config="$argument"
+            break
+          fi
+          if [ "$argument" = apply ]; then
+            want_config=1
+          fi
+        done
+        [ -n "$config" ] || exit 64
+        mkdir -p "$XDG_STATE_HOME/atyrode"
+        printf '%s\n' "$config" > "$XDG_STATE_HOME/atyrode/dotfiles-config"
+        rm -f "$HOME/.zshrc" "$HOME/.zshenv"
+        ln -s /nix/store/fixture-home-manager-files/.zshrc "$HOME/.zshrc"
+        ln -s /nix/store/fixture-home-manager-files/.zshenv "$HOME/.zshenv"
+        ;;
+      *" -- doctor host "*)
+        [ "''${FAKE_VERIFY_FAIL:-0}" != 1 ]
+        ;;
+      *) exit 64 ;;
+    esac
+    EOF
+
+    chmod +x \
+      "$tool_root/git" \
+      "$tool_root/curl" \
+      "$tool_root/sha256sum" \
+      "$tool_root/shasum" \
+      "$tool_root/tar" \
+      "$fake_installer_template" \
+      "$fake_nix_template"
+    for tool in git curl sha256sum shasum tar; do
+      ln -s "$tool_root/$tool" "$fresh_tools/$tool"
+      ln -s "$tool_root/$tool" "$managed_tools/$tool"
+    done
+    ln -s "$fake_nix_template" "$managed_tools/nix"
+
+    new_fixture() {
+      fixture_name="$1"
+      export HOME="$TMPDIR/$fixture_name/home"
+      export XDG_STATE_HOME="$HOME/.local/state"
+      export BOOTSTRAP_NIX_PROFILE_SCRIPT="$HOME/.nix-profile/etc/profile.d/nix.sh"
+      repo="$TMPDIR/$fixture_name/repo"
+      export FAKE_LOG="$TMPDIR/$fixture_name/nix.log"
+      export FAKE_INSTALL_EXECUTED="$TMPDIR/$fixture_name/installer-executed"
+      export FAKE_NIX_TEMPLATE="$fake_nix_template"
+      export FAKE_INSTALLER_TEMPLATE="$fake_installer_template"
+      export FAKE_SHA256SUM="$tool_root/sha256sum"
+      export REAL_SHA256SUM=${pkgs.coreutils}/bin/sha256sum
+      export FAKE_SYSTEM=${system}
+      export EXPECTED_NIX_SHA=${expectedHash}
+      unset \
+        FAKE_ACTIVATION_FAIL \
+        FAKE_BAD_SHA \
+        FAKE_CURL_FAIL \
+        FAKE_GIT_FETCH_FAIL \
+        FAKE_GIT_UPDATE_REPO \
+        FAKE_INSTALLER_FAIL_AFTER_START \
+        FAKE_VERIFY_FAIL
+      mkdir -p "$HOME" "$repo/scripts"
+      cp "$bootstrap" "$repo/install.sh"
+      cp "$migration" "$repo/scripts/bootstrap-migrate.sh"
+      chmod +x "$repo/install.sh" "$repo/scripts/bootstrap-migrate.sh"
+      patchShebangs "$repo/install.sh" "$repo/scripts/bootstrap-migrate.sh"
+      printf '{ outputs = _: {}; }\n' > "$repo/flake.nix"
+      "$real_git" -C "$repo" init -q -b main
+      "$real_git" -C "$repo" config user.name fixture
+      "$real_git" -C "$repo" config user.email fixture@example.invalid
+      "$real_git" -C "$repo" remote add origin https://github.com/atyrode/dotfiles.git
+      "$real_git" -C "$repo" add flake.nix install.sh scripts/bootstrap-migrate.sh
+      "$real_git" -C "$repo" commit -q -m fixture
+      "$real_git" -C "$repo" update-ref refs/remotes/origin/main HEAD
+    }
+
+    expect_failure() {
+      if "$@" > "$TMPDIR/unexpected-success.out" 2> "$TMPDIR/expected-failure.err"; then
+        echo "command unexpectedly succeeded: $*" >&2
+        exit 1
+      fi
+    }
+
+    make_unmanaged_entrypoints() {
+      printf 'zshrc fixture\n' > "$TMPDIR/$fixture_name-zshrc"
+      printf 'zshenv fixture\n' > "$TMPDIR/$fixture_name-zshenv"
+      ln -s "$TMPDIR/$fixture_name-zshrc" "$HOME/.zshrc"
+      ln -s "$TMPDIR/$fixture_name-zshenv" "$HOME/.zshenv"
+    }
+
+    # A clean plan is read-only and never invokes Nix, downloads, or creates receipts.
+    new_fixture plan
+    export PATH="$managed_tools:$base_path"
+    "$repo/install.sh" plan --repo "$repo" --config "$host" > "$TMPDIR/plan.out"
+    grep -q '^Preflight passed' "$TMPDIR/plan.out"
+    grep -q '^Plan' "$TMPDIR/plan.out"
+    test ! -e "$FAKE_LOG"
+    test ! -e "$XDG_STATE_HOME"
+
+    # Repository identity, every class of dirt, and revision state are conservative.
+    "$real_git" -C "$repo" remote set-url origin https://example.invalid/not-dotfiles.git
+    expect_failure "$repo/install.sh" preflight --repo "$repo" --config "$host"
+    "$real_git" -C "$repo" remote set-url origin https://github.com/atyrode/dotfiles.git
+    "$real_git" -C "$repo" config url.file:///tmp/untrusted/.insteadOf https://github.com/
+    expect_failure "$repo/install.sh" preflight --repo "$repo" --config "$host"
+    "$real_git" -C "$repo" config --unset-all url.file:///tmp/untrusted/.insteadOf
+    printf 'untracked\n' > "$repo/untracked"
+    expect_failure "$repo/install.sh" plan --repo "$repo" --config "$host"
+    "$repo/install.sh" plan --repo "$repo" --config "$host" --allow-dirty >/dev/null
+    rm "$repo/untracked"
+    printf 'changed\n' >> "$repo/flake.nix"
+    "$real_git" -C "$repo" add flake.nix
+    expect_failure "$repo/install.sh" plan --repo "$repo" --config "$host"
+    "$real_git" -C "$repo" reset -q --hard HEAD
+    printf 'local revision\n' > "$repo/local-revision"
+    "$real_git" -C "$repo" add local-revision
+    "$real_git" -C "$repo" commit -q -m local-revision
+    expect_failure "$repo/install.sh" plan --repo "$repo" --config "$host"
+    "$repo/install.sh" plan --repo "$repo" --config "$host" --allow-non-main >/dev/null
+    "$real_git" -C "$repo" reset -q --hard origin/main
+    "$real_git" -C "$repo" switch -q -c fixture
+    expect_failure "$repo/install.sh" plan --repo "$repo" --config "$host"
+    "$repo/install.sh" plan --repo "$repo" --config "$host" --allow-non-main >/dev/null
+    "$real_git" -C "$repo" switch -q main
+    "$real_git" -C "$repo" checkout -q --detach
+    expect_failure "$repo/install.sh" plan --repo "$repo" --config "$host"
+    "$repo/install.sh" plan --repo "$repo" --config "$host" --allow-non-main >/dev/null
+
+    # A failed source update is journaled and never reaches activation.
+    new_fixture network-failure
+    export PATH="$managed_tools:$base_path"
+    export FAKE_GIT_FETCH_FAIL=1
+    expect_failure "$repo/install.sh" apply --yes --update --repo "$repo" --config "$host"
+    test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+    test ! -e "$FAKE_LOG"
+    test ! -e "$XDG_STATE_HOME"
+
+    # A successful update re-enters the fetched bootstrap and receipts the new revision.
+    new_fixture update-success
+    export PATH="$managed_tools:$base_path"
+    upstream="$TMPDIR/update-success/upstream"
+    "$real_git" clone -q "$repo" "$upstream"
+    "$real_git" -C "$upstream" config user.name fixture
+    "$real_git" -C "$upstream" config user.email fixture@example.invalid
+    printf 'updated\n' > "$upstream/update-marker"
+    "$real_git" -C "$upstream" add update-marker
+    "$real_git" -C "$upstream" commit -q -m update
+    updated_revision="$("$real_git" -C "$upstream" rev-parse HEAD)"
+    export FAKE_GIT_UPDATE_REPO="$upstream"
+    "$repo/install.sh" apply --yes --update --repo "$repo" --config "$host" >/dev/null
+    test "$("$real_git" -C "$repo" rev-parse HEAD)" = "$updated_revision"
+    grep -R -F $'revision\t'"$updated_revision" \
+      "$XDG_STATE_HOME/atyrode/bootstrap/transactions" >/dev/null
+
+    # Download and integrity failures cannot execute the unverified installer.
+    new_fixture download-failure
+    export PATH="$fresh_tools:$base_path"
+    export FAKE_CURL_FAIL=1
+    expect_failure "$repo/install.sh" apply --yes --repo "$repo" --config "$host"
+    test ! -e "$FAKE_INSTALL_EXECUTED"
+    test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+
+    new_fixture checksum-failure
+    export PATH="$fresh_tools:$base_path"
+    export FAKE_BAD_SHA=1
+    expect_failure "$repo/install.sh" apply --yes --repo "$repo" --config "$host"
+    test ! -e "$FAKE_INSTALL_EXECUTED"
+    test ! -e "$HOME/.nix-profile/bin/nix"
+
+    new_fixture partial-installer-failure
+    export PATH="$fresh_tools:$base_path"
+    export FAKE_INSTALLER_FAIL_AFTER_START=1
+    expect_failure "$repo/install.sh" apply --yes --repo "$repo" --config "$host"
+    test -e "$FAKE_INSTALL_EXECUTED"
+    test ! -e "$HOME/.nix-profile/bin/nix"
+    test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+    find "$XDG_STATE_HOME/atyrode/bootstrap/transactions" -name '*.failed' | grep -q .
+
+    # Fresh installation verifies the artifact, migrates shell links, activates,
+    # verifies, and remains idempotent on a repeated upgrade-style invocation.
+    new_fixture fresh-success
+    export PATH="$fresh_tools:$base_path"
+    make_unmanaged_entrypoints
+    old_zshrc="$(readlink "$HOME/.zshrc")"
+    old_zshenv="$(readlink "$HOME/.zshenv")"
+    "$repo/install.sh" apply --yes --repo "$repo" --config "$host" > "$TMPDIR/fresh.out"
+    test -e "$FAKE_INSTALL_EXECUTED"
+    test "$(cat "$XDG_STATE_HOME/atyrode/dotfiles-config")" = "$host"
+    test "$(readlink "$HOME/.zshrc")" = /nix/store/fixture-home-manager-files/.zshrc
+    test "$(readlink "$HOME/.zshenv")" = /nix/store/fixture-home-manager-files/.zshenv
+    complete_migration="$XDG_STATE_HOME/atyrode/bootstrap/migrations/migration-v1-shell-entrypoints.complete"
+    test -d "$complete_migration"
+    test "$(readlink "$complete_migration/backup/zshrc")" = "$old_zshrc"
+    test "$(readlink "$complete_migration/backup/zshenv")" = "$old_zshenv"
+    "$repo/install.sh" verify --repo "$repo" --config "$host" >/dev/null
+    "$repo/install.sh" apply --yes --repo "$repo" --config "$host" >/dev/null
+    test "$(readlink "$complete_migration/backup/zshrc")" = "$old_zshrc"
+    find "$XDG_STATE_HOME/atyrode/bootstrap/transactions" -name '*.complete' | grep -q .
+    if find "$XDG_STATE_HOME/atyrode/bootstrap" -name receipt.tsv \
+      -exec grep -F "$HOME" {} + | grep -q .; then
+      echo 'receipt exposed an absolute home path' >&2
+      exit 1
+    fi
+    if find "$XDG_STATE_HOME/atyrode/bootstrap" -name receipt.tsv \
+      -exec grep -Ei 'token|password|credential|github\.com' {} + | grep -q .; then
+      echo 'receipt exposed credential-shaped or remote data' >&2
+      exit 1
+    fi
+
+    # Failed activation restores exact pre-activation links and prior host state.
+    new_fixture activation-failure
+    export PATH="$managed_tools:$base_path"
+    make_unmanaged_entrypoints
+    mkdir -p "$XDG_STATE_HOME/atyrode"
+    printf 'sentinel\n' > "$XDG_STATE_HOME/atyrode/dotfiles-config"
+    old_zshrc="$(readlink "$HOME/.zshrc")"
+    old_zshenv="$(readlink "$HOME/.zshenv")"
+    export FAKE_ACTIVATION_FAIL=1
+    expect_failure "$repo/install.sh" apply --yes --repo "$repo" --config "$host"
+    test "$(readlink "$HOME/.zshrc")" = "$old_zshrc"
+    test "$(readlink "$HOME/.zshenv")" = "$old_zshenv"
+    test "$(cat "$XDG_STATE_HOME/atyrode/dotfiles-config")" = sentinel
+    test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+    test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/migrations/migration-v1-shell-entrypoints.pending"
+
+    # A post-activation verification failure also restores migration-owned paths
+    # and the previous active-host receipt instead of being mistaken for success.
+    new_fixture verification-failure
+    export PATH="$managed_tools:$base_path"
+    make_unmanaged_entrypoints
+    mkdir -p "$XDG_STATE_HOME/atyrode"
+    printf 'sentinel\n' > "$XDG_STATE_HOME/atyrode/dotfiles-config"
+    old_zshrc="$(readlink "$HOME/.zshrc")"
+    old_zshenv="$(readlink "$HOME/.zshenv")"
+    export FAKE_VERIFY_FAIL=1
+    expect_failure "$repo/install.sh" apply --yes --repo "$repo" --config "$host"
+    test "$(readlink "$HOME/.zshrc")" = "$old_zshrc"
+    test "$(readlink "$HOME/.zshenv")" = "$old_zshenv"
+    test "$(cat "$XDG_STATE_HOME/atyrode/dotfiles-config")" = sentinel
+    test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+
+    # The pending marker is published atomically only after its recovery payload,
+    # receipt, and prior-state snapshot are complete.
+    new_fixture transaction-publish-interruption
+    export PATH="$managed_tools:$base_path"
+    if BOOTSTRAP_FAILPOINT=before-transaction-publish \
+      "$repo/install.sh" apply --yes --repo "$repo" --config "$host" >/dev/null 2>&1; then
+      echo 'transaction publication failpoint unexpectedly succeeded' >&2
+      exit 1
+    fi
+    test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+    test -z "$(find "$XDG_STATE_HOME/atyrode/bootstrap/transactions" -mindepth 1 -print -quit)"
+    "$repo/install.sh" apply --yes --repo "$repo" --config "$host" >/dev/null
+    find "$XDG_STATE_HOME/atyrode/bootstrap/transactions" -name '*.abandoned' | grep -q .
+
+    # State and transaction namespaces may not redirect writes through symlinks.
+    new_fixture state-root-link
+    export PATH="$managed_tools:$base_path"
+    mkdir -p "$HOME/redirect" "$XDG_STATE_HOME/atyrode"
+    ln -s "$HOME/redirect" "$XDG_STATE_HOME/atyrode/bootstrap"
+    expect_failure "$repo/install.sh" apply --yes --repo "$repo" --config "$host"
+    test -z "$(find "$HOME/redirect" -mindepth 1 -print -quit)"
+
+    new_fixture atyrode-state-link
+    export PATH="$managed_tools:$base_path"
+    mkdir -p "$HOME/redirect" "$XDG_STATE_HOME"
+    ln -s "$HOME/redirect" "$XDG_STATE_HOME/atyrode"
+    expect_failure "$repo/install.sh" apply --yes --repo "$repo" --config "$host"
+    test -z "$(find "$HOME/redirect" -mindepth 1 -print -quit)"
+
+    new_fixture transactions-link
+    export PATH="$managed_tools:$base_path"
+    mkdir -p "$HOME/redirect" "$XDG_STATE_HOME/atyrode/bootstrap"
+    ln -s "$HOME/redirect" "$XDG_STATE_HOME/atyrode/bootstrap/transactions"
+    expect_failure "$repo/install.sh" apply --yes --repo "$repo" --config "$host"
+    test -z "$(find "$HOME/redirect" -mindepth 1 -print -quit)"
+
+    new_fixture pending-link
+    export PATH="$managed_tools:$base_path"
+    mkdir -p "$HOME/redirect" "$XDG_STATE_HOME/atyrode/bootstrap"
+    ln -s "$HOME/redirect" "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+    expect_failure "$repo/install.sh" rollback --yes --repo "$repo"
+
+    # An abrupt interruption is recoverable through the explicit rollback phase.
+    new_fixture interrupted
+    export PATH="$managed_tools:$base_path"
+    make_unmanaged_entrypoints
+    old_zshrc="$(readlink "$HOME/.zshrc")"
+    old_zshenv="$(readlink "$HOME/.zshenv")"
+    if BOOTSTRAP_FAILPOINT=after-migration-prepare \
+      "$repo/install.sh" apply --yes --repo "$repo" --config "$host" >/dev/null 2>&1; then
+      echo 'interruption failpoint unexpectedly succeeded' >&2
+      exit 1
+    fi
+    test -d "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+    test ! -e "$HOME/.zshrc"
+    test ! -e "$HOME/.zshenv"
+    "$repo/install.sh" rollback --yes --repo "$repo" >/dev/null
+    test "$(readlink "$HOME/.zshrc")" = "$old_zshrc"
+    test "$(readlink "$HOME/.zshenv")" = "$old_zshenv"
+    test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+    "$repo/install.sh" rollback --yes --repo "$repo" >/dev/null
+
+    # Recovery uses the transaction-owned, checksummed script and refuses a
+    # corrupt migration receipt without archiving the pending transaction.
+    new_fixture corrupt-recovery
+    export PATH="$managed_tools:$base_path"
+    make_unmanaged_entrypoints
+    if BOOTSTRAP_FAILPOINT=after-migration-prepare \
+      "$repo/install.sh" apply --yes --repo "$repo" --config "$host" >/dev/null 2>&1; then
+      echo 'corrupt-recovery setup unexpectedly succeeded' >&2
+      exit 1
+    fi
+    printf 'move\t../escape\tsymlink\n' >> \
+      "$XDG_STATE_HOME/atyrode/bootstrap/migrations/migration-v1-shell-entrypoints.pending/receipt.tsv"
+    expect_failure "$repo/install.sh" rollback --yes --repo "$repo"
+    test -d "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+    test -d "$XDG_STATE_HOME/atyrode/bootstrap/migrations/migration-v1-shell-entrypoints.pending"
+
+    new_fixture tampered-recovery
+    export PATH="$managed_tools:$base_path"
+    make_unmanaged_entrypoints
+    if BOOTSTRAP_FAILPOINT=after-migration-prepare \
+      "$repo/install.sh" apply --yes --repo "$repo" --config "$host" >/dev/null 2>&1; then
+      echo 'tampered-recovery setup unexpectedly succeeded' >&2
+      exit 1
+    fi
+    printf '\n# tampered\n' >> \
+      "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending/recovery/bootstrap-migrate.sh"
+    expect_failure "$repo/install.sh" rollback --yes --repo "$repo"
+    test -d "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+    test -d "$XDG_STATE_HOME/atyrode/bootstrap/migrations/migration-v1-shell-entrypoints.pending"
+
+    # Migration preparation resumes after an interruption. Rollback validates all
+    # destinations first, so a collision cannot cause a partial restore.
+    export HOME="$TMPDIR/migration/home"
+    export XDG_STATE_HOME="$HOME/.local/state"
+    mkdir -p "$HOME"
+    fixture_name=migration
+    make_unmanaged_entrypoints
+    old_zshrc="$(readlink "$HOME/.zshrc")"
+    old_zshenv="$(readlink "$HOME/.zshenv")"
+    if BOOTSTRAP_MIGRATION_FAILPOINT=after-zshrc bash "$migration" prepare >/dev/null 2>&1; then
+      echo 'migration interruption failpoint unexpectedly succeeded' >&2
+      exit 1
+    fi
+    test ! -e "$HOME/.zshrc"
+    test -L "$HOME/.zshenv"
+    bash "$migration" prepare >/dev/null
+    ln -s /nix/store/fixture-home-manager-files/.zshrc "$HOME/.zshrc"
+    ln -s /nix/store/fixture-home-manager-files/.zshenv "$HOME/.zshenv"
+    bash "$migration" commit >/dev/null
+    rm "$HOME/.zshrc"
+    printf 'replacement\n' > "$HOME/.zshrc"
+    expect_failure bash "$migration" rollback
+    test -L "$HOME/.zshenv"
+    test -L "$XDG_STATE_HOME/atyrode/bootstrap/migrations/migration-v1-shell-entrypoints.complete/backup/zshenv"
+    rm "$HOME/.zshrc"
+    bash "$migration" rollback >/dev/null
+    test "$(readlink "$HOME/.zshrc")" = "$old_zshrc"
+    test "$(readlink "$HOME/.zshenv")" = "$old_zshenv"
+
+    export HOME="$TMPDIR/dual-migration/home"
+    export XDG_STATE_HOME="$HOME/.local/state"
+    mkdir -p "$HOME"
+    printf 'dual\n' > "$TMPDIR/dual-target"
+    ln -s "$TMPDIR/dual-target" "$HOME/.zshrc"
+    bash "$migration" prepare >/dev/null
+    ln -s /nix/store/fixture-home-manager-files/.zshrc "$HOME/.zshrc"
+    bash "$migration" commit >/dev/null
+    migration_root="$XDG_STATE_HOME/atyrode/bootstrap/migrations"
+    cp -R "$migration_root/migration-v1-shell-entrypoints.complete" \
+      "$migration_root/migration-v1-shell-entrypoints.pending"
+    expect_failure bash "$migration" status
+
+    export HOME="$TMPDIR/missing-backup/home"
+    export XDG_STATE_HOME="$HOME/.local/state"
+    mkdir -p "$HOME"
+    printf 'missing\n' > "$TMPDIR/missing-target"
+    ln -s "$TMPDIR/missing-target" "$HOME/.zshrc"
+    bash "$migration" prepare >/dev/null
+    ln -s /nix/store/fixture-home-manager-files/.zshrc "$HOME/.zshrc"
+    bash "$migration" commit >/dev/null
+    rm "$XDG_STATE_HOME/atyrode/bootstrap/migrations/migration-v1-shell-entrypoints.complete/backup/zshrc"
+    expect_failure bash "$migration" status
+
+    export HOME="$TMPDIR/missing-pending-backup/home"
+    export XDG_STATE_HOME="$HOME/.local/state"
+    mkdir -p "$HOME"
+    printf 'pending missing\n' > "$TMPDIR/pending-missing-target"
+    ln -s "$TMPDIR/pending-missing-target" "$HOME/.zshrc"
+    bash "$migration" prepare >/dev/null
+    ln -s /nix/store/fixture-home-manager-files/.zshrc "$HOME/.zshrc"
+    pending_migration="$XDG_STATE_HOME/atyrode/bootstrap/migrations/migration-v1-shell-entrypoints.pending"
+    rm "$pending_migration/backup/zshrc"
+    expect_failure bash "$migration" rollback
+    test -d "$pending_migration"
+    test "$(readlink "$HOME/.zshrc")" = /nix/store/fixture-home-manager-files/.zshrc
+
+    export HOME="$TMPDIR/terminal-link/home"
+    export XDG_STATE_HOME="$HOME/.local/state"
+    terminal_root="$XDG_STATE_HOME/atyrode/bootstrap/migrations"
+    mkdir -p "$terminal_root"
+    ln -s "$HOME/missing" "$terminal_root/migration-v1-shell-entrypoints.pending"
+    expect_failure bash "$migration" status
+
+    export HOME="$TMPDIR/terminal-file/home"
+    export XDG_STATE_HOME="$HOME/.local/state"
+    terminal_root="$XDG_STATE_HOME/atyrode/bootstrap/migrations"
+    mkdir -p "$terminal_root"
+    printf 'invalid\n' > "$terminal_root/migration-v1-shell-entrypoints.complete"
+    expect_failure bash "$migration" rollback
+
+    export HOME="$TMPDIR/regular-entrypoint/home"
+    export XDG_STATE_HOME="$HOME/.local/state"
+    mkdir -p "$HOME"
+    printf 'regular shell entrypoint\n' > "$HOME/.zshrc"
+    bash "$migration" prepare >/dev/null
+    test ! -e "$HOME/.zshrc"
+    test "$(cat "$XDG_STATE_HOME/atyrode/bootstrap/migrations/migration-v1-shell-entrypoints.pending/backup/zshrc")" = \
+      'regular shell entrypoint'
+    ln -s /nix/store/fixture-home-manager-files/.zshrc "$HOME/.zshrc"
+    bash "$migration" commit >/dev/null
+    bash "$migration" rollback >/dev/null
+    test -f "$HOME/.zshrc"
+    test "$(cat "$HOME/.zshrc")" = 'regular shell entrypoint'
+
+    mkdir "$out"
+  ''

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,0 +1,156 @@
+# Bootstrap and migrations
+
+The bootstrap is the only supported path from an unmanaged machine to a
+registered dotfiles host. It is conservative because it runs before the
+managed environment is known to work.
+
+## Fresh-machine command
+
+Choose the host from [`hosts/default.nix`](../hosts/default.nix), then run this
+single command. This example selects the ordinary x86_64 Linux profile:
+
+```sh
+git clone https://github.com/atyrode/dotfiles.git "$HOME/nix-dotfiles" && "$HOME/nix-dotfiles/install.sh" apply --config alex-x86_64-linux
+```
+
+Substitute the exact registered host for a Mac, desktop Linux machine, or VPS.
+Bootstrap never infers a profile from architecture alone: x86_64 Linux could be
+the base development machine, the desktop profile, or the server profile.
+
+The unmanaged prerequisites are Git, Bash, `curl`, `tar`, and either
+`sha256sum` or `shasum`. The command clones inspectable code before executing
+it; there is no supported `curl | shell` path.
+
+## Phases and source policy
+
+The phases are independently callable:
+
+```sh
+./install.sh preflight --config alex-x86_64-linux
+./install.sh plan --config alex-x86_64-linux
+./install.sh apply --config alex-x86_64-linux
+./install.sh verify --config alex-x86_64-linux
+./install.sh rollback --yes
+```
+
+`preflight` verifies the platform, explicit host selection, repository root,
+raw and Git-resolved origin, branch/revision relationship to cached
+`origin/main`, required tools, and the absence of an interrupted transaction.
+It rejects staged, tracked, and untracked changes. `plan` adds the ordered Nix,
+migration, activation, and verification actions without creating state,
+downloading an artifact, fetching Git, or moving a file.
+
+`apply` repeats both phases and asks for confirmation. Once Nix is available it
+uses the packaged `atyrode apply` plan and activation, so the host registry and
+the `nh` backend remain the only activation contract. Flakes are enabled only
+through the process-scoped `NIX_CONFIG`; bootstrap does not append to a
+user-owned `nix.conf`.
+
+Use `--update` to explicitly fetch the verified origin and fast-forward main.
+If source changes, bootstrap re-enters the fetched `install.sh` before opening
+a transaction. It never pulls implicitly. `--allow-dirty` and
+`--allow-non-main` are review acknowledgements for intentional local work;
+`--update` cannot be combined with a dirty checkout. A Git `url.*.insteadOf`
+rewrite cannot redirect the accepted GitHub origin unnoticed.
+
+## Nix installer decision
+
+Fresh machines install upstream Nix 2.34.7 from the official
+`releases.nixos.org` archive. The four archive SHA-256 values are embedded in
+`install.sh` for x86_64/aarch64 Linux and Darwin. Bootstrap downloads into a
+private temporary directory, verifies the complete archive before extraction,
+checks the expected installer path, and only then runs the upstream multi-user
+installer. Existing Nix installations are reused.
+
+This choice was reviewed on 2026-07-10:
+
+- [Upstream Nix](https://nix.dev/manual/nix/latest/) keeps the existing runtime,
+  supports all four repository targets (including the Intel Mac while it
+  remains registered), and provides official versioned release archives. Its
+  multi-user uninstall is manual and OS-specific rather than receipt-driven.
+- The [Lix installer](https://git.lix.systems/lix-project/lix-installer) has
+  strong plan, receipt, recovery, and uninstall behavior without diagnostic
+  telemetry, but selecting it also changes the Nix implementation and its
+  current Intel-Mac path is legacy. That product/retirement decision is outside
+  bootstrap hardening.
+- The [Determinate installer](https://github.com/DeterminateSystems/nix-installer)
+  has strong planning and receipt-based uninstall, but now defaults to
+  Determinate Nix, its upstream-Nix compatibility flag was documented only
+  through 2026-01-01, current releases do not cover Intel Darwin, and
+  diagnostics are enabled unless configured otherwise.
+
+The bootstrap transaction records the selected upstream version, platform
+hash, source disposition, and repository revision. A partial upstream
+installer failure remains visible as a failed bootstrap receipt. Bootstrap
+does not automatically remove a system-wide Nix install: that could destroy a
+pre-existing or concurrently repaired store. To uninstall a bootstrap-created
+Nix, first preserve the failed receipt, confirm that Nix was not present before
+the run, and follow the official
+[multi-user uninstall procedure](https://nix.dev/manual/nix/2.22/installation/uninstall)
+for the current OS. That procedure is destructive and intentionally remains an
+operator action.
+
+## Transactions, receipts, and recovery
+
+Bootstrap state lives under:
+
+```text
+${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/bootstrap/
+├── apply.pending/
+├── migrations/
+│   └── migration-v1-shell-entrypoints.{pending,complete,rolled-back}
+└── transactions/
+    └── apply-v1-<timestamp>-<process>.{complete,failed,rolled-back}
+```
+
+`apply.pending` is constructed privately and published by one rename only
+after its receipt, prior host-state snapshot, and checksummed recovery copies
+are complete. An interrupted pre-publication directory is preserved as an
+`*.abandoned` transaction on the next apply; it is never interpreted as a
+successful or recoverable apply. Completed receipts contain schema/version
+identifiers, hashes, relative logical actions, phases, host, system, revision,
+and outcome. They do not contain repository/home absolute paths, remote URLs,
+environment dumps, or credentials.
+
+The versioned shell-entrypoint migration applies only to unmanaged `.zshrc`
+and `.zshenv` files or symlinks. It writes a relative-path manifest before the
+first move, resumes safely after interruption, and commits only after Home
+Manager links both applicable paths. It never executes an unmanaged file to
+infer ownership. Actual backups may naturally contain private shell content;
+their parent directories are mode `0700` and must be protected like any other
+local backup.
+
+An activation or verification failure invokes the transaction-owned recovery
+copy, verifies its SHA-256, restores every migration-owned entrypoint only when
+there is no user-created collision, restores the previous active-host state,
+and archives the journal as failed. If the process is killed after the pending
+marker is published, run:
+
+```sh
+./install.sh rollback --yes
+```
+
+Rollback refuses ambiguous dual receipts, corrupted manifests, missing or
+changed backups, symlinked state namespaces, and newly-created destination
+data. On refusal, preserve both the pending transaction and live paths; do not
+delete either copy. If the checkout is unavailable, run the transaction-owned
+copy directly:
+
+```sh
+bash "${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/bootstrap/apply.pending/recovery/install.sh" rollback --yes
+```
+
+This rollback restores bootstrap-owned filesystem moves and the active-host
+receipt. It does not uninstall Nix or roll back a successfully activated Nix or
+nix-darwin generation. Those are separate, explicit system operations.
+
+## Verification coverage
+
+`checks/bootstrap.nix` uses temporary homes and repositories. It covers a clean
+plan, fresh and repeated application, successful and failed source updates,
+wrong and rewritten origins, dirty/staged/non-main revisions, download and
+checksum failure, partial installer failure, activation and verification
+failure, interruption before and after transaction publication, resumable
+migration, collisions, corrupt and dual receipts, missing backups, symlinked
+state namespaces, rollback, receipt privacy, and idempotence. The same check
+runs natively in all four CI jobs.

--- a/flake.nix
+++ b/flake.nix
@@ -352,6 +352,7 @@
         import ./checks/agent-tools.nix { inherit lib pkgs; }
         // {
           atyrode-cli = import ./checks/atyrode-cli.nix { inherit pkgs; };
+          bootstrap = import ./checks/bootstrap.nix { inherit pkgs; };
           codex-use = import ./checks/codex-use.nix {
             inherit lib pkgs;
             baseConfig = baseOnlyConfig;

--- a/install.sh
+++ b/install.sh
@@ -1,223 +1,772 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
-# Install dotfiles on Linux or macOS.
-# Usage:
-#   ./install.sh
-#   curl -fsSL https://raw.githubusercontent.com/atyrode/dotfiles/main/install.sh | bash
+# The bootstrap intentionally stays compatible with Bash 3.2 and platform
+# tools because it runs before the managed Nix environment exists.
 
-REPO_URL="https://github.com/atyrode/dotfiles.git"
-DEFAULT_DOTFILES_DIR="${HOME}/dotfiles"
+readonly REPO_HTTPS_URL="https://github.com/atyrode/dotfiles.git"
+readonly REPO_SSH_URL="git@github.com:atyrode/dotfiles.git"
+readonly NIX_VERSION="2.34.7"
+readonly BOOTSTRAP_SCHEMA="1"
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+COMMAND="${1:-}"
+if [[ -n "$COMMAND" ]]; then
+  shift
+fi
+
+DOTFILES_DIR="${DOTFILES_DIR:-$SCRIPT_DIR}"
+FLAKE_CONFIG="${FLAKE_CONFIG:-}"
+ALLOW_DIRTY=0
+ALLOW_NON_MAIN=0
+UPDATE_SOURCE=0
+ASSUME_YES=0
+SYSTEM=""
+NIX_URL=""
+NIX_SHA256=""
+TRANSACTION=""
+SOURCE_CHANGED=0
+ACTIVE_PHASE="bootstrap"
+
+die() {
+  printf 'bootstrap: %s\n' "$*" >&2
+  return 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./install.sh preflight [OPTIONS]
+  ./install.sh plan [OPTIONS]
+  ./install.sh apply [OPTIONS]
+  ./install.sh verify [OPTIONS]
+  ./install.sh rollback --yes [OPTIONS]
+
+Options:
+  --repo PATH          Use this existing checkout (default: script checkout).
+  --config HOST        Select a registered host explicitly.
+  --update             Fetch origin and fast-forward main before activation.
+  --allow-dirty        Intentionally use a checkout with local changes.
+  --allow-non-main     Intentionally use a branch or detached revision other than main.
+  --yes                Confirm apply or rollback without an interactive prompt.
+  -h, --help           Show this help.
+
+No command defaults to mutation. Run `plan`, inspect it, then run `apply`.
+EOF
+}
+
+parse_options() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo)
+        [[ $# -ge 2 ]] || die "--repo requires a path"
+        DOTFILES_DIR="$2"
+        shift 2
+        ;;
+      --config)
+        [[ $# -ge 2 ]] || die "--config requires a registered host"
+        FLAKE_CONFIG="$2"
+        shift 2
+        ;;
+      --update) UPDATE_SOURCE=1; shift ;;
+      --allow-dirty) ALLOW_DIRTY=1; shift ;;
+      --allow-non-main) ALLOW_NON_MAIN=1; shift ;;
+      --yes) ASSUME_YES=1; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "unknown option: $1" ;;
+    esac
+  done
+}
 
 detect_system() {
-    case "$(uname -s):$(uname -m)" in
-        Darwin:arm64) echo "aarch64-darwin" ;;
-        Darwin:x86_64) echo "x86_64-darwin" ;;
-        Linux:arm64|Linux:aarch64) echo "aarch64-linux" ;;
-        Linux:x86_64) echo "x86_64-linux" ;;
-        *)
-            echo "Unsupported system: $(uname -s) $(uname -m)" >&2
-            return 1
-            ;;
-    esac
+  case "$(uname -s):$(uname -m)" in
+    Darwin:arm64) printf 'aarch64-darwin\n' ;;
+    Darwin:x86_64) printf 'x86_64-darwin\n' ;;
+    Linux:arm64|Linux:aarch64) printf 'aarch64-linux\n' ;;
+    Linux:x86_64) printf 'x86_64-linux\n' ;;
+    *) die "unsupported system: $(uname -s) $(uname -m)" ;;
+  esac
+}
+
+select_nix_artifact() {
+  case "$SYSTEM" in
+    aarch64-darwin)
+      NIX_SHA256="1e18301c4ea78c667f2753159156b5bdb899993720e8aa7bcca97e8312d3d6b"
+      ;;
+    x86_64-darwin)
+      NIX_SHA256="bf3dadfd65be182ad3141b1224bbc82e0f2a61d4f36781938b5e6ede029c2a37"
+      ;;
+    aarch64-linux)
+      NIX_SHA256="1cee64ae7a02330c6421924c28f597c41813f2214ff108622087d8056378b088"
+      ;;
+    x86_64-linux)
+      NIX_SHA256="eafe5042404e818505e28c5ca3d0885f3ec45c31f955489a25bb38258f87560ef"
+      ;;
+    *) die "no pinned Nix artifact for $SYSTEM" ;;
+  esac
+  NIX_URL="https://releases.nixos.org/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-${SYSTEM}.tar.xz"
 }
 
 source_nix() {
-    if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
-        # shellcheck disable=SC1091
-        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-    elif [[ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]]; then
-        # shellcheck disable=SC1091
-        . "$HOME/.nix-profile/etc/profile.d/nix.sh"
-    fi
-}
+  local profile=""
 
-source_home_manager_session_vars() {
-    local session_vars="$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
-
-    if [[ ! -f "$session_vars" ]]; then
-        return 0
-    fi
-
-    echo "Loading Home Manager environment..."
+  if [[ "${BOOTSTRAP_NIX_PROFILE_SCRIPT+x}" == x ]]; then
+    profile="${BOOTSTRAP_NIX_PROFILE_SCRIPT:-}"
+  elif [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
+    profile="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+  elif [[ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]]; then
+    profile="$HOME/.nix-profile/etc/profile.d/nix.sh"
+  fi
+  if [[ -n "$profile" && -f "$profile" ]]; then
     set +u
     # shellcheck disable=SC1090
-    . "$session_vars"
+    . "$profile"
     set -u
+  fi
 }
 
-record_active_config() {
-    local state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/atyrode"
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
 
-    mkdir -p "$state_dir"
-    printf '%s\n' "$FLAKE_CONFIG" > "$state_dir/dotfiles-config"
+canonicalize_repo() {
+  [[ -d "$DOTFILES_DIR" ]] || die "repository directory does not exist: $DOTFILES_DIR"
+  DOTFILES_DIR="$(CDPATH='' cd -- "$DOTFILES_DIR" && pwd -P)"
+}
+
+verify_origin() {
+  local origin resolved
+
+  origin="$(git -C "$DOTFILES_DIR" config --get remote.origin.url 2>/dev/null || true)"
+  case "$origin" in
+    "$REPO_HTTPS_URL"|"${REPO_HTTPS_URL%.git}"|"$REPO_SSH_URL"|ssh://git@github.com/atyrode/dotfiles.git)
+      ;;
+    '') die "checkout has no origin remote; expected $REPO_HTTPS_URL" ;;
+    *) die "checkout origin is not atyrode/dotfiles; refusing to fetch or activate it" ;;
+  esac
+  resolved="$(git -C "$DOTFILES_DIR" remote get-url origin 2>/dev/null || true)"
+  case "$resolved" in
+    "$REPO_HTTPS_URL"|"${REPO_HTTPS_URL%.git}"|"$REPO_SSH_URL"|ssh://git@github.com/atyrode/dotfiles.git)
+      ;;
+    *) die "origin resolves through Git configuration to an untrusted URL; remove url.*.insteadOf rewrites" ;;
+  esac
+}
+
+verify_checkout() {
+  local root branch status counts local_ahead remote_ahead
+
+  [[ -f "$DOTFILES_DIR/flake.nix" ]] || die "not a dotfiles flake checkout: $DOTFILES_DIR"
+  [[ -x "$DOTFILES_DIR/scripts/bootstrap-migrate.sh" ]] ||
+    die "bootstrap migration script is missing or not executable"
+  git -C "$DOTFILES_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+    die "repository is not a Git checkout: $DOTFILES_DIR"
+  git -C "$DOTFILES_DIR" ls-files --error-unmatch -- \
+    flake.nix install.sh scripts/bootstrap-migrate.sh >/dev/null 2>&1 ||
+    die "bootstrap entrypoints must be tracked by the verified repository"
+  root="$(git -C "$DOTFILES_DIR" rev-parse --show-toplevel)"
+  root="$(CDPATH='' cd -- "$root" && pwd -P)"
+  [[ "$root" == "$DOTFILES_DIR" ]] || die "--repo must name the checkout root: $root"
+  verify_origin
+
+  if [[ "$UPDATE_SOURCE" -eq 1 && "$ALLOW_DIRTY" -eq 1 ]]; then
+    die "--update cannot be combined with --allow-dirty"
+  fi
+
+  status="$(git -C "$DOTFILES_DIR" status --porcelain --untracked-files=normal)"
+  if [[ -n "$status" && "$ALLOW_DIRTY" -ne 1 ]]; then
+    die "checkout has staged, tracked, or untracked changes; use --allow-dirty only after reviewing them"
+  fi
+
+  branch="$(git -C "$DOTFILES_DIR" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  if [[ "$branch" != main && "$ALLOW_NON_MAIN" -ne 1 ]]; then
+    if [[ -z "$branch" ]]; then
+      die "checkout is detached; use --allow-non-main only for an intentionally reviewed revision"
+    fi
+    die "checkout is on $branch, not main; use --allow-non-main only after reviewing it"
+  fi
+  if [[ "$UPDATE_SOURCE" -eq 1 && "$branch" != main ]]; then
+    die "--update is only supported on main"
+  fi
+  if [[ "$branch" == main ]]; then
+    if git -C "$DOTFILES_DIR" show-ref --verify --quiet refs/remotes/origin/main; then
+      counts="$(git -C "$DOTFILES_DIR" rev-list --left-right --count HEAD...origin/main)"
+      local_ahead="${counts%%[[:space:]]*}"
+      remote_ahead="${counts##*[[:space:]]}"
+      if [[ ( "$local_ahead" != 0 || "$remote_ahead" != 0 ) && "$ALLOW_NON_MAIN" -ne 1 && "$UPDATE_SOURCE" -ne 1 ]]; then
+        die "main differs from cached origin/main; use --update or --allow-non-main for a reviewed revision"
+      fi
+    elif [[ "$UPDATE_SOURCE" -ne 1 && "$ALLOW_NON_MAIN" -ne 1 ]]; then
+      die "origin/main is unavailable; use --update or --allow-non-main for a reviewed revision"
+    fi
+  fi
+}
+
+bootstrap_state_root() {
+  printf '%s\n' "${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/bootstrap"
+}
+
+preflight() {
+  local pending
+
+  command_exists git || die "git is required"
+  command_exists tar || die "tar is required"
+  command_exists mktemp || die "mktemp is required"
+  canonicalize_repo
+  verify_checkout
+
+  SYSTEM="$(detect_system)"
+  select_nix_artifact
+  if [[ -z "$FLAKE_CONFIG" ]]; then
+    die "--config HOST (or FLAKE_CONFIG) is required; bootstrap never guesses a machine profile"
+  fi
+  case "$FLAKE_CONFIG" in
+    *[!A-Za-z0-9@._-]*|'') die "configuration contains unsupported characters" ;;
+  esac
+
+  source_nix
+  if ! command_exists sha256sum && ! command_exists shasum; then
+    die "sha256sum or shasum is required for verified receipts and Nix artifacts"
+  fi
+  if ! command_exists nix; then
+    command_exists curl || die "curl is required to download the pinned Nix artifact"
+  fi
+
+  pending="$(bootstrap_state_root)/apply.pending"
+  if [[ -e "$pending" || -L "$pending" ]]; then
+    die "an interrupted bootstrap transaction exists; run ./install.sh rollback --yes before applying again"
+  fi
+
+  printf 'Preflight passed\n'
+  printf '  system: %s\n' "$SYSTEM"
+  printf '  configuration: %s\n' "$FLAKE_CONFIG"
+  printf '  repository: %s\n' "$DOTFILES_DIR"
+  printf '  revision: %s\n' "$(git -C "$DOTFILES_DIR" rev-parse --short=12 HEAD)"
+}
+
+print_plan() {
+  local step=1
+
+  printf '\nPlan\n'
+  if [[ "$UPDATE_SOURCE" -eq 1 ]]; then
+    printf '  %s. Fetch the verified origin and fast-forward main.\n' "$step"
+    step=$((step + 1))
+  fi
+  if command_exists nix; then
+    printf '  %s. Reuse the installed Nix command; do not reinstall it.\n' "$step"
+  else
+    printf '  %s. Download upstream Nix %s for %s and require SHA-256 %s.\n' \
+      "$step" "$NIX_VERSION" "$SYSTEM" "$NIX_SHA256"
+  fi
+  step=$((step + 1))
+  printf '  %s. Evaluate the registered host through the packaged atyrode CLI.\n' "$step"
+  step=$((step + 1))
+  printf '  %s. Prepare versioned shell-entrypoint migration backups:\n' "$step"
+  "$DOTFILES_DIR/scripts/bootstrap-migrate.sh" plan | sed 's/^/     - /'
+  step=$((step + 1))
+  printf '  %s. Activate %s through atyrode/nh.\n' "$step" "$FLAKE_CONFIG"
+  step=$((step + 1))
+  printf '  %s. Verify host state and complete the migration and bootstrap receipts.\n' "$step"
+  printf '\nNo changes were made. apply will show this plan again before confirmation.\n'
+}
+
+confirm_action() {
+  local prompt="$1"
+  local answer
+
+  if [[ "$ASSUME_YES" -eq 1 ]]; then
+    return
+  fi
+  [[ -t 0 ]] || die "$prompt requires an interactive terminal or --yes"
+  printf '%s [y/N] ' "$prompt" >&2
+  IFS= read -r answer
+  case "$answer" in
+    y|Y|yes|YES) ;;
+    *) die "cancelled" ;;
+  esac
+}
+
+ensure_safe_state_root() {
+  local root="$1"
+  local parent="${root%/*}"
+  local transactions="$root/transactions"
+
+  if [[ -e "$parent" || -L "$parent" ]]; then
+    [[ -d "$parent" && ! -L "$parent" ]] || die "$parent must be a real directory"
+  else
+    mkdir -p "$parent"
+  fi
+  if [[ -e "$root" || -L "$root" ]]; then
+    [[ -d "$root" && ! -L "$root" ]] || die "$root must be a real directory"
+  else
+    mkdir -p "$root"
+  fi
+  if [[ -e "$transactions" || -L "$transactions" ]]; then
+    [[ -d "$transactions" && ! -L "$transactions" ]] ||
+      die "$transactions must be a real directory"
+  else
+    mkdir "$transactions"
+  fi
+  chmod 700 "$root" "$transactions"
+}
+
+append_transaction() {
+  [[ $# -eq 2 ]] || die "internal receipt error"
+  printf '%s\t%s\n' "$1" "$2" >> "$TRANSACTION/receipt.tsv"
+}
+
+archive_abandoned_transactions() {
+  local root="$1"
+  local abandoned name target
+
+  shopt -s nullglob
+  for abandoned in "$root"/.apply.creating.*; do
+    [[ -d "$abandoned" && ! -L "$abandoned" ]] ||
+      die "unsafe abandoned bootstrap transaction: $abandoned"
+    name="${abandoned##*/}"
+    target="$root/transactions/${name#.}.abandoned"
+    if [[ -e "$target" || -L "$target" ]]; then
+      target="$target.$$"
+    fi
+    mv "$abandoned" "$target"
+  done
+  shopt -u nullglob
+}
+
+begin_transaction() {
+  local root pending creating state_file state_status revision migration_sha installer_sha
+
+  root="$(bootstrap_state_root)"
+  state_file="${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/dotfiles-config"
+  if [[ -L "$state_file" ]]; then
+    die "$state_file must not be a symlink"
+  elif [[ -f "$state_file" ]]; then
+    state_status=present
+  elif [[ -e "$state_file" ]]; then
+    die "$state_file has an unsupported type"
+  else
+    state_status=absent
+  fi
+
+  ensure_safe_state_root "$root"
+  archive_abandoned_transactions "$root"
+  pending="$root/apply.pending"
+  [[ ! -e "$pending" && ! -L "$pending" ]] ||
+    die "an interrupted bootstrap transaction already exists"
+  creating="$(mktemp -d "$root/.apply.creating.XXXXXX")"
+  [[ -d "$creating" && ! -L "$creating" ]] || die "could not create a safe transaction"
+  TRANSACTION="$creating"
+  chmod 700 "$TRANSACTION"
+  mkdir "$TRANSACTION/backup" "$TRANSACTION/recovery"
+  chmod 700 "$TRANSACTION/backup" "$TRANSACTION/recovery"
+  cp "$DOTFILES_DIR/scripts/bootstrap-migrate.sh" "$TRANSACTION/recovery/bootstrap-migrate.sh"
+  cp "${BASH_SOURCE[0]}" "$TRANSACTION/recovery/install.sh"
+  chmod 700 "$TRANSACTION/recovery/bootstrap-migrate.sh" "$TRANSACTION/recovery/install.sh"
+  migration_sha="$(sha256_file "$TRANSACTION/recovery/bootstrap-migrate.sh")"
+  installer_sha="$(sha256_file "$TRANSACTION/recovery/install.sh")"
+  revision="$(git -C "$DOTFILES_DIR" rev-parse HEAD)"
+  {
+    printf 'version\t%s\n' "$BOOTSTRAP_SCHEMA"
+    printf 'system\t%s\n' "$SYSTEM"
+    printf 'configuration\t%s\n' "$FLAKE_CONFIG"
+    printf 'revision\t%s\n' "$revision"
+    printf 'nix-version\t%s\n' "$NIX_VERSION"
+    printf 'nix-sha256\t%s\n' "$NIX_SHA256"
+    printf 'migration-sha256\t%s\n' "$migration_sha"
+    printf 'installer-sha256\t%s\n' "$installer_sha"
+    printf 'phase\tstarted\n'
+  } > "$TRANSACTION/receipt.tsv"
+  chmod 600 "$TRANSACTION/receipt.tsv"
+
+  if [[ "$state_status" == present ]]; then
+    cp "$state_file" "$TRANSACTION/backup/dotfiles-config"
+    chmod 600 "$TRANSACTION/backup/dotfiles-config"
+  fi
+  append_transaction state-before "$state_status"
+  if [[ "${BOOTSTRAP_FAILPOINT:-}" == before-transaction-publish ]]; then
+    printf 'bootstrap: interrupted at test failpoint before-transaction-publish\n' >&2
+    exit 75
+  fi
+  mv "$TRANSACTION" "$pending"
+  TRANSACTION="$pending"
+}
+
+transaction_value() {
+  local key="$1"
+  local record value extra found=""
+
+  [[ -f "$TRANSACTION/receipt.tsv" && ! -L "$TRANSACTION/receipt.tsv" ]] ||
+    die "unsafe bootstrap transaction receipt"
+  while IFS=$'\t' read -r record value extra; do
+    if [[ "$record" == "$key" ]]; then
+      [[ -z "${extra:-}" && -z "$found" ]] || die "unsafe bootstrap receipt: duplicate or extra fields"
+      found="$value"
+    fi
+  done < "$TRANSACTION/receipt.tsv"
+  [[ -n "$found" ]] || die "unsafe bootstrap receipt: missing $key"
+  printf '%s\n' "$found"
+}
+
+restore_previous_state() {
+  local status config state_dir state_file backup current="" current_exists=0 temporary
+
+  status="$(transaction_value state-before)"
+  config="$(transaction_value configuration)"
+  state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/atyrode"
+  state_file="$state_dir/dotfiles-config"
+  backup="$TRANSACTION/backup/dotfiles-config"
+  if [[ -f "$state_file" && ! -L "$state_file" ]]; then
+    current_exists=1
+    current="$(cat "$state_file")"
+  elif [[ -e "$state_file" || -L "$state_file" ]]; then
+    die "$state_file changed to an unsafe type; preserve it and recover manually"
+  fi
+
+  case "$status" in
+    present)
+      [[ -f "$backup" && ! -L "$backup" ]] || die "previous host-state backup is missing"
+      if [[ "$current_exists" -eq 1 && "$current" != "$config" ]] && ! cmp -s "$state_file" "$backup"; then
+        die "host state changed after bootstrap began; refusing to overwrite it"
+      fi
+      if [[ -e "$state_dir" || -L "$state_dir" ]]; then
+        [[ -d "$state_dir" && ! -L "$state_dir" ]] || die "$state_dir must be a real directory"
+      else
+        mkdir -p "$state_dir"
+      fi
+      temporary="$(mktemp "$state_dir/.dotfiles-config.restore.XXXXXX")"
+      cp "$backup" "$temporary"
+      chmod 600 "$temporary"
+      mv "$temporary" "$state_file"
+      ;;
+    absent)
+      if [[ "$current_exists" -eq 1 && "$current" != "$config" ]]; then
+        die "host state was created by another process; refusing to remove it"
+      fi
+      if [[ -f "$state_file" && ! -L "$state_file" ]]; then
+        rm "$state_file"
+      fi
+      ;;
+    *) die "unsafe bootstrap receipt: invalid prior state" ;;
+  esac
+}
+
+finish_transaction() {
+  local outcome="$1"
+  local root target stamp
+
+  append_transaction outcome "$outcome"
+  root="$(bootstrap_state_root)"
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  target="$root/transactions/apply-v${BOOTSTRAP_SCHEMA}-${stamp}-$$.$outcome"
+  if [[ -e "$target" || -L "$target" ]]; then
+    target="$target.$$"
+  fi
+  mv "$TRANSACTION" "$target"
+  TRANSACTION=""
+  printf 'Bootstrap receipt: %s\n' "${target#"$root/"}"
+}
+
+migration_owned_by_transaction() {
+  [[ -f "$TRANSACTION/migration-owned" && ! -L "$TRANSACTION/migration-owned" ]]
+}
+
+verify_recovery_script() {
+  local name="$1"
+  local key="$2"
+  local path="$TRANSACTION/recovery/$name"
+  local expected actual
+
+  [[ -f "$path" && ! -L "$path" ]] || die "transaction recovery copy $name is missing or unsafe"
+  expected="$(transaction_value "$key")"
+  actual="$(sha256_file "$path")"
+  [[ "$actual" == "$expected" ]] || die "transaction recovery copy $name failed verification"
+}
+
+migration_command() {
+  verify_recovery_script bootstrap-migrate.sh migration-sha256
+  bash "$TRANSACTION/recovery/bootstrap-migrate.sh" "$@"
+}
+
+rollback_current_transaction() {
+  local migration_status
+
+  if migration_owned_by_transaction; then
+    migration_status="$(migration_command status)"
+    case "$migration_status" in
+      pending|complete) migration_command rollback ;;
+      applicable) ;;
+      *) die "migration recovery returned an unknown state" ;;
+    esac
+  fi
+  restore_previous_state
+}
+
+fail_transaction() {
+  local reason="$1"
+  local recovery="$TRANSACTION/recovery/install.sh"
+
+  trap - ERR INT TERM
+  printf 'bootstrap: apply failed during %s\n' "$reason" >&2
+  if [[ -n "$TRANSACTION" && -d "$TRANSACTION" ]]; then
+    if BOOTSTRAP_RECOVERY_OUTCOME=failed BOOTSTRAP_FAILURE_REASON="$reason" \
+      bash "$recovery" rollback --yes; then
+      printf 'Original shell entrypoints and host-state receipt were restored.\n' >&2
+    else
+      printf 'Automatic recovery was incomplete. Preserve %s and run:\n' "$TRANSACTION" >&2
+      printf '  bash %s rollback --yes\n' "$recovery" >&2
+    fi
+  fi
+  printf 'Nix generations are not changed automatically during bootstrap recovery.\n' >&2
+  exit 1
+}
+
+on_apply_error() {
+  local status="$1"
+
+  if [[ "${BASH_SUBSHELL:-0}" -gt 0 ]]; then
+    return "$status"
+  fi
+  fail_transaction "$ACTIVE_PHASE (exit $status)"
+}
+
+update_checkout() {
+  local counts local_ahead remote_ahead
+
+  git -C "$DOTFILES_DIR" fetch --prune origin || return 1
+  git -C "$DOTFILES_DIR" show-ref --verify --quiet refs/remotes/origin/main || return 1
+  counts="$(git -C "$DOTFILES_DIR" rev-list --left-right --count HEAD...origin/main)" || return 1
+  local_ahead="${counts%%[[:space:]]*}"
+  remote_ahead="${counts##*[[:space:]]}"
+  [[ "$local_ahead" == 0 ]] || {
+    printf 'bootstrap: local main has commits not on origin/main; refusing to update\n' >&2
+    return 1
+  }
+  if [[ "$remote_ahead" != 0 ]]; then
+    git -C "$DOTFILES_DIR" merge --ff-only origin/main || return 1
+    SOURCE_CHANGED=1
+  fi
+}
+
+restart_after_source_update() {
+  local args=(apply --repo "$DOTFILES_DIR" --config "$FLAKE_CONFIG")
+
+  if [[ "$ASSUME_YES" -eq 1 ]]; then
+    args+=(--yes)
+  fi
+  if [[ "$ALLOW_NON_MAIN" -eq 1 ]]; then
+    args+=(--allow-non-main)
+  fi
+  exec bash "$DOTFILES_DIR/install.sh" "${args[@]}"
+}
+
+sha256_file() {
+  local path="$1"
+
+  if [[ "$SYSTEM" == *-darwin ]] && command_exists shasum; then
+    shasum -a 256 "$path" | sed 's/[[:space:]].*$//'
+  elif command_exists sha256sum; then
+    sha256sum "$path" | sed 's/[[:space:]].*$//'
+  else
+    shasum -a 256 "$path" | sed 's/[[:space:]].*$//'
+  fi
+}
+
+install_pinned_nix() {
+  local temporary archive extracted actual
+
+  temporary="$(mktemp -d "${TMPDIR:-/tmp}/atyrode-nix.XXXXXX")"
+  archive="$temporary/nix.tar.xz"
+  printf 'Downloading pinned upstream Nix %s from releases.nixos.org...\n' "$NIX_VERSION"
+  if ! curl --fail --location --proto '=https' --tlsv1.2 --output "$archive" "$NIX_URL"; then
+    rm -rf "$temporary"
+    return 1
+  fi
+  actual="$(sha256_file "$archive")"
+  if [[ "$actual" != "$NIX_SHA256" ]]; then
+    printf 'bootstrap: Nix artifact checksum mismatch (expected %s, received %s)\n' \
+      "$NIX_SHA256" "$actual" >&2
+    rm -rf "$temporary"
+    return 1
+  fi
+  if ! tar -xf "$archive" -C "$temporary"; then
+    rm -rf "$temporary"
+    return 1
+  fi
+  extracted="$temporary/nix-${NIX_VERSION}-${SYSTEM}/install"
+  if [[ ! -f "$extracted" || -L "$extracted" ]]; then
+    printf 'bootstrap: verified Nix archive does not contain the expected installer\n' >&2
+    rm -rf "$temporary"
+    return 1
+  fi
+  append_transaction nix-source verified-upstream-artifact
+  if ! sh "$extracted" --daemon; then
+    rm -rf "$temporary"
+    return 1
+  fi
+  rm -rf "$temporary"
+  source_nix
+  command_exists nix || return 1
+  append_transaction nix-installed by-bootstrap
 }
 
 ensure_nix() {
-    source_nix
-
-    if command -v nix >/dev/null 2>&1; then
-        return 0
-    fi
-
-    echo "Installing Nix..."
-    sh <(curl -L https://nixos.org/nix/install) --daemon
-    source_nix
-
-    if ! command -v nix >/dev/null 2>&1; then
-        echo "Nix installation finished, but nix is not available in this shell." >&2
-        echo "Open a new terminal, then re-run this script." >&2
-        exit 1
-    fi
+  source_nix
+  if command_exists nix; then
+    append_transaction nix-source existing-installation
+    return
+  fi
+  install_pinned_nix
 }
 
-ensure_flakes() {
-    local nix_config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/nix"
-    local nix_config="$nix_config_dir/nix.conf"
+enable_flakes_for_process() {
+  local feature="extra-experimental-features = nix-command flakes"
 
-    echo "Configuring Nix flakes..."
-    mkdir -p "$nix_config_dir"
-
-    if ! grep -Eq '^[[:space:]]*(extra-)?experimental-features[[:space:]]*=.*nix-command.*flakes' "$nix_config" 2>/dev/null; then
-        printf '\nextra-experimental-features = nix-command flakes\n' >> "$nix_config"
-    fi
+  if [[ -n "${NIX_CONFIG:-}" ]]; then
+    NIX_CONFIG="${NIX_CONFIG}
+$feature"
+  else
+    NIX_CONFIG="$feature"
+  fi
+  export NIX_CONFIG
 }
 
-resolve_dotfiles_dir() {
-    if [[ -n "${DOTFILES_DIR:-}" ]]; then
-        echo "$DOTFILES_DIR"
-    elif [[ -f "$PWD/flake.nix" && -d "$PWD/home" ]]; then
-        echo "$PWD"
-    else
-        echo "$DEFAULT_DOTFILES_DIR"
-    fi
+run_atyrode() {
+  nix run "$DOTFILES_DIR#atyrode" -- "$@"
 }
 
-prepare_dotfiles_dir() {
-    if [[ -f "$DOTFILES_DIR/flake.nix" && -d "$DOTFILES_DIR/home" ]]; then
-        echo "Using existing dotfiles checkout: $DOTFILES_DIR"
-        cd "$DOTFILES_DIR"
-    elif [[ -d "$DOTFILES_DIR/.git" ]]; then
-        echo "Updating existing dotfiles checkout: $DOTFILES_DIR"
-        git -C "$DOTFILES_DIR" pull
-        cd "$DOTFILES_DIR"
-    else
-        echo "Cloning dotfiles into: $DOTFILES_DIR"
-        git clone "$REPO_URL" "$DOTFILES_DIR"
-        cd "$DOTFILES_DIR"
-    fi
+managed_activation_plan() {
+  run_atyrode apply "$FLAKE_CONFIG" --repo "$DOTFILES_DIR" --plan
 }
 
-warn_about_untracked_files() {
-    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        return 0
-    fi
-
-    local untracked
-    untracked="$(git ls-files --others --exclude-standard)"
-    if [[ -n "$untracked" ]]; then
-        echo "Warning: untracked files are ignored by Nix flakes unless they are added to git:"
-        echo "$untracked"
-    fi
+activate_configuration() {
+  run_atyrode apply "$FLAKE_CONFIG" --repo "$DOTFILES_DIR" --restart-shell
 }
 
-backup_if_symlink() {
-    local path="$1"
+verify_installation() {
+  local state_file migration_status
 
-    if [[ ! -L "$path" ]]; then
-        return 0
-    fi
-
-    local target
-    target="$(readlink "$path")"
-    case "$target" in
-        /nix/store/*-home-manager-files/*)
-            return 0
-            ;;
-    esac
-
-    local backup="$path.backup"
-    if [[ -e "$backup" || -L "$backup" ]]; then
-        backup="$path.backup.$(date +%Y%m%d%H%M%S)"
-    fi
-
-    echo "Backing up existing symlink: $path -> $backup"
-    mv "$path" "$backup"
+  source_nix
+  command_exists nix || die "Nix is not available"
+  state_file="${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/dotfiles-config"
+  [[ -f "$state_file" && ! -L "$state_file" ]] || die "active host receipt is missing"
+  [[ "$(cat "$state_file")" == "$FLAKE_CONFIG" ]] ||
+    die "active host receipt does not match $FLAKE_CONFIG"
+  run_atyrode doctor host "$FLAKE_CONFIG" >/dev/null
+  if [[ -n "$TRANSACTION" ]]; then
+    migration_status="$(migration_command status)"
+  else
+    migration_status="$(bash "$DOTFILES_DIR/scripts/bootstrap-migrate.sh" status)"
+  fi
+  [[ "$migration_status" == complete ]] || die "bootstrap migration is not complete"
+  printf 'Verification passed for %s on %s\n' "$FLAKE_CONFIG" "$SYSTEM"
 }
 
-backup_home_manager_symlink_conflicts() {
-    # Home Manager's -b backup path does not back up symlinks during collision
-    # checks, so handle the expected shell entrypoints before switching.
-    backup_if_symlink "$HOME/.zshrc"
-    backup_if_symlink "$HOME/.zshenv"
+apply_configuration() {
+  local migration_status
+
+  preflight
+  print_plan
+  confirm_action "Apply this bootstrap plan?"
+
+  if [[ "$UPDATE_SOURCE" -eq 1 ]]; then
+    update_checkout || die "source update failed before any bootstrap transaction started"
+    verify_checkout
+    if [[ "$SOURCE_CHANGED" -eq 1 ]]; then
+      restart_after_source_update
+    fi
+  fi
+
+  begin_transaction
+  trap 'on_apply_error $?' ERR
+  trap 'fail_transaction "interrupt signal"' INT TERM
+
+  ACTIVE_PHASE="Nix installation"
+  append_transaction phase ensuring-nix
+  ensure_nix
+  enable_flakes_for_process
+
+  ACTIVE_PHASE="managed host preflight"
+  append_transaction phase managed-preflight
+  managed_activation_plan
+
+  ACTIVE_PHASE="migration state validation"
+  migration_status="$(migration_command status)"
+  if [[ "$migration_status" == complete ]]; then
+    append_transaction migration preexisting-complete
+  else
+    : > "$TRANSACTION/migration-owned"
+    chmod 600 "$TRANSACTION/migration-owned"
+    append_transaction migration owned
+  fi
+  ACTIVE_PHASE="migration preparation"
+  append_transaction phase preparing-migration
+  migration_command prepare
+
+  if [[ "${BOOTSTRAP_FAILPOINT:-}" == after-migration-prepare ]]; then
+    printf 'bootstrap: interrupted at test failpoint after-migration-prepare\n' >&2
+    exit 75
+  fi
+
+  ACTIVE_PHASE="configuration activation"
+  append_transaction phase activating
+  activate_configuration
+  ACTIVE_PHASE="migration completion"
+  append_transaction phase committing-migration
+  migration_command commit
+  ACTIVE_PHASE="verification"
+  append_transaction phase verifying
+  verify_installation
+  trap - ERR INT TERM
+  finish_transaction complete
+
+  printf '\nBootstrap complete. Start the managed login shell with: exec zsh -l\n'
 }
 
-switch_configuration() {
-    if [[ "$SYSTEM" == *-darwin ]]; then
-        local nix_cmd
-        nix_cmd="$(command -v nix)"
-        local nix_config="${NIX_CONFIG:-extra-experimental-features = nix-command flakes}"
+rollback_interrupted() {
+  local root current_sha expected_sha outcome reason
 
-        if [[ "$EUID" -eq 0 ]]; then
-            "$nix_cmd" run ".#darwin-rebuild" -- switch --flake ".#$FLAKE_CONFIG"
-        else
-            sudo -H env NIX_CONFIG="$nix_config" "$nix_cmd" run ".#darwin-rebuild" -- switch --flake ".#$FLAKE_CONFIG"
-        fi
-    else
-        HOME_MANAGER_BACKUP_EXT=backup nix run ".#home-manager" -- switch --flake ".#$FLAKE_CONFIG"
+  root="$(bootstrap_state_root)"
+  TRANSACTION="$root/apply.pending"
+  if [[ ! -e "$TRANSACTION" && ! -L "$TRANSACTION" ]]; then
+    printf 'No interrupted bootstrap transaction needs rollback.\n'
+    return
+  fi
+  [[ -d "$TRANSACTION" && ! -L "$TRANSACTION" ]] ||
+    die "interrupted transaction must be a real directory"
+  [[ -f "$TRANSACTION/receipt.tsv" && ! -L "$TRANSACTION/receipt.tsv" ]] ||
+    die "interrupted transaction has no safe receipt"
+  verify_recovery_script install.sh installer-sha256
+  expected_sha="$(transaction_value installer-sha256)"
+  current_sha="$(sha256_file "${BASH_SOURCE[0]}")"
+  if [[ "$current_sha" != "$expected_sha" ]]; then
+    if [[ "$ASSUME_YES" -eq 1 ]]; then
+      exec bash "$TRANSACTION/recovery/install.sh" rollback --yes
     fi
+    exec bash "$TRANSACTION/recovery/install.sh" rollback
+  fi
+  FLAKE_CONFIG="$(transaction_value configuration)"
+  SYSTEM="$(transaction_value system)"
+  confirm_action "Restore the interrupted bootstrap transaction?"
+  rollback_current_transaction
+  outcome="${BOOTSTRAP_RECOVERY_OUTCOME:-rolled-back}"
+  case "$outcome" in
+    failed|rolled-back) ;;
+    *) die "invalid recovery outcome" ;;
+  esac
+  reason="${BOOTSTRAP_FAILURE_REASON:-operator-requested recovery}"
+  append_transaction recovery "$reason"
+  finish_transaction "$outcome"
+  printf 'Interrupted bootstrap changes were rolled back.\n'
 }
 
-SYSTEM="$(detect_system)"
-FLAKE_CONFIG="${FLAKE_CONFIG:-alex-${SYSTEM}}"
-DOTFILES_DIR="$(resolve_dotfiles_dir)"
+parse_options "$@"
 
-echo "Installing dotfiles..."
-echo "System: $SYSTEM"
-echo "Configuration: $FLAKE_CONFIG"
-
-ensure_nix
-ensure_flakes
-prepare_dotfiles_dir
-warn_about_untracked_files
-backup_home_manager_symlink_conflicts
-
-echo "Building and activating configuration..."
-echo "This may take a few minutes on first run."
-
-if switch_configuration; then
-    echo ""
-    echo "Installation complete."
-    echo ""
-
-    if ! record_active_config; then
-        echo "Warning: could not record active dotfiles configuration." >&2
-    fi
-    source_home_manager_session_vars
-
-    HM_ZSH=""
-    if [[ -f "$HOME/.nix-profile/bin/zsh" ]]; then
-        HM_ZSH="$HOME/.nix-profile/bin/zsh"
-    elif command -v zsh >/dev/null 2>&1; then
-        HM_ZSH="$(command -v zsh)"
-    fi
-
-    echo "Next steps:"
-    if [[ -n "$HM_ZSH" ]]; then
-        echo "   1. Switch to the managed shell now: exec $HM_ZSH"
-    else
-        echo "   1. Open a new terminal so your shell environment reloads."
-    fi
-    echo "   2. Run 'atyrode' to see available tools."
-    echo "   3. Run 'zconf' after future dotfiles changes."
-else
-    echo ""
-    echo "Installation failed. Try the same switch manually for the full error:"
-    echo "   cd $DOTFILES_DIR"
-    if [[ "$SYSTEM" == *-darwin ]]; then
-        echo "   sudo -H nix run .#darwin-rebuild -- switch --flake .#$FLAKE_CONFIG"
-    else
-        echo "   HOME_MANAGER_BACKUP_EXT=backup nix run .#home-manager -- switch --flake .#$FLAKE_CONFIG"
-    fi
-    exit 1
-fi
+case "$COMMAND" in
+  preflight) preflight ;;
+  plan) preflight; print_plan ;;
+  apply) apply_configuration ;;
+  verify) preflight; enable_flakes_for_process; verify_installation ;;
+  rollback) rollback_interrupted ;;
+  -h|--help|help) usage ;;
+  '') usage >&2; exit 64 ;;
+  *) usage >&2; die "unknown phase: $COMMAND" ;;
+esac

--- a/scripts/bootstrap-migrate.sh
+++ b/scripts/bootstrap-migrate.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script deliberately uses only Bash 3.2-era features and platform tools:
+# it runs before Nix is guaranteed to exist, including on macOS.
+
+migration_id="migration-v1-shell-entrypoints"
+state_root="${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/bootstrap/migrations"
+pending="$state_root/$migration_id.pending"
+complete="$state_root/$migration_id.complete"
+
+die() {
+  printf 'bootstrap migration: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage: bootstrap-migrate.sh plan|prepare|commit|rollback|status
+
+The migration backs up unmanaged ~/.zshrc and ~/.zshenv entrypoints before
+activation. Receipts contain only versioned, home-relative logical paths.
+EOF
+}
+
+path_exists() {
+  [[ -e "$1" || -L "$1" ]]
+}
+
+is_managed_link() {
+  local path="$1"
+  local target
+
+  [[ -L "$path" ]] || return 1
+  target="$(readlink "$path")"
+  case "$target" in
+    /nix/store/*-home-manager-files/*) return 0 ;;
+  esac
+  return 1
+}
+
+path_kind() {
+  if [[ -L "$1" ]]; then
+    printf 'symlink\n'
+  elif [[ -f "$1" ]]; then
+    printf 'file\n'
+  else
+    die "$1 has an unsupported type; move it manually before continuing"
+  fi
+}
+
+ensure_state_root() {
+  local bootstrap_root="${state_root%/migrations}"
+  local atyrode_root="${bootstrap_root%/bootstrap}"
+  local directory
+
+  for directory in "$atyrode_root" "$bootstrap_root" "$state_root"; do
+    if path_exists "$directory"; then
+      [[ -d "$directory" && ! -L "$directory" ]] ||
+        die "$directory must be a real directory"
+    else
+      mkdir -p "$directory"
+    fi
+    chmod 700 "$directory"
+  done
+}
+
+validate_state_root() {
+  local bootstrap_root="${state_root%/migrations}"
+  local atyrode_root="${bootstrap_root%/bootstrap}"
+  local directory
+
+  for directory in "$atyrode_root" "$bootstrap_root" "$state_root"; do
+    if path_exists "$directory" && [[ ! -d "$directory" || -L "$directory" ]]; then
+      die "$directory must be a real directory"
+    fi
+  done
+}
+
+validate_receipt() {
+  local transaction="$1"
+  local receipt="$transaction/receipt.tsv"
+  local record relative kind extra
+  local zshrc_count=0
+  local zshenv_count=0
+  local version_count=0
+
+  [[ -d "$transaction" && ! -L "$transaction" ]] ||
+    die "$transaction is not a safe migration transaction"
+  [[ -f "$receipt" && ! -L "$receipt" ]] ||
+    die "$transaction has no safe receipt"
+  [[ -d "$transaction/backup" && ! -L "$transaction/backup" ]] ||
+    die "$transaction has no safe backup directory"
+
+  while IFS=$'\t' read -r record relative kind extra; do
+    [[ -z "${extra:-}" ]] || die "migration receipt has unexpected fields"
+    case "$record" in
+      version)
+        [[ "$relative" == 1 && -z "${kind:-}" ]] ||
+          die "migration receipt has an unsupported version"
+        version_count=$((version_count + 1))
+        ;;
+      move)
+        case "$relative" in
+          .zshrc) zshrc_count=$((zshrc_count + 1)) ;;
+          .zshenv) zshenv_count=$((zshenv_count + 1)) ;;
+          *) die "migration receipt contains an unsafe path: $relative" ;;
+        esac
+        case "$kind" in
+          file|symlink) ;;
+          *) die "migration receipt contains an unsafe path type" ;;
+        esac
+        ;;
+      '') ;;
+      *) die "migration receipt contains an unknown record" ;;
+    esac
+  done < "$receipt"
+
+  [[ "$version_count" -eq 1 ]] || die "migration receipt has no unique version"
+  [[ "$zshrc_count" -le 1 && "$zshenv_count" -le 1 ]] ||
+    die "migration receipt contains duplicate paths"
+}
+
+validate_terminal_state() {
+  local transaction
+
+  validate_state_root
+  for transaction in "$pending" "$complete"; do
+    if path_exists "$transaction"; then
+      [[ -d "$transaction" && ! -L "$transaction" ]] ||
+        die "$transaction must be a real migration receipt directory"
+    fi
+  done
+  if path_exists "$pending" && path_exists "$complete"; then
+    die "both pending and complete receipts exist; preserve them and resolve the collision"
+  fi
+}
+
+backup_name() {
+  case "$1" in
+    .zshrc) printf 'zshrc\n' ;;
+    .zshenv) printf 'zshenv\n' ;;
+    *) die "unsafe migration path: $1" ;;
+  esac
+}
+
+validate_complete_backups() {
+  local transaction="$1"
+  local record relative kind extra backup name
+
+  validate_receipt "$transaction"
+  while IFS=$'\t' read -r record relative kind extra; do
+    [[ "$record" == move ]] || continue
+    name="$(backup_name "$relative")"
+    backup="$transaction/backup/$name"
+    case "$kind" in
+      symlink) [[ -L "$backup" ]] || die "the recorded symlink backup for $relative is missing" ;;
+      file) [[ -f "$backup" && ! -L "$backup" ]] || die "the recorded file backup for $relative is missing" ;;
+    esac
+  done < "$transaction/receipt.tsv"
+}
+
+print_plan_for_path() {
+  local relative="$1"
+  local source="$HOME/$relative"
+
+  if path_exists "$source" && ! is_managed_link "$source"; then
+    printf 'backup %s (%s) into the protected migration transaction\n' \
+      "$relative" "$(path_kind "$source")"
+  else
+    printf 'leave %s unchanged (absent or already Home Manager-owned)\n' "$relative"
+  fi
+}
+
+plan_migration() {
+  validate_terminal_state
+  if [[ -d "$complete" ]]; then
+    validate_complete_backups "$complete"
+    printf '%s is already complete; no migration changes are required\n' "$migration_id"
+    return
+  fi
+  if [[ -d "$pending" ]]; then
+    validate_receipt "$pending"
+    printf 'resume %s from its pending receipt\n' "$migration_id"
+    return
+  fi
+
+  print_plan_for_path .zshrc
+  print_plan_for_path .zshenv
+}
+
+write_initial_receipt() {
+  local transaction="$1"
+  local receipt="$transaction/receipt.tsv"
+  local relative source
+
+  printf 'version\t1\n' > "$receipt"
+  for relative in .zshrc .zshenv; do
+    source="$HOME/$relative"
+    if path_exists "$source" && ! is_managed_link "$source"; then
+      printf 'move\t%s\t%s\n' "$relative" "$(path_kind "$source")" >> "$receipt"
+    fi
+  done
+  chmod 600 "$receipt"
+}
+
+resume_prepare() {
+  local record relative kind extra source backup name
+
+  validate_receipt "$pending"
+  while IFS=$'\t' read -r record relative kind extra; do
+    [[ "$record" == move ]] || continue
+    source="$HOME/$relative"
+    name="$(backup_name "$relative")"
+    backup="$pending/backup/$name"
+
+    if path_exists "$backup"; then
+      if ! path_exists "$source" || is_managed_link "$source"; then
+        continue
+      fi
+      die "$relative and its migration backup both exist; preserve both and resolve the collision"
+    fi
+    path_exists "$source" ||
+      die "$relative disappeared before its migration backup was created"
+    [[ "$(path_kind "$source")" == "$kind" ]] ||
+      die "$relative changed type before it could be backed up"
+    mv "$source" "$backup"
+    if [[ "${BOOTSTRAP_MIGRATION_FAILPOINT:-}" == "after-${relative#.}" ]]; then
+      printf 'bootstrap migration: interrupted at test failpoint after-%s\n' "${relative#.}" >&2
+      exit 75
+    fi
+  done < "$pending/receipt.tsv"
+}
+
+prepare_migration() {
+  local creating
+
+  ensure_state_root
+  validate_terminal_state
+  if [[ -e "$complete" || -L "$complete" ]]; then
+    validate_complete_backups "$complete"
+    printf '%s already complete\n' "$migration_id"
+    return
+  fi
+  if [[ ! -d "$pending" ]]; then
+    creating="$state_root/.$migration_id.creating.$$"
+    [[ ! -e "$creating" && ! -L "$creating" ]] || die "temporary migration path already exists"
+    mkdir "$creating"
+    chmod 700 "$creating"
+    mkdir "$creating/backup"
+    chmod 700 "$creating/backup"
+    write_initial_receipt "$creating"
+    mv "$creating" "$pending"
+  fi
+
+  resume_prepare
+  printf '%s prepared; original entrypoints are protected by the pending receipt\n' "$migration_id"
+}
+
+commit_migration() {
+  local record relative kind extra source
+
+  validate_terminal_state
+  if [[ -d "$complete" ]]; then
+    validate_complete_backups "$complete"
+    printf '%s already complete\n' "$migration_id"
+    return
+  fi
+  validate_receipt "$pending"
+  while IFS=$'\t' read -r record relative kind extra; do
+    [[ "$record" == move ]] || continue
+    source="$HOME/$relative"
+    is_managed_link "$source" ||
+      die "$relative is not linked by Home Manager; refusing to complete the migration"
+  done < "$pending/receipt.tsv"
+
+  validate_complete_backups "$pending"
+
+  mv "$pending" "$complete"
+  printf '%s complete; backups remain in the protected receipt\n' "$migration_id"
+}
+
+rollback_transaction() {
+  local transaction="$1"
+  local record relative kind extra source backup name
+
+  validate_receipt "$transaction"
+  # Validate every restore before moving anything so a collision cannot cause a
+  # half-rollback.
+  while IFS=$'\t' read -r record relative kind extra; do
+    [[ "$record" == move ]] || continue
+    source="$HOME/$relative"
+    name="$(backup_name "$relative")"
+    backup="$transaction/backup/$name"
+    if path_exists "$backup"; then
+      if path_exists "$source" && ! is_managed_link "$source"; then
+        die "$relative now contains user-owned data; refusing to overwrite it during rollback"
+      fi
+    else
+      path_exists "$source" || die "$relative and its recorded backup are both missing"
+      ! is_managed_link "$source" ||
+        die "the recorded backup for $relative is missing after activation"
+      [[ "$(path_kind "$source")" == "$kind" ]] ||
+        die "$relative changed type before rollback"
+    fi
+  done < "$transaction/receipt.tsv"
+
+  while IFS=$'\t' read -r record relative kind extra; do
+    [[ "$record" == move ]] || continue
+    source="$HOME/$relative"
+    name="$(backup_name "$relative")"
+    backup="$transaction/backup/$name"
+
+    path_exists "$backup" || continue
+
+    if path_exists "$source"; then
+      rm "$source"
+    fi
+    mv "$backup" "$source"
+  done < "$transaction/receipt.tsv"
+}
+
+rollback_migration() {
+  local transaction=""
+  local rolled_back
+
+  ensure_state_root
+  validate_terminal_state
+  if [[ -d "$pending" ]]; then
+    transaction="$pending"
+  elif [[ -d "$complete" ]]; then
+    transaction="$complete"
+  else
+    printf 'No bootstrap migration transaction needs rollback\n'
+    return
+  fi
+
+  rollback_transaction "$transaction"
+  rolled_back="$state_root/$migration_id.rolled-back"
+  if [[ -e "$rolled_back" || -L "$rolled_back" ]]; then
+    rolled_back="$rolled_back.$$"
+  fi
+  mv "$transaction" "$rolled_back"
+  printf '%s rolled back; the relative-path receipt remains at %s\n' \
+    "$migration_id" "${rolled_back#"$state_root/"}"
+}
+
+status_migration() {
+  validate_terminal_state
+  if [[ -d "$pending" ]]; then
+    validate_receipt "$pending"
+    printf 'pending\n'
+  elif [[ -d "$complete" ]]; then
+    validate_complete_backups "$complete"
+    printf 'complete\n'
+  else
+    printf 'applicable\n'
+  fi
+}
+
+case "${1:-}" in
+  plan) plan_migration ;;
+  prepare) prepare_migration ;;
+  commit) commit_migration ;;
+  rollback) rollback_migration ;;
+  status) status_migration ;;
+  -h|--help|help) usage ;;
+  *) usage >&2; exit 64 ;;
+esac


### PR DESCRIPTION
Closes #11

## What changed

- Replaced the mutable one-shot installer with explicit `preflight`, `plan`, `apply`, `verify`, and `rollback` phases.
- Require an explicit registered host, verify the raw and Git-resolved repository origin, reject risky checkout states by default, and make source updates opt-in and fast-forward-only.
- Pin upstream Nix 2.34.7 artifacts for all four tracked systems and verify SHA-256 before extraction or execution; process-scoped flake configuration no longer edits user-owned `nix.conf`.
- Added a versioned, idempotent shell-entrypoint migration with relative receipts, pending/completed state, checksummed transaction-owned recovery scripts, collision-safe rollback, and automatic restoration after activation or verification failure.
- Added temporary-home fixtures for fresh/repeated installs, updates, wrong or rewritten origins, download/integrity/partial-installer failures, activation and verification failures, interruption, tampering, receipt corruption, missing backups, symlinked state roots, and rollback.
- Documented the supported fresh-machine command, the upstream Nix/Lix/Determinate installer decision, receipt ownership, recovery, and uninstall boundaries.

## Validation

- `nix build 'path:.#checks.x86_64-linux.bootstrap' --no-link --show-trace`
- `nix flake check 'path:.' --show-trace`
- `nix flake check 'path:.' --all-systems --no-build --show-trace`
- `bash -n install.sh scripts/bootstrap-migrate.sh`
- `shellcheck -x install.sh scripts/bootstrap-migrate.sh`
- `zsh -n home/shell/*.zsh`
- `nixfmt --check flake.nix checks/bootstrap.nix`
- `git diff --check`
