### PR TITLE
Define and validate the Home Manager–system boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ receipts. See [Bootstrap and migrations](docs/bootstrap.md).
 - **dive** - Docker image inspector
 - **fastfetch** - Explicit system information command (not a startup side effect)
 - **Explicit capabilities** - ffmpeg (`media`), Android tools/scrcpy (`mobile`),
-  and nmap/socat/ClamAV (`security`)
+  and nmap/socat (`security`)
 
 ### macOS Apps
 - **Nix app bundles** - ChatGPT, Godot, Lichess, Obsidian, OrbStack, Postman,
@@ -77,6 +77,7 @@ Use the packaged `atyrode` interface, or check these highlights:
 atyrode apply --plan  # Inspect the exact host, source, and backend
 zconf                 # Compatibility wrapper for `atyrode apply`
 atyrode doctor host   # Validate the managed machine identity
+atyrode doctor system # Audit system-owned operational prerequisites
 ```
 
 ### Agent Tools
@@ -134,7 +135,8 @@ dotfiles/
 ├── agents/                  # Generic cross-project skills
 ├── checks/                  # Nix package and migration checks
 ├── darwin/                # nix-darwin and Homebrew configuration
-│   └── default.nix        # macOS system and cask definitions
+│   ├── casks.nix          # Shared declarative Homebrew cask list
+│   └── default.nix        # macOS system ownership and activation
 ├── docs/                    # Architecture and maintenance guides
 ├── flake.nix              # Main flake configuration
 ├── install.sh             # Phased, transactional bootstrap
@@ -189,6 +191,10 @@ compatibility boundary.
 baseline, optional capabilities, project-owned runtimes, harness boundaries,
 and closure review workflow.
 
+[Home Manager and system boundary](docs/system-boundary.md) records which
+layer owns login shells, the Nix daemon, containers, device access, antivirus,
+and Homebrew, plus the read-only operational readiness checks.
+
 [Shell surface](docs/shell.md) records every retained and removed function,
 alias, startup side effect, and Oh My Zsh plugin.
 
@@ -235,7 +241,8 @@ package inventory, then run `atyrode apply`.
 
 ### Add macOS Homebrew Apps
 
-Edit `darwin/default.nix` and add cask names to `homebrew.casks`, then run `zconf` on macOS.
+Edit `darwin/casks.nix`, then run `zconf` on macOS. nix-darwin generates the
+matching Brewfile and checks for non-destructive Homebrew drift.
 
 ### Modify Shell Functions
 

--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -1,9 +1,14 @@
-{ pkgs }:
+{
+  atyrode,
+  pkgs,
+  productionAtyrode,
+  productionHost,
+}:
 
 pkgs.runCommand "check-atyrode-cli"
   {
     nativeBuildInputs = [
-      pkgs.atyrode
+      atyrode
       pkgs.jq
     ];
   }
@@ -36,6 +41,19 @@ pkgs.runCommand "check-atyrode-cli"
     export _ATYRODE_TEST_HOSTNAME="fixture-linux"
     export _ATYRODE_TEST_SYSTEM="x86_64-linux"
     export _ATYRODE_TEST_USER="alex"
+
+    # Production packages ignore every test-only identity override. Otherwise
+    # a project environment could spoof apply and doctor preflight identity.
+    set +e
+    env \
+      _ATYRODE_TEST_HOSTNAME=spoofed \
+      _ATYRODE_TEST_SYSTEM=${pkgs.stdenv.hostPlatform.system} \
+      _ATYRODE_TEST_USER=alex \
+      ${productionAtyrode}/bin/atyrode doctor host ${productionHost} --json \
+      > "$TMPDIR/production-identity.out" 2> "$TMPDIR/production-identity.err"
+    production_identity_status="$?"
+    set -e
+    test "$production_identity_status" = 65
 
     atyrode capabilities list --json | jq -e 'index("base") and index("server")' >/dev/null
     atyrode capabilities show alex-linux --json | jq -e '.host == "alex-x86_64-linux"' >/dev/null
@@ -78,6 +96,258 @@ pkgs.runCommand "check-atyrode-cli"
       echo 'cross-system host selection unexpectedly succeeded' >&2
       exit 1
     fi
+
+    # System diagnostics distinguish installed binaries from operational
+    # readiness without touching the build host's account or services.
+    linux_ready="$TMPDIR/linux-ready.json"
+    jq -n --arg path "$HOME/.nix-profile/bin/zsh" '{
+      loginShell: {path:$path, executable:true, listed:true},
+      nix: {
+        daemonReachable:true,
+        trustedUsersExact:true,
+        officialCacheOnly:true,
+        officialKeyOnly:true,
+        signaturesRequired:true,
+        optimiserScheduled:false,
+        rawSubstituter:"https://super-secret@example.invalid/cache?token=super-secret"
+      },
+      container: {dockerGroup:false, mode:"rootless"},
+      device: {adbAvailable:true, policy:"uaccess"},
+      homebrew: {available:false, drift:false}
+    }' > "$linux_ready"
+    export _ATYRODE_TEST_SYSTEM_FIXTURE="$linux_ready"
+    system_result="$(atyrode doctor system alex-x86_64-linux-desktop --json)"
+    jq -e '
+      .schemaVersion == 1
+      and .command == "doctor system"
+      and .ok
+      and .mutationBoundary == "read-only probes"
+      and (.checks | map(.id)) == [
+        "login-shell",
+        "nix-daemon",
+        "nix-policy",
+        "container-engine",
+        "antivirus-data",
+        "device-permissions",
+        "homebrew-drift"
+      ]
+      and (.checks[] | select(.id == "container-engine") | .actual.mode) == "rootless"
+      and (.checks[] | select(.id == "antivirus-data") | .code) == "not-configured"
+      and (.checks[] | select(.id == "homebrew-drift") | .status) == "not-applicable"
+    ' <<< "$system_result" >/dev/null
+    if grep -q 'super-secret' <<< "$system_result"; then
+      echo 'system diagnostics exposed raw Nix configuration' >&2
+      exit 1
+    fi
+
+    minimal_result="$(atyrode doctor system alex-x86_64-linux --json)"
+    jq -e '
+      .ok
+      and (.checks[] | select(.id == "container-engine") | .status) == "not-applicable"
+      and (.checks[] | select(.id == "device-permissions") | .status) == "not-applicable"
+    ' <<< "$minimal_result" >/dev/null
+
+    antivirus_present="$TMPDIR/antivirus-present.json"
+    jq '.antivirus.binariesPresent = true' "$linux_ready" > "$antivirus_present"
+    export _ATYRODE_TEST_SYSTEM_FIXTURE="$antivirus_present"
+    if atyrode doctor system alex-x86_64-linux-desktop --json > "$TMPDIR/antivirus-present.out"; then
+      echo 'unmanaged ClamAV binaries unexpectedly passed diagnostics' >&2
+      exit 1
+    else
+      test "$?" -eq 69
+    fi
+    jq -e '
+      (.checks[] | select(.id == "antivirus-data") | .code) == "unmanaged-antivirus-present"
+    ' "$TMPDIR/antivirus-present.out" >/dev/null
+
+    # The real Android rule parser requires one active Android/ADB-identified
+    # vendor line to carry the accepted access policy. It ignores unrelated,
+    # split, commented, and unreadable rules without printing filesystem errors.
+    android_probe="$TMPDIR/android-probe.json"
+    jq '.device = {adbAvailable:true}' "$linux_ready" > "$android_probe"
+    android_rules="$TMPDIR/udev-rules"
+    mkdir "$android_rules"
+    export _ATYRODE_TEST_SYSTEM_FIXTURE="$android_probe"
+    export _ATYRODE_TEST_UDEV_ROOT="$android_rules"
+    cat > "$android_rules/51-android.rules" <<'EOF'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="18d1"
+    SUBSYSTEM=="video4linux", TAG+="uaccess"
+    EOF
+    if atyrode doctor system alex-x86_64-linux-desktop --json \
+      > "$TMPDIR/android-split.out" 2> "$TMPDIR/android-split.err"; then
+      echo 'unrelated Android rule lines unexpectedly passed diagnostics' >&2
+      exit 1
+    else
+      test "$?" -eq 69
+    fi
+    test ! -s "$TMPDIR/android-split.err"
+    jq -e '
+      (.checks[] | select(.id == "device-permissions") | .code) == "android-device-permissions"
+    ' "$TMPDIR/android-split.out" >/dev/null
+
+    cat > "$android_rules/51-android.rules" <<'EOF'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="18d1", TAG+="uaccess"
+    EOF
+    atyrode doctor system alex-x86_64-linux-desktop --json | jq -e '.ok' >/dev/null
+
+    chmod 000 "$android_rules/51-android.rules"
+    if atyrode doctor system alex-x86_64-linux-desktop --json \
+      > "$TMPDIR/android-unreadable.out" 2> "$TMPDIR/android-unreadable.err"; then
+      echo 'an unreadable Android rule unexpectedly passed diagnostics' >&2
+      exit 1
+    else
+      test "$?" -eq 69
+    fi
+    test ! -s "$TMPDIR/android-unreadable.err"
+    chmod 600 "$android_rules/51-android.rules"
+    unset _ATYRODE_TEST_UDEV_ROOT
+
+    linux_incomplete="$TMPDIR/linux-incomplete.json"
+    jq -n '{
+      loginShell: {path:"/bin/bash", executable:true, listed:true},
+      nix: {
+        daemonReachable:false,
+        trustedUsersExact:false,
+        officialCacheOnly:false,
+        officialKeyOnly:false,
+        signaturesRequired:false,
+        optimiserScheduled:false
+      },
+      container: {dockerGroup:true, mode:"rootful"},
+      device: {adbAvailable:true, policy:"missing"},
+      homebrew: {available:false, drift:true}
+    }' > "$linux_incomplete"
+    export _ATYRODE_TEST_SYSTEM_FIXTURE="$linux_incomplete"
+    if atyrode doctor system alex-x86_64-linux-desktop --json > "$TMPDIR/linux-incomplete.out"; then
+      echo 'incomplete Linux system unexpectedly passed diagnostics' >&2
+      exit 1
+    else
+      test "$?" -eq 69
+    fi
+    jq -e '
+      (.ok | not)
+      and ([.checks[] | select(.status == "incomplete") | .code] | index("login-shell-mismatch"))
+      and ([.checks[] | select(.status == "incomplete") | .code] | index("nix-daemon-unreachable"))
+      and ([.checks[] | select(.status == "incomplete") | .code] | index("nix-policy-drift"))
+      and ([.checks[] | select(.status == "incomplete") | .code] | index("docker-group-membership"))
+      and ([.checks[] | select(.status == "incomplete") | .code] | index("android-device-permissions"))
+    ' "$TMPDIR/linux-incomplete.out" >/dev/null
+
+    server_ready="$TMPDIR/server-ready.json"
+    jq '.loginShell.path = "/run/current-system/sw/bin/zsh"' "$linux_ready" > "$server_ready"
+    export _ATYRODE_TEST_USER=fixture
+    export _ATYRODE_TEST_SYSTEM_FIXTURE="$server_ready"
+    server_result="$(atyrode doctor system fixture-server --json)"
+    jq -e '
+      .ok
+      and ([.checks[] | select(.id == "login-shell" or .id == "nix-daemon" or
+          .id == "nix-policy" or .id == "container-engine" or
+          .id == "antivirus-data" or .id == "device-permissions") | .owner]
+        | all(. == "nixos"))
+    ' <<< "$server_result" >/dev/null
+
+    darwin_ready="$TMPDIR/darwin-ready.json"
+    jq -n '{
+      loginShell: {path:"/run/current-system/sw/bin/zsh", executable:true, listed:true},
+      nix: {
+        daemonReachable:true,
+        trustedUsersExact:true,
+        officialCacheOnly:true,
+        officialKeyOnly:true,
+        signaturesRequired:true,
+        optimiserScheduled:true
+      },
+      container: {dockerGroup:false, mode:"orbstack"},
+      device: {adbAvailable:true, policy:"macos-user-authorization"},
+      homebrew: {available:true, drift:false}
+    }' > "$darwin_ready"
+    export _ATYRODE_TEST_SYSTEM="aarch64-darwin"
+    export _ATYRODE_TEST_USER=alex
+    export _ATYRODE_TEST_SYSTEM_FIXTURE="$darwin_ready"
+    darwin_result="$(atyrode doctor system alex-aarch64-darwin --json)"
+    jq -e '
+      .ok
+      and .platform == "darwin"
+      and (.checks[] | select(.id == "container-engine") | .actual.mode) == "orbstack"
+      and (.checks[] | select(.id == "device-permissions") | .status) == "ok"
+      and (.checks[] | select(.id == "homebrew-drift") | .status) == "ok"
+    ' <<< "$darwin_result" >/dev/null
+
+    darwin_missing_adb="$TMPDIR/darwin-missing-adb.json"
+    jq '.device.adbAvailable = false' "$darwin_ready" > "$darwin_missing_adb"
+    export _ATYRODE_TEST_SYSTEM_FIXTURE="$darwin_missing_adb"
+    if atyrode doctor system alex-aarch64-darwin --json > "$TMPDIR/darwin-missing-adb.out"; then
+      echo 'Darwin mobile readiness ignored a missing ADB binary' >&2
+      exit 1
+    else
+      test "$?" -eq 69
+    fi
+    jq -e '
+      (.checks[] | select(.id == "device-permissions") | .code) == "android-tools-missing"
+    ' "$TMPDIR/darwin-missing-adb.out" >/dev/null
+
+    darwin_drift="$TMPDIR/darwin-drift.json"
+    jq '.homebrew.drift = true' "$darwin_ready" > "$darwin_drift"
+    export _ATYRODE_TEST_SYSTEM_FIXTURE="$darwin_drift"
+    if atyrode doctor system alex-aarch64-darwin --json > "$TMPDIR/darwin-drift.out"; then
+      echo 'Homebrew drift unexpectedly passed diagnostics' >&2
+      exit 1
+    else
+      test "$?" -eq 69
+    fi
+    jq -e '
+      (.checks[] | select(.id == "homebrew-drift") | .code) == "homebrew-drift"
+    ' "$TMPDIR/darwin-drift.out" >/dev/null
+
+    darwin_probe_failure="$TMPDIR/darwin-probe-failure.json"
+    jq '.homebrew.probeFailed = true' "$darwin_ready" > "$darwin_probe_failure"
+    export _ATYRODE_TEST_SYSTEM_FIXTURE="$darwin_probe_failure"
+    if atyrode doctor system alex-aarch64-darwin --json > "$TMPDIR/darwin-probe-failure.out"; then
+      echo 'Homebrew probe failure unexpectedly passed diagnostics' >&2
+      exit 1
+    else
+      test "$?" -eq 69
+    fi
+    jq -e '
+      (.checks[] | select(.id == "homebrew-drift") | .code) == "homebrew-probe-failed"
+    ' "$TMPDIR/darwin-probe-failure.out" >/dev/null
+
+    export _ATYRODE_TEST_SYSTEM="x86_64-linux"
+    export _ATYRODE_TEST_USER="fixture"
+    export _ATYRODE_TEST_SYSTEM_FIXTURE="$linux_ready"
+    security_result="$(atyrode doctor system fixture-security --json)"
+    jq -e '
+      (.checks[] | select(.id == "antivirus-data") | .status) == "not-applicable"
+      and (.checks[] | select(.id == "antivirus-data") | .code) == "not-configured"
+    ' <<< "$security_result" >/dev/null
+
+    if atyrode doctor system fixture-security --unknown >/dev/null 2>&1; then
+      echo 'unknown doctor system option unexpectedly succeeded' >&2
+      exit 1
+    else
+      test "$?" -eq 64
+    fi
+    export _ATYRODE_TEST_USER="wrong-user"
+    if atyrode doctor system fixture-security --json >/dev/null 2>&1; then
+      echo 'system diagnostics ignored host identity mismatch' >&2
+      exit 1
+    else
+      test "$?" -eq 65
+    fi
+
+    if grep -Eq 'brew bundle cleanup .*--(force|zap)|(^|[[:space:]])(sudo|chsh|usermod|freshclam)([[:space:]]|$)|adb[[:space:]]+devices' \
+      ${../pkgs/atyrode/atyrode}; then
+      echo 'doctor system contains a mutating system probe' >&2
+      exit 1
+    fi
+    grep -F 'brew bundle check --no-upgrade --file "$homebrew_brewfile" </dev/null' \
+      ${../pkgs/atyrode/atyrode} >/dev/null
+    grep -F 'brew bundle cleanup --file "$homebrew_brewfile" </dev/null' \
+      ${../pkgs/atyrode/atyrode} >/dev/null
+    grep -F '"$test_hooks" == 1 && -n "''${ATYRODE_GIT:-}"' \
+      ${../pkgs/atyrode/atyrode} >/dev/null
+    grep -F '"$test_hooks" == 1 && -n "''${ATYRODE_NH:-}"' \
+      ${../pkgs/atyrode/atyrode} >/dev/null
 
     mkdir "$out"
   ''

--- a/checks/bootstrap.nix
+++ b/checks/bootstrap.nix
@@ -17,6 +17,7 @@ pkgs.runCommand "check-bootstrap-${system}"
       pkgs.bash
       pkgs.coreutils
       pkgs.findutils
+      pkgs.gawk
       pkgs.git
       pkgs.gnugrep
       pkgs.gnused
@@ -47,6 +48,14 @@ pkgs.runCommand "check-bootstrap-${system}"
     fi
 
     mkdir -p "$fresh_tools" "$managed_tools"
+    grep -Fqx 'readonly BOOTSTRAP_TEST_HOOKS=0' "$bootstrap"
+    grep -Fqx 'readonly BOOTSTRAP_MIGRATION_TEST_HOOKS=0' "$migration"
+    production_migration="$migration"
+    cp "$migration" "$tool_root/bootstrap-migrate-test"
+    substituteInPlace "$tool_root/bootstrap-migrate-test" \
+      --replace-fail 'readonly BOOTSTRAP_MIGRATION_TEST_HOOKS=0' \
+      'readonly BOOTSTRAP_MIGRATION_TEST_HOOKS=1'
+    migration="$tool_root/bootstrap-migrate-test"
 
     cat > "$tool_root/git" <<'EOF'
     #!${pkgs.runtimeShell}
@@ -118,6 +127,34 @@ pkgs.runCommand "check-bootstrap-${system}"
     exec "$FAKE_SHA256SUM" "$@"
     EOF
 
+    cat > "$tool_root/sudo" <<'EOF'
+    #!${pkgs.runtimeShell}
+    set -eu
+    [ "''${FAKE_SUDO_FAIL:-0}" != 1 ] || exit 77
+    if [ "''${1:-}" = -- ]; then
+      shift
+    fi
+    exec "$@"
+    EOF
+
+    cat > "$tool_root/chsh" <<'EOF'
+    #!${pkgs.runtimeShell}
+    set -eu
+    [ "''${FAKE_CHSH_FAIL:-0}" != 1 ] || exit 78
+    target=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -s)
+          target="$2"
+          shift 2
+          ;;
+        *) shift ;;
+      esac
+    done
+    [ -n "$target" ] || exit 64
+    printf '%s\n' "$target" > "$BOOTSTRAP_ACCOUNT_SHELL_FILE"
+    EOF
+
     cat > "$fake_installer_template" <<'EOF'
     #!${pkgs.runtimeShell}
     set -eu
@@ -180,9 +217,21 @@ pkgs.runCommand "check-bootstrap-${system}"
         rm -f "$HOME/.zshrc" "$HOME/.zshenv"
         ln -s /nix/store/fixture-home-manager-files/.zshrc "$HOME/.zshrc"
         ln -s /nix/store/fixture-home-manager-files/.zshenv "$HOME/.zshenv"
+        mkdir -p "$HOME/.nix-profile/bin"
+        ln -sf ${pkgs.zsh}/bin/zsh "$HOME/.nix-profile/bin/zsh"
         ;;
       *" -- doctor host "*)
         [ "''${FAKE_VERIFY_FAIL:-0}" != 1 ]
+        ;;
+      *" -- doctor system "*)
+        current="$(cat "$BOOTSTRAP_ACCOUNT_SHELL_FILE" 2>/dev/null || true)"
+        if [ "$current" = "$FAKE_EXPECTED_LOGIN_SHELL" ] &&
+          grep -Fqx -- "$FAKE_EXPECTED_LOGIN_SHELL" "$BOOTSTRAP_SHELLS_FILE"; then
+          printf 'login-shell: ok — fixture account database matches managed Zsh\n'
+          exit 0
+        fi
+        printf 'login-shell: incomplete — fixture account database or shell registry differs\n'
+        exit 69
         ;;
       *) exit 64 ;;
     esac
@@ -193,10 +242,12 @@ pkgs.runCommand "check-bootstrap-${system}"
       "$tool_root/curl" \
       "$tool_root/sha256sum" \
       "$tool_root/shasum" \
+      "$tool_root/sudo" \
+      "$tool_root/chsh" \
       "$tool_root/tar" \
       "$fake_installer_template" \
       "$fake_nix_template"
-    for tool in git curl sha256sum shasum tar; do
+    for tool in git curl sha256sum shasum sudo chsh tar; do
       ln -s "$tool_root/$tool" "$fresh_tools/$tool"
       ln -s "$tool_root/$tool" "$managed_tools/$tool"
     done
@@ -216,17 +267,31 @@ pkgs.runCommand "check-bootstrap-${system}"
       export REAL_SHA256SUM=${pkgs.coreutils}/bin/sha256sum
       export FAKE_SYSTEM=${system}
       export EXPECTED_NIX_SHA=${expectedHash}
+      export BOOTSTRAP_ACCOUNT_SHELL_FILE="$TMPDIR/$fixture_name/account-shell"
+      export BOOTSTRAP_SHELLS_FILE="$TMPDIR/$fixture_name/shells"
+      case "$FAKE_SYSTEM" in
+        *-linux) export FAKE_EXPECTED_LOGIN_SHELL="$HOME/.nix-profile/bin/zsh" ;;
+        *-darwin) export FAKE_EXPECTED_LOGIN_SHELL=/run/current-system/sw/bin/zsh ;;
+        *) exit 64 ;;
+      esac
       unset \
         FAKE_ACTIVATION_FAIL \
         FAKE_BAD_SHA \
+        FAKE_CHSH_FAIL \
         FAKE_CURL_FAIL \
         FAKE_GIT_FETCH_FAIL \
         FAKE_GIT_UPDATE_REPO \
         FAKE_INSTALLER_FAIL_AFTER_START \
+        FAKE_SUDO_FAIL \
         FAKE_VERIFY_FAIL
       mkdir -p "$HOME" "$repo/scripts"
+      printf '%s\n' "$FAKE_EXPECTED_LOGIN_SHELL" > "$BOOTSTRAP_ACCOUNT_SHELL_FILE"
+      printf '%s\n' "$FAKE_EXPECTED_LOGIN_SHELL" > "$BOOTSTRAP_SHELLS_FILE"
       cp "$bootstrap" "$repo/install.sh"
       cp "$migration" "$repo/scripts/bootstrap-migrate.sh"
+      substituteInPlace "$repo/install.sh" \
+        --replace-fail 'readonly BOOTSTRAP_TEST_HOOKS=0' \
+        'readonly BOOTSTRAP_TEST_HOOKS=1'
       chmod +x "$repo/install.sh" "$repo/scripts/bootstrap-migrate.sh"
       patchShebangs "$repo/install.sh" "$repo/scripts/bootstrap-migrate.sh"
       printf '{ outputs = _: {}; }\n' > "$repo/flake.nix"
@@ -261,6 +326,20 @@ pkgs.runCommand "check-bootstrap-${system}"
     grep -q '^Plan' "$TMPDIR/plan.out"
     test ! -e "$FAKE_LOG"
     test ! -e "$XDG_STATE_HOME"
+
+    # Production bootstrap ignores ambient test hooks, including an arbitrary
+    # profile script that would otherwise be sourced before activation.
+    cat > "$TMPDIR/poison-profile" <<'EOF'
+    : > "$BOOTSTRAP_POISON_MARKER"
+    EOF
+    export BOOTSTRAP_POISON_MARKER="$TMPDIR/poison-profile-executed"
+    BOOTSTRAP_NIX_PROFILE_SCRIPT="$TMPDIR/poison-profile" \
+      bash "$bootstrap" plan --repo "$repo" --config "$host" >/dev/null
+    test ! -e "$BOOTSTRAP_POISON_MARKER"
+    grep -F '"$BOOTSTRAP_TEST_HOOKS" == 1 && -n "''${BOOTSTRAP_SHELLS_FILE:-}"' \
+      "$bootstrap" >/dev/null
+    grep -F '"$BOOTSTRAP_TEST_HOOKS" == 1 && -n "''${BOOTSTRAP_ACCOUNT_SHELL_FILE:-}"' \
+      "$bootstrap" >/dev/null
 
     # Repository identity, every class of dirt, and revision state are conservative.
     "$real_git" -C "$repo" remote set-url origin https://example.invalid/not-dotfiles.git
@@ -346,6 +425,11 @@ pkgs.runCommand "check-bootstrap-${system}"
     new_fixture fresh-success
     export PATH="$fresh_tools:$base_path"
     make_unmanaged_entrypoints
+    if [[ "$FAKE_SYSTEM" == *-linux ]]; then
+      printf '/bin/bash\n' > "$BOOTSTRAP_ACCOUNT_SHELL_FILE"
+      : > "$BOOTSTRAP_SHELLS_FILE"
+      export SHELL="$FAKE_EXPECTED_LOGIN_SHELL"
+    fi
     old_zshrc="$(readlink "$HOME/.zshrc")"
     old_zshenv="$(readlink "$HOME/.zshenv")"
     "$repo/install.sh" apply --yes --repo "$repo" --config "$host" > "$TMPDIR/fresh.out"
@@ -361,6 +445,9 @@ pkgs.runCommand "check-bootstrap-${system}"
     "$repo/install.sh" apply --yes --repo "$repo" --config "$host" >/dev/null
     test "$(readlink "$complete_migration/backup/zshrc")" = "$old_zshrc"
     find "$XDG_STATE_HOME/atyrode/bootstrap/transactions" -name '*.complete' | grep -q .
+    test "$(cat "$BOOTSTRAP_ACCOUNT_SHELL_FILE")" = "$FAKE_EXPECTED_LOGIN_SHELL"
+    test "$(grep -Fxc -- "$FAKE_EXPECTED_LOGIN_SHELL" "$BOOTSTRAP_SHELLS_FILE")" = 1
+    unset SHELL
     if find "$XDG_STATE_HOME/atyrode/bootstrap" -name receipt.tsv \
       -exec grep -F "$HOME" {} + | grep -q .; then
       echo 'receipt exposed an absolute home path' >&2
@@ -370,6 +457,86 @@ pkgs.runCommand "check-bootstrap-${system}"
       -exec grep -Ei 'token|password|credential|github\.com' {} + | grep -q .; then
       echo 'receipt exposed credential-shaped or remote data' >&2
       exit 1
+    fi
+
+    # The conservative prerequisite marker is published before the completed
+    # activation receipt. An interruption after that receipt therefore cannot
+    # make an unverified login-shell transition look ready.
+    new_fixture login-shell-receipt-interruption
+    export PATH="$managed_tools:$base_path"
+    if BOOTSTRAP_FAILPOINT=after-login-shell-receipt \
+      "$repo/install.sh" apply --yes --repo "$repo" --config "$host" >/dev/null 2>&1; then
+      echo 'login-shell receipt failpoint unexpectedly succeeded' >&2
+      exit 1
+    fi
+    test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
+    test -f "$XDG_STATE_HOME/atyrode/bootstrap/login-shell.incomplete"
+    find "$XDG_STATE_HOME/atyrode/bootstrap/transactions" -name '*.complete' | grep -q .
+    "$repo/install.sh" verify --repo "$repo" --config "$host" >/dev/null
+    test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/login-shell.incomplete"
+
+    # Unsafe marker types are rejected before any managed evaluation or
+    # activation can begin.
+    new_fixture login-shell-marker-link
+    export PATH="$managed_tools:$base_path"
+    mkdir -p "$HOME/redirect" "$XDG_STATE_HOME/atyrode/bootstrap"
+    ln -s "$HOME/redirect" "$XDG_STATE_HOME/atyrode/bootstrap/login-shell.incomplete"
+    expect_failure "$repo/install.sh" apply --yes --repo "$repo" --config "$host"
+    test ! -e "$FAKE_LOG"
+
+    new_fixture login-shell-marker-directory
+    export PATH="$managed_tools:$base_path"
+    mkdir -p "$XDG_STATE_HOME/atyrode/bootstrap/login-shell.incomplete"
+    expect_failure "$repo/install.sh" apply --yes --repo "$repo" --config "$host"
+    test ! -e "$FAKE_LOG"
+
+    # Linux login-shell ownership is a separate, recoverable prerequisite. A
+    # privilege failure cannot roll back a completed Home Manager activation or
+    # masquerade as a successful system-boundary transition.
+    if [[ "$FAKE_SYSTEM" == *-linux ]]; then
+      new_fixture login-shell-privilege-failure
+      export PATH="$managed_tools:$base_path"
+      printf '/bin/bash\n' > "$BOOTSTRAP_ACCOUNT_SHELL_FILE"
+      : > "$BOOTSTRAP_SHELLS_FILE"
+      export FAKE_SUDO_FAIL=1
+      set +e
+      "$repo/install.sh" apply --yes --repo "$repo" --config "$host" \
+        > "$TMPDIR/login-shell-privilege.out" \
+        2> "$TMPDIR/login-shell-privilege.err"
+      login_shell_status="$?"
+      set -e
+      test "$login_shell_status" = 69
+      test "$(cat "$XDG_STATE_HOME/atyrode/dotfiles-config")" = "$host"
+      find "$XDG_STATE_HOME/atyrode/bootstrap/transactions" -name '*.complete' | grep -q .
+      test -f "$XDG_STATE_HOME/atyrode/bootstrap/login-shell.incomplete"
+      test "$(cat "$BOOTSTRAP_ACCOUNT_SHELL_FILE")" = /bin/bash
+      unset FAKE_SUDO_FAIL
+      "$repo/install.sh" apply --yes --repo "$repo" --config "$host" >/dev/null
+      test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/login-shell.incomplete"
+      test "$(cat "$BOOTSTRAP_ACCOUNT_SHELL_FILE")" = "$FAKE_EXPECTED_LOGIN_SHELL"
+      test "$(grep -Fxc -- "$FAKE_EXPECTED_LOGIN_SHELL" "$BOOTSTRAP_SHELLS_FILE")" = 1
+
+      # A chsh-specific failure has the same recovery contract after the shell
+      # has already been registered in /etc/shells.
+      new_fixture login-shell-chsh-failure
+      export PATH="$managed_tools:$base_path"
+      printf '/bin/bash\n' > "$BOOTSTRAP_ACCOUNT_SHELL_FILE"
+      export FAKE_CHSH_FAIL=1
+      set +e
+      "$repo/install.sh" apply --yes --repo "$repo" --config "$host" \
+        > "$TMPDIR/login-shell-chsh.out" \
+        2> "$TMPDIR/login-shell-chsh.err"
+      login_shell_status="$?"
+      set -e
+      test "$login_shell_status" = 69
+      test -f "$XDG_STATE_HOME/atyrode/bootstrap/login-shell.incomplete"
+      test "$(cat "$BOOTSTRAP_ACCOUNT_SHELL_FILE")" = /bin/bash
+      unset FAKE_CHSH_FAIL
+      "$repo/install.sh" verify --repo "$repo" --config "$host" >/dev/null 2>&1 && exit 1
+      "$repo/install.sh" apply --yes --repo "$repo" --config "$host" >/dev/null
+      test ! -e "$XDG_STATE_HOME/atyrode/bootstrap/login-shell.incomplete"
+      test "$(cat "$BOOTSTRAP_ACCOUNT_SHELL_FILE")" = "$FAKE_EXPECTED_LOGIN_SHELL"
+      test "$(grep -Fxc -- "$FAKE_EXPECTED_LOGIN_SHELL" "$BOOTSTRAP_SHELLS_FILE")" = 1
     fi
 
     # Failed activation restores exact pre-activation links and prior host state.
@@ -495,6 +662,23 @@ pkgs.runCommand "check-bootstrap-${system}"
     expect_failure "$repo/install.sh" rollback --yes --repo "$repo"
     test -d "$XDG_STATE_HOME/atyrode/bootstrap/apply.pending"
     test -d "$XDG_STATE_HOME/atyrode/bootstrap/migrations/migration-v1-shell-entrypoints.pending"
+
+    # Production migration ignores ambient failpoints; only the build-time
+    # test copy can simulate interruption.
+    export HOME="$TMPDIR/production-migration/home"
+    export XDG_STATE_HOME="$HOME/.local/state"
+    mkdir -p "$HOME"
+    fixture_name=production-migration
+    make_unmanaged_entrypoints
+    old_zshrc="$(readlink "$HOME/.zshrc")"
+    old_zshenv="$(readlink "$HOME/.zshenv")"
+    BOOTSTRAP_MIGRATION_FAILPOINT=after-zshrc \
+      bash "$production_migration" prepare >/dev/null
+    test ! -e "$HOME/.zshrc"
+    test ! -e "$HOME/.zshenv"
+    bash "$production_migration" rollback >/dev/null
+    test "$(readlink "$HOME/.zshrc")" = "$old_zshrc"
+    test "$(readlink "$HOME/.zshenv")" = "$old_zshenv"
 
     # Migration preparation resumes after an interruption. Rollback validates all
     # destinations first, so a collision cannot cause a partial restore.

--- a/checks/fixtures/nixos-server.nix
+++ b/checks/fixtures/nixos-server.nix
@@ -41,16 +41,19 @@ in
 
     modules = [
       dotfiles.nixosModules.dotfiles-home
-      {
+      ({ pkgs, ... }: {
         boot.isContainer = true;
         nixpkgs.hostPlatform = system;
         system.stateVersion = "26.05";
+
+        programs.zsh.enable = true;
 
         atyrode.dotfiles.hostRegistry = registry;
 
         users.users.${username} = {
           home = homeDirectory;
           isNormalUser = true;
+          shell = pkgs.zsh;
         };
 
         home-manager.users.${username} = {
@@ -68,7 +71,7 @@ in
             inherit homeDirectory username;
           };
         };
-      }
+      })
     ];
   };
 }

--- a/checks/portable-profiles.nix
+++ b/checks/portable-profiles.nix
@@ -98,6 +98,11 @@ assert lib.assertMsg (
 assert lib.assertMsg (
   fixtureIdentity.username == "fixture"
 ) "NixOS consumer identity did not retain its fixture user";
+assert lib.assertMsg externalConfig.config.programs.zsh.enable
+  "NixOS consumer must own system Zsh enablement";
+assert lib.assertMsg (
+  lib.getName externalConfig.config.users.users.fixture.shell == "zsh"
+) "NixOS consumer must own the account login shell";
 assert lib.assertMsg (
   !(selectionSucceeds [ "server" ] system)
 ) "a portable composition without base unexpectedly validated";

--- a/checks/system-boundary.nix
+++ b/checks/system-boundary.nix
@@ -1,0 +1,238 @@
+{
+  darwinConfigs ? { },
+  externalFixture ? null,
+  homeConfigs,
+  lib,
+  pkgs,
+  serverConfig ? null,
+  system,
+}:
+
+let
+  boundary = builtins.fromJSON (builtins.readFile ../inventory/system-boundary.json);
+  packageInventory = builtins.fromJSON (builtins.readFile ../inventory/packages.json);
+  darwinCasks = import ../darwin/casks.nix;
+  knownCapabilities = builtins.attrNames (import ../home/profiles);
+
+  sort = lib.sort builtins.lessThan;
+  normaliseHome = value: if value ? config then value.config else value;
+  normaliseDarwin = value: if value ? config then value.config else value;
+
+  configuredHomes = map normaliseHome (builtins.attrValues homeConfigs);
+  serverHomes = lib.optional (serverConfig != null) (normaliseHome serverConfig);
+  externalSystem = if externalFixture == null then null else externalFixture.configuration.config;
+  externalHomes = lib.optional (
+    externalFixture != null
+  ) externalSystem.home-manager.users.${externalFixture.host.username};
+  configuredDarwin = map normaliseDarwin (builtins.attrValues darwinConfigs);
+  darwinHomes = lib.concatMap (
+    config: builtins.attrValues config.home-manager.users
+  ) configuredDarwin;
+  darwinHomePackages = lib.unique (lib.concatMap packageNames darwinHomes);
+  portableHomes = configuredHomes ++ serverHomes ++ externalHomes ++ darwinHomes;
+
+  packageNames = config: lib.unique (map lib.getName (config.home.packages or [ ]));
+  hasCapability =
+    capability: config: builtins.elem capability (config.atyrode.capabilities.selected or [ ]);
+  hasAll = expected: actual: lib.all (package: builtins.elem package actual) expected;
+  noManagedShell = config: !((config.home.sessionVariables or { }) ? SHELL);
+  noClamAV = config: !(builtins.elem "clamav" (packageNames config));
+
+  capabilityOwners = [
+    "agent-tools"
+    "base"
+    "containers"
+    "desktop"
+    "development"
+    "media"
+    "mobile"
+    "security"
+  ];
+  specialOwners = [
+    "experimental"
+    "project"
+    "system"
+  ];
+  inventoryOwners = map (record: record.owner) packageInventory;
+  inventoryPackages = lib.concatMap (record: record.packages) packageInventory;
+  recordFor =
+    owner:
+    lib.findFirst (
+      record: record.owner == owner
+    ) (throw "missing package owner ${owner}") packageInventory;
+  packagesFor = owner: sort (recordFor owner).packages;
+  selectorsAreKnown =
+    record:
+    lib.all (selector: builtins.elem selector (knownCapabilities ++ [ "darwin" ])) record.selectedBy;
+  capabilityOwnershipIsDirect = owner: (recordFor owner).selectedBy == [ owner ];
+
+  expectedContainerPackages =
+    if lib.hasSuffix "-darwin" system then
+      [
+        "dive"
+        "orbstack"
+      ]
+    else
+      [
+        "dive"
+        "docker"
+        "docker-compose"
+      ];
+  forbiddenContainerPackages =
+    if lib.hasSuffix "-darwin" system then
+      [
+        "docker"
+        "docker-compose"
+      ]
+    else
+      [ "orbstack" ];
+  containerHomes = builtins.filter (hasCapability "containers") portableHomes;
+  containerHomeMatchesPolicy =
+    config:
+    let
+      actual = packageNames config;
+    in
+    hasAll expectedContainerPackages actual
+    && lib.intersectLists forbiddenContainerPackages actual == [ ];
+
+  expectedOrder = [
+    "login-shell"
+    "nix-daemon"
+    "nix-policy"
+    "container-engine"
+    "antivirus-data"
+    "device-permissions"
+    "homebrew-drift"
+  ];
+  officialCache = "https://cache.nixos.org/";
+  officialKey = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
+
+  darwinPolicyMatches =
+    config:
+    let
+      activation = config.system.activationScripts.postActivation.text;
+      shellPaths = map toString config.environment.shells;
+      configuredCasks = map (
+        cask: if builtins.isString cask then cask else cask.name
+      ) config.homebrew.casks;
+    in
+    config.programs.zsh.enable
+    && builtins.elem boundary.loginShell.darwinPath shellPaths
+    && config.users.users.${config.system.primaryUser}.shell == null
+    && !(builtins.elem config.system.primaryUser config.users.knownUsers)
+    && config.nix.settings.trusted-users == [ "root" ]
+    && config.nix.settings.substituters == [ officialCache ]
+    && config.nix.settings.trusted-public-keys == [ officialKey ]
+    && config.nix.settings.require-sigs
+    && config.nix.optimise.automatic
+    && config.launchd.daemons."nix-optimise".serviceConfig.Label == boundary.nix.darwinOptimiserLabel
+    && config.nix-homebrew.mutableTaps == false
+    && config.homebrew.global.autoUpdate == false
+    && config.homebrew.global.brewfile
+    && config.homebrew.onActivation.autoUpdate == false
+    && config.homebrew.onActivation.upgrade == false
+    && config.homebrew.onActivation.cleanup == "check"
+    && sort configuredCasks == sort darwinCasks
+    && lib.hasInfix "/usr/bin/dscl" activation
+    && lib.hasInfix "/run/current-system/sw/bin/zsh" activation
+    && lib.hasInfix "refusing to create" activation;
+in
+assert lib.assertMsg (boundary.schemaVersion == 1) "unknown system-boundary policy schema";
+assert lib.assertMsg (
+  boundary.checkOrder == expectedOrder
+) "system diagnostic order differs from the reviewed boundary";
+assert lib.assertMsg (
+  builtins.length boundary.checkOrder == builtins.length (lib.unique boundary.checkOrder)
+) "system diagnostic identifiers must be unique";
+assert lib.assertMsg (
+  boundary.loginShell.program == "zsh"
+  && boundary.loginShell.linuxPath == "$HOME/.nix-profile/bin/zsh"
+  && boundary.loginShell.darwinPath == "/run/current-system/sw/bin/zsh"
+  && boundary.loginShell.nixosPath == "/run/current-system/sw/bin/zsh"
+) "login-shell ownership paths differ from the reviewed boundary";
+assert lib.assertMsg (
+  boundary.nix.store == "daemon"
+  && boundary.nix.trustedUsers == [ "root" ]
+  && boundary.nix.substituter == officialCache
+  && boundary.nix.trustedPublicKey == officialKey
+) "Nix daemon, trust, or cache ownership differs from the reviewed boundary";
+assert lib.assertMsg (
+  boundary.containers.linux.requiredSecurityOption == "rootless"
+  && boundary.containers.linux.forbiddenGroups == [ "docker" ]
+  && boundary.containers.linux.socketTemplate == "/run/user/{uid}/docker.sock"
+  && boundary.containers.darwin.context == "orbstack"
+) "container-engine ownership differs from the reviewed boundary";
+assert lib.assertMsg (
+  boundary.antivirus.managed == false && boundary.antivirus.reason != ""
+) "antivirus must remain explicitly unmanaged until a host owns updates and scanning";
+assert lib.assertMsg (
+  boundary.android.acceptedAccessPolicies == [
+    "uaccess"
+    "reviewed-user-group"
+  ]
+  && boundary.android.ruleIdentification == "filename-mentions-android-or-adb"
+  &&
+    boundary.android.acceptedGroups == [
+      "adbusers"
+      "plugdev"
+    ]
+) "Android device-access policy differs from the reviewed boundary";
+assert lib.assertMsg (
+  boundary.homebrew.cleanup == "check"
+  &&
+    boundary.homebrew.forbiddenAutomaticModes == [
+      "uninstall"
+      "zap"
+    ]
+) "Homebrew cleanup must remain report-only and non-destructive";
+assert lib.assertMsg (
+  sort inventoryOwners == sort (capabilityOwners ++ specialOwners)
+) "the package inventory has missing, duplicate, or unknown owners";
+assert lib.assertMsg (
+  builtins.length inventoryPackages == builtins.length (lib.unique inventoryPackages)
+) "a package is assigned to more than one owner";
+assert lib.assertMsg (lib.all selectorsAreKnown packageInventory)
+  "the package inventory contains an unknown capability selector";
+assert lib.assertMsg (lib.all capabilityOwnershipIsDirect capabilityOwners)
+  "capability-owned packages must be selected directly by their owning capability";
+assert lib.assertMsg (
+  packagesFor "containers" == [
+    "dive"
+    "docker"
+    "docker-compose"
+    "orbstack"
+  ]
+) "container clients are not assigned coherently";
+assert lib.assertMsg (
+  packagesFor "security" == [
+    "nmap"
+    "socat"
+  ]
+) "the security capability must contain only the reviewed network diagnostics";
+assert lib.assertMsg (
+  !(builtins.elem "clamav" inventoryPackages)
+) "ClamAV must remain absent until signature updates and scanning have a system owner";
+assert lib.assertMsg (lib.all (
+  cask: builtins.elem cask inventoryPackages
+) darwinCasks) "a nix-darwin Homebrew cask is missing from the package ownership inventory";
+assert lib.assertMsg (
+  lib.intersectLists darwinCasks darwinHomePackages == [ ]
+) "a Homebrew-owned Darwin cask is also installed by Home Manager";
+assert lib.assertMsg (lib.all noManagedShell portableHomes)
+  "Home Manager must not override SHELL; the account database owns the login shell";
+assert lib.assertMsg (lib.all noClamAV portableHomes)
+  "a portable Home Manager configuration unexpectedly installs ClamAV";
+assert lib.assertMsg (lib.all containerHomeMatchesPolicy containerHomes)
+  "the containers capability does not match the platform-specific client policy";
+assert lib.assertMsg (
+  externalFixture == null || externalSystem.programs.zsh.enable
+) "the external NixOS consumer must own system Zsh enablement";
+assert lib.assertMsg (
+  externalFixture == null
+  || lib.getName externalSystem.users.users.${externalFixture.host.username}.shell == "zsh"
+) "the external NixOS consumer must own its account login shell";
+assert lib.assertMsg (lib.all darwinPolicyMatches configuredDarwin)
+  "nix-darwin shell, Nix daemon, or Homebrew policy differs from the reviewed boundary";
+pkgs.runCommand "check-system-boundary-${system}" { } ''
+  mkdir "$out"
+''

--- a/darwin/casks.nix
+++ b/darwin/casks.nix
@@ -1,0 +1,12 @@
+[
+  "arduino-ide"
+  "bitwarden"
+  "codex-app"
+  "display-pilot"
+  "discord"
+  "parsec"
+  "plugdata"
+  "sonos"
+  "steam"
+  "zen"
+]

--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -4,18 +4,65 @@
   homeModules,
   homebrew-cask,
   homebrew-core,
+  lib,
   pkgs,
   username,
   ...
 }:
 
+let
+  casks = import ./casks.nix;
+in
 {
   system = {
     primaryUser = username;
     stateVersion = 7;
   };
 
-  users.users.${username}.home = homeDirectory;
+  environment.shells = [ pkgs.zsh ];
+
+  programs.zsh.enable = true;
+
+  users.users.${username} = {
+    home = homeDirectory;
+  };
+
+  nix.settings = {
+    experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
+    require-sigs = true;
+    substituters = lib.mkForce [ "https://cache.nixos.org/" ];
+    trusted-public-keys = lib.mkForce [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+    ];
+    trusted-users = lib.mkForce [ "root" ];
+  };
+
+  nix.optimise.automatic = true;
+
+  system.activationScripts.postActivation.text = lib.mkAfter ''
+    shell_user=${lib.escapeShellArg username}
+    shell_record="/Users/$shell_user"
+    expected_shell=/run/current-system/sw/bin/zsh
+
+    if ! /usr/bin/dscl . -read "$shell_record" UniqueID >/dev/null 2>&1; then
+      echo "nix-darwin: primary user $shell_user does not exist; refusing to create it" >&2
+      exit 1
+    fi
+    current_shell="$(/usr/bin/dscl . -read "$shell_record" UserShell 2>/dev/null \
+      | /usr/bin/awk '{ print $2 }')"
+    if [ "$current_shell" != "$expected_shell" ]; then
+      /usr/bin/dscl . -create "$shell_record" UserShell "$expected_shell"
+    fi
+    current_shell="$(/usr/bin/dscl . -read "$shell_record" UserShell 2>/dev/null \
+      | /usr/bin/awk '{ print $2 }')"
+    if [ "$current_shell" != "$expected_shell" ]; then
+      echo "nix-darwin: failed to configure the login shell for $shell_user" >&2
+      exit 1
+    fi
+  '';
 
   home-manager = {
     useGlobalPkgs = true;
@@ -49,23 +96,17 @@
     enable = true;
     taps = builtins.attrNames config.nix-homebrew.taps;
 
-    casks = [
-      "arduino-ide"
-      "bitwarden"
-      "codex-app"
-      "display-pilot"
-      "discord"
-      "parsec"
-      "plugdata"
-      "sonos"
-      "steam"
-      "zen"
-    ];
+    inherit casks;
+
+    global = {
+      autoUpdate = false;
+      brewfile = true;
+    };
 
     onActivation = {
       autoUpdate = false;
       upgrade = false;
-      cleanup = "none";
+      cleanup = "check";
     };
   };
 }

--- a/docs/atyrode.md
+++ b/docs/atyrode.md
@@ -42,10 +42,16 @@ session variables and leaves full startup to `exec zsh -l` or a new terminal.
 atyrode capabilities list --json
 atyrode capabilities show alex-linux --json
 atyrode doctor host --json
+atyrode doctor system --json
 atyrode doctor tools --json
 ```
 
 Diagnostics use stable non-zero exits for invalid input, missing files or tools,
 identity mismatches, and activation failure. They do not expose credentials.
+`doctor system [HOST] [--json]` audits the boundary that package installation
+alone cannot satisfy: the real login shell, Nix daemon and trust policy,
+container engine, antivirus ownership, Android device policy, and Homebrew
+drift. Its stable check IDs, row schema, statuses, exits, and read-only probe
+contract are documented in [Home Manager and system boundary](system-boundary.md).
 The `workspace`, `agent`, `generations`, `rollback`, and `clean` namespaces are
 reserved for their owning follow-up issues and currently fail clearly.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -46,7 +46,9 @@ downloading an artifact, fetching Git, or moving a file.
 uses the packaged `atyrode apply` plan and activation, so the host registry and
 the `nh` backend remain the only activation contract. Flakes are enabled only
 through the process-scoped `NIX_CONFIG`; bootstrap does not append to a
-user-owned `nix.conf`.
+user-owned `nix.conf`. After the Home Manager transaction succeeds, bootstrap
+also verifies the system-owned login-shell prerequisite described in [Home
+Manager and system boundary](system-boundary.md).
 
 Use `--update` to explicitly fetch the verified origin and fast-forward main.
 If source changes, bootstrap re-enters the fetched `install.sh` before opening
@@ -99,6 +101,7 @@ Bootstrap state lives under:
 ```text
 ${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/bootstrap/
 ├── apply.pending/
+├── login-shell.incomplete
 ├── migrations/
 │   └── migration-v1-shell-entrypoints.{pending,complete,rolled-back}
 └── transactions/
@@ -146,6 +149,21 @@ This rollback restores bootstrap-owned filesystem moves and the active-host
 receipt. It does not uninstall Nix or roll back a successfully activated Nix or
 nix-darwin generation. Those are separate, explicit system operations.
 
+The login shell is deliberately outside the Home Manager transaction. On
+standalone Linux, bootstrap verifies the managed Zsh executable, registers it
+once in `/etc/shells` with explicit privilege, selects it with `chsh`, and
+reads the account database back. On macOS, nix-darwin owns the equivalent
+`UserShell` activation and bootstrap verifies its result. `$SHELL` is never
+accepted as proof because an inherited environment can be stale or forged.
+
+If this post-activation prerequisite cannot be completed, bootstrap returns
+`69` but leaves the successful Home Manager activation and completed receipt
+intact. It atomically publishes `login-shell.incomplete` before archiving the
+completed receipt, and clears it only after account-database verification, so
+an interruption cannot look like a fully ready machine. Fix the system
+prerequisite and run `./install.sh verify --config <host>`, or rerun `apply`
+with the required privilege. A passing verification removes the marker.
+
 ## Verification coverage
 
 `checks/bootstrap.nix` uses temporary homes and repositories. It covers a clean
@@ -154,5 +172,6 @@ wrong and rewritten origins, dirty/staged/non-main revisions, download and
 checksum failure, partial installer failure, activation and verification
 failure, interruption before and after transaction publication, resumable
 migration, collisions, corrupt and dual receipts, missing backups, symlinked
-state namespaces, rollback, receipt privacy, and idempotence. The same check
-runs natively in all four CI jobs.
+state namespaces, rollback, receipt privacy, login-shell marker interruption,
+unsafe marker types, privilege failure and recovery, production-only test-hook
+gating, and idempotence. The same check runs natively in all four CI jobs.

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -21,7 +21,8 @@ points; OMP and Codex profiles remain harness-specific mutable-state boundaries.
 - `media`: audio/video conversion and inspection.
 - `containers`: container clients and inspection tools; the daemon is
   system-owned.
-- `security`: declared scanning and network diagnostics.
+- `security`: network diagnostics. ClamAV is intentionally absent because no
+  registered host owns signature updates or a scanning workflow.
 - `server`: marks a Linux-only headless composition. The reviewed portable
   server selection combines it with `base` and `agent-tools`.
 
@@ -39,6 +40,8 @@ names.
 Production NixOS hosts do not belong in this registry. Their infrastructure
 flake supplies identity and system facts while importing the same capability
 modules through the [portable profile contract](portable-profiles.md).
+The full Home Manager, nix-darwin, and NixOS ownership matrix is documented in
+[Home Manager and system boundary](system-boundary.md).
 
 ## Adding a host
 

--- a/docs/package-ownership.md
+++ b/docs/package-ownership.md
@@ -17,7 +17,9 @@ from the server composition.
   mutable and harness-owned outside derivations.
 - `desktop`, `mobile`, `media`, `containers`, and `security` are explicit host
   capabilities. Container daemons and Homebrew application state remain
-  system-owned.
+  system-owned. The `security` capability contains network diagnostics; ClamAV
+  is intentionally unowned because there is no signature-update and scanning
+  workflow.
 - Python/Pillow/uv, Node/Bun/Deno, Go, Rust, and GCC are project-owned. A Nix
   project commits a dev shell and `.envrc`; other projects commit `mise.toml`
   plus their native manifest. Nix and mise must not own the same project runtime.
@@ -43,6 +45,11 @@ and #30; neither is pulled into the baseline for harness symmetry.
 
 `atyrode doctor tools --json` reports these versions, launch modes, paths,
 owners, and missing-capability remediation without reading authentication state.
+Package presence is separate from system readiness. `atyrode doctor system
+[HOST] [--json]` verifies the system-owned login shell, daemon policy,
+container engine, Android access policy, antivirus disposition, and Homebrew
+drift without changing them. See [Home Manager and system
+boundary](system-boundary.md).
 
 ## Closure review
 
@@ -68,7 +75,8 @@ delivers 36 top-level packages and measures 2,108,944,256 NAR bytes across 396
 store paths. Its enforced ceilings are 40 packages, 2,348,810,240 bytes, and 440
 paths. The profile deliberately excludes development, containers, security,
 media, mobile, and desktop capabilities; it therefore contains neither
-workstation language stacks nor Docker/ClamAV. The aarch64 ceilings are 40
+workstation language stacks, container clients, nor antivirus software. The
+aarch64 ceilings are 40
 packages, 2.5 GiB, and 500 paths and are enforced by the native CI runner. See
 [Portable Home Manager profiles](portable-profiles.md) for the manifest schema
 and pin/update workflow.

--- a/docs/portable-profiles.md
+++ b/docs/portable-profiles.md
@@ -8,8 +8,11 @@ configuration.
 The dependency is deliberately one-way: infrastructure pins this flake;
 dotfiles never imports the infrastructure repository. NixOS owns privileged
 filesystems, networking, the firewall, the Nix daemon, system services,
-container runtimes, backups, and production secrets. The consuming flake also
-owns hostnames, provider identifiers, user names, and home paths.
+container runtimes, account login shells, device rules, backups, and production
+secrets. The consuming flake also owns hostnames, provider identifiers, user
+names, and home paths. The cross-platform ownership matrix and readiness
+diagnostics are documented in [Home Manager and system
+boundary](system-boundary.md).
 
 ## Exported contract
 
@@ -72,13 +75,16 @@ example intentionally leaves every production system option in the consumer:
         system = host.system;
         modules = [
           dotfiles.nixosModules.dotfiles-home
-          {
+          ({ pkgs, ... }: {
             atyrode.dotfiles.hostRegistry.${hostId} = host;
 
             users.users.${host.username} = {
               isNormalUser = true;
               home = host.homeDirectory;
+              shell = pkgs.zsh;
             };
+
+            programs.zsh.enable = true;
 
             home-manager.users.${host.username} = {
               imports = [
@@ -95,8 +101,9 @@ example intentionally leaves every production system option in the consumer:
               };
             };
 
-            # networking, filesystems, services, secrets, and backups live here
-          }
+            # Nix daemon policy, networking, filesystems, services, device
+            # rules, container engines, secrets, and backups live here.
+          })
         ];
       };
     };

--- a/docs/system-boundary.md
+++ b/docs/system-boundary.md
@@ -1,0 +1,146 @@
+# Home Manager and system boundary
+
+Home Manager owns the portable user environment in this repository. It can
+install a client or shell and configure files below the user's home directory;
+it cannot make an account database, daemon, device rule, privileged group, or
+native package manager operational. Those prerequisites belong to the system
+layer and are checked separately.
+
+## Ownership matrix
+
+| Concern | Standalone Home Manager on Linux | Home Manager through nix-darwin | Home Manager imported by NixOS |
+|---|---|---|---|
+| User packages and dotfiles | Home Manager | Home Manager | Home Manager |
+| Zsh startup, Git, CLI and agent configuration | Home Manager | Home Manager | Home Manager |
+| Home Manager generations | Home Manager | Home Manager inside the Darwin generation | Home Manager inside the NixOS generation |
+| Account and login-shell selection | Bootstrap registers `$HOME/.nix-profile/bin/zsh` in `/etc/shells` and selects it with `chsh` using explicit privilege | nix-darwin registers Zsh and sets the existing primary user's `UserShell` to `/run/current-system/sw/bin/zsh` during activation | The consuming infrastructure enables Zsh and sets `users.users.<name>.shell` |
+| Nix daemon, store and service lifecycle | The system-wide Nix installation | nix-darwin | The consuming NixOS infrastructure |
+| Nix trust, cache and optimisation policy | System Nix configuration; never a Home Manager `nix.conf` override | nix-darwin | The consuming NixOS infrastructure |
+| Container engine and privileged access | System/operator, using a rootless per-user engine | OrbStack runtime state, outside Home Manager | The consuming infrastructure |
+| Android device access | System-owned udev policy | macOS per-device USB authorization | The consuming infrastructure's udev policy |
+| Antivirus signatures and scanning | Unmanaged; ClamAV is intentionally absent | Unmanaged; ClamAV is intentionally absent | An infrastructure concern if the host elects to provide it |
+| Homebrew installation and declared casks | Not applicable | nix-homebrew and nix-darwin; Homebrew retains native mutable state | Not applicable |
+| Filesystems, networking, firewall, SSH, services, logging, updates, monitoring, backups and secrets | Operating system/operator | Operating system and nix-darwin where declared | The consuming infrastructure |
+
+The NixOS relationship is one-way: infrastructure pins this flake and imports
+its Home Manager profiles. Dotfiles do not import infrastructure or acquire
+production identity, disks, services, or secrets. See [Portable Home Manager
+profiles](portable-profiles.md).
+
+## Installed is not operational
+
+Package presence proves only that a program can be invoked. Operational
+readiness also depends on state that Home Manager must not silently create:
+
+- Zsh can be installed while the real account database still selects Bash, or
+  while the managed path is missing from `/etc/shells`.
+- The Docker client can be installed while no engine is reachable. On Linux,
+  readiness means a rootless engine at `/run/user/<uid>/docker.sock`; membership
+  in the root-equivalent `docker` group is forbidden. On macOS, readiness means
+  the explicit `orbstack` Docker context is available.
+- `adb` can be installed while Linux USB access has no suitable udev rule.
+  Readiness requires an Android/ADB-identified vendor rule using `uaccess`, or
+  a reviewed `adbusers` or `plugdev` group rule whose group the user actually
+  belongs to. On macOS the
+  check proves ADB is installed; macOS still grants device authorization at
+  connection time, so it does not claim that a particular device is trusted.
+- The Nix CLI can run while the daemon is unreachable or its effective trust
+  and cache settings differ from policy.
+- Declared Homebrew casks can be present while additional, undeclared Homebrew
+  state has drifted outside the generated Brewfile.
+
+ClamAV was removed rather than treated as ready merely because its executable
+was installed. No registered host owns signature updates, scheduled scans,
+quarantine, or alert handling. The `security` capability therefore provides
+network diagnostics (`nmap` and `socat`), not an implied antivirus service.
+The doctor only checks for binary presence; it never executes ClamAV or updates
+signatures. A leftover binary is `incomplete` unmanaged drift until removed or
+backed by a separately reviewed system policy.
+
+## System diagnostics
+
+Run the read-only readiness audit for the active host, or name a registered
+host explicitly:
+
+```sh
+atyrode doctor system
+atyrode doctor system alex-x86_64-linux-desktop
+atyrode doctor system alex-aarch64-darwin --json
+```
+
+The checks always appear in this order:
+
+| Check ID | What it establishes |
+|---|---|
+| `login-shell` | The real account database selects the expected executable Zsh path and that path is listed as an allowed shell. |
+| `nix-daemon` | The system-owned daemon store is reachable. |
+| `nix-policy` | Trusted users are exactly `root`, only the official signed cache and key are configured, signatures are required, and the nix-darwin optimiser is scheduled on macOS. |
+| `container-engine` | The selected container engine is reachable without Docker-group membership, or the capability is not selected. |
+| `antivirus-data` | Verifies ClamAV binaries are absent while no host owns signatures/scanning; an unmanaged binary is drift. |
+| `device-permissions` | Android access policy is ready, or the `mobile` capability is not selected. |
+| `homebrew-drift` | The generated nix-darwin Brewfile matches Homebrew state, or Homebrew does not apply. |
+
+Each row has a stable `id`, `owner`, `required`, `status`, `code`, `summary`,
+`remediation`, `expected`, and `actual` shape. Status is one of:
+
+- `ok`: the applicable readiness contract is satisfied;
+- `incomplete`: installed capability or required system policy is not ready;
+- `not-applicable`: the platform/capability does not require the check, or a
+  deliberately unmanaged feature such as antivirus is being recorded.
+
+JSON output has `schemaVersion: 1`, the canonical host, platform, system,
+capabilities, ordered `checks`, an aggregate `ok`, and
+`mutationBoundary: "read-only probes"`. It reports booleans and policy results
+instead of raw Nix configuration values, so cache URLs containing credentials
+cannot leak through the diagnostic.
+
+The command exits `0` when no check is incomplete, `69` when remediation is
+needed, `64` for invalid invocation, and `65` for an unknown or mismatched host
+identity. Internal policy/schema failures use `70`.
+
+Diagnostics do not start or restart services, change shells or groups, install
+udev rules, update antivirus data, start ADB, or remove Homebrew packages. In
+particular, the Android probe does not run `adb devices`, which could start a
+daemon and create authentication state. The Homebrew probe runs `brew bundle
+check` plus generated `brew bundle cleanup` in check mode, with standard input
+closed and without `--force` or `--zap`; missing and extra state must be
+reviewed and either declared or removed manually.
+
+## Login-shell activation and recovery
+
+Home Manager owns Zsh configuration but not the account's login-shell field.
+The bootstrap closes that prerequisite after a successful Home Manager
+transaction:
+
+- Linux verifies `$HOME/.nix-profile/bin/zsh`, adds it to `/etc/shells` once,
+  uses explicit root or `sudo` privilege for `chsh`, and then reads the account
+  database back. It never treats the inherited `$SHELL` environment variable
+  as proof.
+- nix-darwin declares the system Zsh path and updates only the already-existing
+  primary user's `UserShell`. Activation refuses to invent a missing user.
+- NixOS consumers own both `programs.zsh.enable` and the user's system shell in
+  their infrastructure configuration.
+
+If this final prerequisite fails, the already-successful Home Manager
+activation remains complete. Bootstrap returns `69` and writes
+`${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/bootstrap/login-shell.incomplete`
+as a recoverable, non-secret marker; it does not mislabel the activation as
+failed or roll it back. Repair the reported system prerequisite and run
+`./install.sh verify --config <host>`, or rerun `apply` with the needed
+privilege. Successful verification removes the marker.
+
+## Platform policy details
+
+The reviewed Nix policy is deliberately narrow: the daemon store is
+system-owned, trusted users are exactly `root`, the official Nix cache and its
+official signing key are the only configured binary cache, and signatures are
+required. nix-darwin also schedules store optimisation. Linux Home Manager
+does not pretend to own those settings; standalone Linux repairs belong to the
+system Nix installation, and NixOS repairs belong to the consuming
+infrastructure.
+
+On macOS, nix-darwin owns the immutable list of Homebrew taps and casks and
+uses `cleanup = "check"` with automatic update and upgrade disabled. This
+makes drift visible without automatically uninstalling operator-owned software.
+Homebrew's cellar and application state remain native mutable state rather than
+Nix store content.

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
         "vscode"
         "whatsapp-for-mac"
       ];
+      homebrewCasks = import ./darwin/casks.nix;
 
       rawCapabilityModules = import ./home/profiles;
 
@@ -252,6 +253,7 @@
             omp-configured = final.callPackage ./pkgs/omp-configured { };
             atyrode = final.callPackage ./pkgs/atyrode {
               capabilities = knownCapabilities;
+              inherit homebrewCasks;
               hostRegistry = publicRegistry;
             };
           })
@@ -467,6 +469,39 @@
               }
             else
               null;
+          systemDoctorAtyrode = pkgs.atyrode.override {
+            enableTestHooks = true;
+            hostRegistry = publicHosts // {
+              fixture-server = {
+                id = "fixture-server";
+                aliases = [ ];
+                capabilities = [
+                  "base"
+                  "server"
+                ];
+                dotfilesDirectory = "/home/fixture/nix-dotfiles";
+                homeDirectory = "/home/fixture";
+                hostname = null;
+                platform = "linux";
+                system = "x86_64-linux";
+                username = "fixture";
+              };
+              fixture-security = {
+                id = "fixture-security";
+                aliases = [ ];
+                capabilities = [
+                  "base"
+                  "security"
+                ];
+                dotfilesDirectory = "/home/fixture/nix-dotfiles";
+                homeDirectory = "/home/fixture";
+                hostname = null;
+                platform = "linux";
+                system = "x86_64-linux";
+                username = "fixture";
+              };
+            };
+          };
           systemHomeConfigs = lib.filterAttrs (
             name: _config: hosts.${name}.system == system
           ) canonicalHomeConfigs;
@@ -521,7 +556,19 @@
         in
         import ./checks/agent-tools.nix { inherit lib pkgs; }
         // {
-          atyrode-cli = import ./checks/atyrode-cli.nix { inherit pkgs; };
+          atyrode-cli = import ./checks/atyrode-cli.nix {
+            inherit pkgs;
+            atyrode = systemDoctorAtyrode;
+            productionAtyrode = pkgs.atyrode;
+            productionHost =
+              {
+                "aarch64-darwin" = "alex-aarch64-darwin";
+                "x86_64-darwin" = "alex-x86_64-darwin";
+                "aarch64-linux" = "alex-aarch64-linux";
+                "x86_64-linux" = "alex-x86_64-linux";
+              }
+              .${system};
+          };
           bootstrap = import ./checks/bootstrap.nix { inherit pkgs; };
           codex-use = import ./checks/codex-use.nix {
             inherit lib pkgs;
@@ -536,6 +583,13 @@
           shell-surface = import ./checks/shell-surface.nix {
             inherit lib pkgs;
             hostConfigs = canonicalHomeConfigs;
+          };
+          system-boundary = import ./checks/system-boundary.nix {
+            inherit lib pkgs system;
+            homeConfigs = systemHomeConfigs;
+            serverConfig = if isLinux then serverHomeConfig.config else null;
+            externalFixture = if isLinux then externalServerFixture else null;
+            darwinConfigs = systemDarwinConfigs;
           };
         }
         // lib.optionalAttrs isLinux {

--- a/home/profiles/containers.nix
+++ b/home/profiles/containers.nix
@@ -1,7 +1,8 @@
 { lib, pkgs, ... }:
 {
   # This capability installs clients and inspection tools only. Daemon and
-  # desktop-engine ownership remains with the system/desktop layers.
+  # rootless-engine ownership remains with the system layer on Linux. OrbStack
+  # is the selected Darwin engine and retains its own runtime state.
   home.packages = [
     pkgs.dive
   ]
@@ -11,5 +12,6 @@
       docker
       docker-compose
     ]
-  );
+  )
+  ++ lib.optionals pkgs.stdenv.isDarwin [ pkgs.orbstack ];
 }

--- a/home/profiles/desktop.nix
+++ b/home/profiles/desktop.nix
@@ -17,7 +17,6 @@ in
       chatgpt
       godot
       obsidian
-      orbstack
       postman
       prismlauncher
       reaper

--- a/home/profiles/security.nix
+++ b/home/profiles/security.nix
@@ -1,7 +1,8 @@
 { pkgs, ... }:
 {
+  # Antivirus requires system-owned signature updates and a scanning workflow.
+  # No registered host has that policy, so ClamAV is intentionally absent.
   home.packages = with pkgs; [
-    clamav
     nmap
     socat
   ];

--- a/home/zsh.nix
+++ b/home/zsh.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ ... }:
 
 {
   programs.zsh = {
@@ -20,6 +20,4 @@
       source ${./shell/startup.zsh}
     '';
   };
-
-  home.sessionVariables.SHELL = "${pkgs.zsh}/bin/zsh";
 }

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ readonly REPO_HTTPS_URL="https://github.com/atyrode/dotfiles.git"
 readonly REPO_SSH_URL="git@github.com:atyrode/dotfiles.git"
 readonly NIX_VERSION="2.34.7"
 readonly BOOTSTRAP_SCHEMA="1"
+readonly BOOTSTRAP_TEST_HOOKS=0
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 COMMAND="${1:-}"
@@ -110,7 +111,7 @@ select_nix_artifact() {
 source_nix() {
   local profile=""
 
-  if [[ "${BOOTSTRAP_NIX_PROFILE_SCRIPT+x}" == x ]]; then
+  if [[ "$BOOTSTRAP_TEST_HOOKS" == 1 && "${BOOTSTRAP_NIX_PROFILE_SCRIPT+x}" == x ]]; then
     profile="${BOOTSTRAP_NIX_PROFILE_SCRIPT:-}"
   elif [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
     profile="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
@@ -266,6 +267,12 @@ print_plan() {
   printf '  %s. Activate %s through atyrode/nh.\n' "$step" "$FLAKE_CONFIG"
   step=$((step + 1))
   printf '  %s. Verify host state and complete the migration and bootstrap receipts.\n' "$step"
+  step=$((step + 1))
+  if [[ "$SYSTEM" == *-darwin ]]; then
+    printf '  %s. Verify nix-darwin configured the real account login shell.\n' "$step"
+  else
+    printf '  %s. Register and select the managed Zsh login shell with explicit privilege, then verify the account database.\n' "$step"
+  fi
   printf '\nNo changes were made. apply will show this plan again before confirmation.\n'
 }
 
@@ -309,6 +316,19 @@ ensure_safe_state_root() {
   chmod 700 "$root" "$transactions"
 }
 
+ensure_safe_login_shell_marker() {
+  local marker
+
+  marker="$(bootstrap_state_root)/login-shell.incomplete"
+  if [[ -L "$marker" ]]; then
+    die "unsafe login-shell prerequisite marker"
+  elif [[ -f "$marker" || ! -e "$marker" ]]; then
+    return
+  else
+    die "login-shell prerequisite marker has an unsupported type"
+  fi
+}
+
 append_transaction() {
   [[ $# -eq 2 ]] || die "internal receipt error"
   printf '%s\t%s\n' "$1" "$2" >> "$TRANSACTION/receipt.tsv"
@@ -348,6 +368,7 @@ begin_transaction() {
   fi
 
   ensure_safe_state_root "$root"
+  ensure_safe_login_shell_marker
   archive_abandoned_transactions "$root"
   pending="$root/apply.pending"
   [[ ! -e "$pending" && ! -L "$pending" ]] ||
@@ -382,7 +403,7 @@ begin_transaction() {
     chmod 600 "$TRANSACTION/backup/dotfiles-config"
   fi
   append_transaction state-before "$state_status"
-  if [[ "${BOOTSTRAP_FAILPOINT:-}" == before-transaction-publish ]]; then
+  if [[ "$BOOTSTRAP_TEST_HOOKS" == 1 && "${BOOTSTRAP_FAILPOINT:-}" == before-transaction-publish ]]; then
     printf 'bootstrap: interrupted at test failpoint before-transaction-publish\n' >&2
     exit 75
   fi
@@ -660,6 +681,118 @@ verify_installation() {
   printf 'Verification passed for %s on %s\n' "$FLAKE_CONFIG" "$SYSTEM"
 }
 
+account_login_shell() {
+  local user="$1"
+  local fixture=""
+
+  if [[ "$BOOTSTRAP_TEST_HOOKS" == 1 && -n "${BOOTSTRAP_ACCOUNT_SHELL_FILE:-}" ]]; then
+    fixture="$BOOTSTRAP_ACCOUNT_SHELL_FILE"
+  fi
+
+  if [[ -n "$fixture" ]]; then
+    [[ -f "$fixture" && ! -L "$fixture" ]] || return 1
+    cat "$fixture"
+  elif command_exists getent; then
+    getent passwd "$user" 2>/dev/null | awk -F: 'NR == 1 { print $7 }'
+  else
+    return 1
+  fi
+}
+
+run_privileged() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  elif command_exists sudo; then
+    sudo -- "$@"
+  else
+    printf 'bootstrap: system prerequisite incomplete: sudo is required to configure the Linux login shell\n' >&2
+    return 1
+  fi
+}
+
+configure_linux_login_shell() {
+  local user target shells_file current
+
+  [[ "$SYSTEM" == *-linux ]] || return 0
+  user="$(id -un)"
+  target="$HOME/.nix-profile/bin/zsh"
+  shells_file=/etc/shells
+  if [[ "$BOOTSTRAP_TEST_HOOKS" == 1 && -n "${BOOTSTRAP_SHELLS_FILE:-}" ]]; then
+    shells_file="$BOOTSTRAP_SHELLS_FILE"
+  fi
+  [[ -x "$target" ]] || {
+    printf 'bootstrap: system prerequisite incomplete: managed Zsh is not executable at %s\n' "$target" >&2
+    return 1
+  }
+  [[ -f "$shells_file" && ! -L "$shells_file" ]] || {
+    printf 'bootstrap: system prerequisite incomplete: %s must be a regular file\n' "$shells_file" >&2
+    return 1
+  }
+  if ! grep -Fqx -- "$target" "$shells_file"; then
+    # shellcheck disable=SC2016 # Positional parameters expand in the privileged shell.
+    run_privileged sh -c \
+      'grep -Fqx -- "$1" "$2" || printf "%s\n" "$1" >> "$2"' \
+      sh "$target" "$shells_file" || {
+        printf 'bootstrap: system prerequisite incomplete: could not register managed Zsh in %s\n' \
+          "$shells_file" >&2
+        return 1
+      }
+  fi
+  current="$(account_login_shell "$user" || true)"
+  if [[ "$current" != "$target" ]]; then
+    command_exists chsh || {
+      printf 'bootstrap: system prerequisite incomplete: chsh is unavailable\n' >&2
+      return 1
+    }
+    run_privileged chsh -s "$target" "$user" || {
+      printf 'bootstrap: system prerequisite incomplete: chsh could not update the account database\n' >&2
+      return 1
+    }
+  fi
+  current="$(account_login_shell "$user" || true)"
+  [[ "$current" == "$target" ]] || {
+    printf 'bootstrap: system prerequisite incomplete: account login shell remains %s\n' \
+      "${current:-unknown}" >&2
+    return 1
+  }
+}
+
+mark_login_shell_incomplete() {
+  local root temporary marker
+
+  root="$(bootstrap_state_root)"
+  marker="$root/login-shell.incomplete"
+  ensure_safe_login_shell_marker
+  temporary="$(mktemp "$root/.login-shell.incomplete.XXXXXX")"
+  {
+    printf 'version\t1\n'
+    printf 'status\tincomplete\n'
+    printf 'owner\tsystem-prerequisite\n'
+  } > "$temporary"
+  chmod 600 "$temporary"
+  mv "$temporary" "$marker"
+}
+
+clear_login_shell_incomplete() {
+  local marker
+
+  marker="$(bootstrap_state_root)/login-shell.incomplete"
+  ensure_safe_login_shell_marker
+  if [[ -f "$marker" ]]; then
+    rm "$marker"
+  fi
+}
+
+verify_system_login_shell() {
+  local diagnostics
+
+  diagnostics="$(run_atyrode doctor system "$FLAKE_CONFIG" 2>/dev/null || true)"
+  if ! grep -q '^login-shell: ok ' <<<"$diagnostics"; then
+    printf 'bootstrap: system prerequisite incomplete: atyrode could not verify the real account login shell\n' >&2
+    return 1
+  fi
+}
+
 apply_configuration() {
   local migration_status
 
@@ -701,7 +834,7 @@ apply_configuration() {
   append_transaction phase preparing-migration
   migration_command prepare
 
-  if [[ "${BOOTSTRAP_FAILPOINT:-}" == after-migration-prepare ]]; then
+  if [[ "$BOOTSTRAP_TEST_HOOKS" == 1 && "${BOOTSTRAP_FAILPOINT:-}" == after-migration-prepare ]]; then
     printf 'bootstrap: interrupted at test failpoint after-migration-prepare\n' >&2
     exit 75
   fi
@@ -716,9 +849,23 @@ apply_configuration() {
   append_transaction phase verifying
   verify_installation
   trap - ERR INT TERM
+  mark_login_shell_incomplete
   finish_transaction complete
 
-  printf '\nBootstrap complete. Start the managed login shell with: exec zsh -l\n'
+  if [[ "$BOOTSTRAP_TEST_HOOKS" == 1 && "${BOOTSTRAP_FAILPOINT:-}" == after-login-shell-receipt ]]; then
+    printf 'bootstrap: interrupted at test failpoint after-login-shell-receipt\n' >&2
+    exit 75
+  fi
+
+  if ! configure_linux_login_shell || ! verify_system_login_shell; then
+    printf 'Home Manager activation completed, but the login-shell system prerequisite is incomplete.\n' >&2
+    printf 'Fix the reported system boundary and run ./install.sh verify --config %s.\n' \
+      "$FLAKE_CONFIG" >&2
+    return 69
+  fi
+  clear_login_shell_incomplete
+
+  printf '\nBootstrap complete. Open a new terminal or run: exec zsh -l\n'
 }
 
 rollback_interrupted() {
@@ -764,7 +911,13 @@ case "$COMMAND" in
   preflight) preflight ;;
   plan) preflight; print_plan ;;
   apply) apply_configuration ;;
-  verify) preflight; enable_flakes_for_process; verify_installation ;;
+  verify)
+    preflight
+    enable_flakes_for_process
+    verify_installation
+    verify_system_login_shell || die "login-shell system prerequisite is incomplete"
+    clear_login_shell_incomplete
+    ;;
   rollback) rollback_interrupted ;;
   -h|--help|help) usage ;;
   '') usage >&2; exit 64 ;;

--- a/inventory/packages.json
+++ b/inventory/packages.json
@@ -37,7 +37,7 @@
     "versionOwner": "pinned nixpkgs",
     "mutableState": "application-owned user data and caches",
     "closureClass": "very-large",
-    "packages": ["arduino-ide", "chatgpt", "ghostty-bin", "godot", "lichess", "obsidian", "orbstack", "parsec-bin", "plugdata", "postman", "prismlauncher", "reaper", "signal-desktop", "spotify", "steam", "steamcmd", "vital", "vlc", "vlc-bin", "vscode", "whatsapp-for-mac"]
+    "packages": ["arduino-ide", "chatgpt", "ghostty-bin", "godot", "lichess", "obsidian", "parsec-bin", "plugdata", "postman", "prismlauncher", "reaper", "signal-desktop", "spotify", "steam", "steamcmd", "vital", "vlc", "vlc-bin", "vscode", "whatsapp-for-mac"]
   },
   {
     "owner": "mobile",
@@ -67,17 +67,17 @@
     "versionOwner": "pinned nixpkgs",
     "mutableState": "daemon-owned images and volumes outside Home Manager",
     "closureClass": "medium",
-    "packages": ["dive", "docker", "docker-compose"]
+    "packages": ["dive", "docker", "docker-compose", "orbstack"]
   },
   {
     "owner": "security",
     "deliveryLayer": "home-manager",
     "selectedBy": ["security"],
-    "consumer": "declared server diagnostics and scanning",
+    "consumer": "declared network diagnostics",
     "versionOwner": "pinned nixpkgs",
-    "mutableState": "ClamAV signatures and tool caches",
-    "closureClass": "large",
-    "packages": ["clamav", "nmap", "socat"]
+    "mutableState": "tool-specific caches only",
+    "closureClass": "small",
+    "packages": ["nmap", "socat"]
   },
   {
     "owner": "project",

--- a/inventory/system-boundary.json
+++ b/inventory/system-boundary.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 1,
+  "checkOrder": [
+    "login-shell",
+    "nix-daemon",
+    "nix-policy",
+    "container-engine",
+    "antivirus-data",
+    "device-permissions",
+    "homebrew-drift"
+  ],
+  "loginShell": {
+    "program": "zsh",
+    "linuxPath": "$HOME/.nix-profile/bin/zsh",
+    "darwinPath": "/run/current-system/sw/bin/zsh",
+    "nixosPath": "/run/current-system/sw/bin/zsh"
+  },
+  "nix": {
+    "store": "daemon",
+    "trustedUsers": ["root"],
+    "substituter": "https://cache.nixos.org/",
+    "trustedPublicKey": "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=",
+    "darwinOptimiserLabel": "org.nixos.nix-optimise"
+  },
+  "containers": {
+    "linux": {
+      "socketTemplate": "/run/user/{uid}/docker.sock",
+      "requiredSecurityOption": "rootless",
+      "forbiddenGroups": ["docker"]
+    },
+    "darwin": {
+      "context": "orbstack"
+    }
+  },
+  "antivirus": {
+    "managed": false,
+    "reason": "No registered host owns signature updates and a scanning workflow."
+  },
+  "android": {
+    "linuxRuleRoots": [
+      "/etc/udev/rules.d",
+      "/run/udev/rules.d",
+      "/usr/lib/udev/rules.d",
+      "/lib/udev/rules.d"
+    ],
+    "acceptedAccessPolicies": ["uaccess", "reviewed-user-group"],
+    "ruleIdentification": "filename-mentions-android-or-adb",
+    "acceptedGroups": ["adbusers", "plugdev"]
+  },
+  "homebrew": {
+    "cleanup": "check",
+    "forbiddenAutomaticModes": ["uninstall", "zap"]
+  }
+}

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -4,6 +4,10 @@ set -euo pipefail
 
 readonly registry='@registry@'
 readonly capability_inventory='@capabilities@'
+readonly homebrew_brewfile='@homebrew_brewfile@'
+readonly homebrew_cask_inventory='@homebrew_casks@'
+readonly system_policy='@system_policy@'
+readonly test_hooks='@test_hooks@'
 readonly tool_inventory='@tools@'
 readonly EX_USAGE=64 EX_DATAERR=65 EX_NOINPUT=66 EX_UNAVAILABLE=69 EX_SOFTWARE=70
 
@@ -21,6 +25,7 @@ Usage:
   atyrode capabilities list [--json]
   atyrode capabilities show [HOST] [--json]
   atyrode doctor host [HOST] [--json]
+  atyrode doctor system [HOST] [--json]
   atyrode doctor tools [--json]
   atyrode host [HOST] [--json]
 
@@ -31,7 +36,7 @@ EOF
 }
 
 actual_system() {
-  if [[ -n "${_ATYRODE_TEST_SYSTEM:-}" ]]; then
+  if [[ "$test_hooks" == 1 && -n "${_ATYRODE_TEST_SYSTEM:-}" ]]; then
     printf '%s\n' "$_ATYRODE_TEST_SYSTEM"
     return
   fi
@@ -45,11 +50,15 @@ actual_system() {
 }
 
 actual_user() {
-  printf '%s\n' "${_ATYRODE_TEST_USER:-$(id -un)}"
+  if [[ "$test_hooks" == 1 && -n "${_ATYRODE_TEST_USER:-}" ]]; then
+    printf '%s\n' "$_ATYRODE_TEST_USER"
+  else
+    id -un
+  fi
 }
 
 actual_hostname() {
-  if [[ -n "${_ATYRODE_TEST_HOSTNAME:-}" ]]; then
+  if [[ "$test_hooks" == 1 && -n "${_ATYRODE_TEST_HOSTNAME:-}" ]]; then
     printf '%s\n' "$_ATYRODE_TEST_HOSTNAME"
   else
     hostname -s 2>/dev/null || hostname
@@ -163,6 +172,506 @@ doctor_tools() {
   jq -e 'all(.[]; (.expected | not) or .status == "ok")' <<<"$rows" >/dev/null
 }
 
+system_checks='[]'
+system_fixture='{}'
+
+system_check_add() {
+  local id="$1" owner="$2" required="$3" status="$4" code="$5"
+  local summary="$6" remediation="$7" expected="$8" actual="$9"
+
+  system_checks="$(jq -c \
+    --arg id "$id" \
+    --arg owner "$owner" \
+    --argjson required "$required" \
+    --arg status "$status" \
+    --arg code "$code" \
+    --arg summary "$summary" \
+    --arg remediation "$remediation" \
+    --argjson expected "$expected" \
+    --argjson actual "$actual" \
+    '. + [{
+      id: $id,
+      owner: $owner,
+      required: $required,
+      status: $status,
+      code: (if $code == "" then null else $code end),
+      summary: $summary,
+      remediation: (if $remediation == "" then null else $remediation end),
+      expected: $expected,
+      actual: $actual
+    }]' <<<"$system_checks")"
+}
+
+load_system_fixture() {
+  local fixture_path="${_ATYRODE_TEST_SYSTEM_FIXTURE:-}"
+
+  if [[ "$test_hooks" != 1 || -z "$fixture_path" ]]; then
+    printf '{}\n'
+    return
+  fi
+  [[ -f "$fixture_path" && ! -L "$fixture_path" ]] ||
+    die "$EX_DATAERR" "system diagnostic fixture must be a regular file"
+  jq -ec 'select(type == "object")' "$fixture_path" ||
+    die "$EX_DATAERR" "system diagnostic fixture is not a JSON object"
+}
+
+has_system_fixture() {
+  [[ "$system_fixture" != '{}' ]]
+}
+
+has_capability() {
+  local data="$1" capability="$2"
+  jq -e --arg capability "$capability" '.capabilities | index($capability)' <<<"$data" >/dev/null
+}
+
+nix_system_owner() {
+  local data="$1" platform="$2"
+
+  if [[ "$platform" == darwin ]]; then
+    printf 'nix-darwin\n'
+  elif has_capability "$data" server; then
+    printf 'nixos\n'
+  else
+    printf 'system\n'
+  fi
+}
+
+portable_system_owner() {
+  local data="$1"
+
+  if has_capability "$data" server; then
+    printf 'nixos\n'
+  else
+    printf 'system\n'
+  fi
+}
+
+word_in_list() {
+  local needle="$1" words="$2"
+  case " $words " in
+    *" $needle "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+probe_login_shell() {
+  local data="$1" platform="$2" user="$3"
+  local owner expected current="" executable=false listed=false status code summary remediation
+  local expected_json actual_json
+
+  if [[ "$platform" == darwin ]]; then
+    owner=nix-darwin
+    expected="$(jq -r '.loginShell.darwinPath' "$system_policy")"
+  elif has_capability "$data" server; then
+    owner=nixos
+    expected="$(jq -r '.loginShell.nixosPath' "$system_policy")"
+  else
+    owner=bootstrap
+    expected="$HOME/.nix-profile/bin/zsh"
+  fi
+
+  if has_system_fixture; then
+    current="$(jq -r '.loginShell.path // empty' <<<"$system_fixture")"
+    executable="$(jq -r '.loginShell.executable // false' <<<"$system_fixture")"
+    listed="$(jq -r '.loginShell.listed // false' <<<"$system_fixture")"
+  else
+    if [[ "$platform" == darwin ]]; then
+      current="$(/usr/bin/dscl . -read "/Users/$user" UserShell 2>/dev/null | awk '{ print $2 }')"
+    elif command -v getent >/dev/null 2>&1; then
+      current="$(getent passwd "$user" 2>/dev/null | awk -F: 'NR == 1 { print $7 }')"
+    fi
+    [[ -x "$expected" ]] && executable=true
+    grep -Fqx -- "$expected" /etc/shells 2>/dev/null && listed=true
+  fi
+
+  expected_json="$(jq -nc --arg path "$expected" '{program:"zsh",path:$path,listed:true,executable:true}')"
+  actual_json="$(jq -nc --arg path "$current" --argjson executable "$executable" \
+    --argjson listed "$listed" '{path:$path,executable:$executable,listed:$listed,source:"account-database"}')"
+  if [[ "$current" == "$expected" && "$executable" == true && "$listed" == true ]]; then
+    status=ok; code=""; summary="account login shell is the managed Zsh path"; remediation=""
+  else
+    status=incomplete; code="login-shell-mismatch"
+    summary="Zsh is installed but the account login shell is not operationally configured"
+    if [[ "$platform" == darwin ]]; then
+      remediation="apply nix-darwin again; its activation owns the primary account UserShell"
+    elif [[ "$owner" == nixos ]]; then
+      remediation="configure programs.zsh and users.users.<name>.shell in the NixOS infrastructure"
+    else
+      remediation="rerun install.sh apply with privilege to register and select the managed Zsh path"
+    fi
+  fi
+  system_check_add login-shell "$owner" true "$status" "$code" "$summary" "$remediation" \
+    "$expected_json" "$actual_json"
+}
+
+probe_nix_daemon() {
+  local data="$1" platform="$2" reachable=false owner status code summary remediation expected_json actual_json
+
+  owner="$(nix_system_owner "$data" "$platform")"
+  if has_system_fixture; then
+    reachable="$(jq -r '.nix.daemonReachable // false' <<<"$system_fixture")"
+  elif nix store info --store daemon --json >/dev/null 2>&1; then
+    reachable=true
+  fi
+  expected_json='{"store":"daemon","reachable":true}'
+  actual_json="$(jq -nc --argjson reachable "$reachable" '{store:"daemon",reachable:$reachable}')"
+  if [[ "$reachable" == true ]]; then
+    status=ok; code=""; summary="the system-owned Nix daemon is reachable"; remediation=""
+  else
+    status=incomplete; code="nix-daemon-unreachable"; summary="the Nix client cannot reach the daemon"
+    remediation="repair the system Nix service; Home Manager cannot own or restart it"
+  fi
+  system_check_add nix-daemon "$owner" true "$status" "$code" "$summary" "$remediation" \
+    "$expected_json" "$actual_json"
+}
+
+probe_nix_policy() {
+  local data="$1" platform="$2" owner config_json='{}'
+  local trusted_exact=false official_cache=false official_key=false signatures=false optimiser=false
+  local status code summary remediation expected_json actual_json expected_users
+
+  owner="$(nix_system_owner "$data" "$platform")"
+  expected_users="$(jq -c '.nix.trustedUsers | sort' "$system_policy")"
+  if has_system_fixture; then
+    trusted_exact="$(jq -r '.nix.trustedUsersExact // false' <<<"$system_fixture")"
+    official_cache="$(jq -r '.nix.officialCacheOnly // false' <<<"$system_fixture")"
+    official_key="$(jq -r '.nix.officialKeyOnly // false' <<<"$system_fixture")"
+    signatures="$(jq -r '.nix.signaturesRequired // false' <<<"$system_fixture")"
+    optimiser="$(jq -r '.nix.optimiserScheduled // false' <<<"$system_fixture")"
+  else
+    config_json="$(nix config show --json 2>/dev/null || printf '{}')"
+    jq -e --argjson expected "$expected_users" \
+      '.["trusted-users"].value | sort == $expected' <<<"$config_json" >/dev/null && trusted_exact=true
+    jq -e --arg expected "$(jq -r '.nix.substituter' "$system_policy")" \
+      '.["substituters"].value == [$expected]' <<<"$config_json" >/dev/null && official_cache=true
+    jq -e --arg expected "$(jq -r '.nix.trustedPublicKey' "$system_policy")" \
+      '.["trusted-public-keys"].value == [$expected]' <<<"$config_json" >/dev/null && official_key=true
+    jq -e '.["require-sigs"].value == true' <<<"$config_json" >/dev/null && signatures=true
+    if [[ "$platform" == darwin ]] && /bin/launchctl print \
+      "system/$(jq -r '.nix.darwinOptimiserLabel' "$system_policy")" >/dev/null 2>&1; then
+      optimiser=true
+    fi
+  fi
+
+  expected_json="$(jq -nc --argjson trustedUsers "$expected_users" \
+    --argjson scheduled "$([[ "$platform" == darwin ]] && echo true || echo false)" \
+    '{trustedUsers:$trustedUsers,officialSignedCacheOnly:true,signaturesRequired:true,optimiserScheduled:$scheduled}')"
+  actual_json="$(jq -nc --argjson trustedUsersExact "$trusted_exact" \
+    --argjson officialCacheOnly "$official_cache" --argjson officialKeyOnly "$official_key" \
+    --argjson signaturesRequired "$signatures" --argjson optimiserScheduled "$optimiser" \
+    '{trustedUsersExact:$trustedUsersExact,officialCacheOnly:$officialCacheOnly,
+      officialKeyOnly:$officialKeyOnly,signaturesRequired:$signaturesRequired,
+      optimiserScheduled:$optimiserScheduled}')"
+  if [[ "$trusted_exact" == true && "$official_cache" == true && "$official_key" == true \
+    && "$signatures" == true && ( "$platform" != darwin || "$optimiser" == true ) ]]; then
+    status=ok; code=""; summary="Nix trust, signed cache, and optimisation ownership match policy"; remediation=""
+  else
+    status=incomplete; code="nix-policy-drift"
+    summary="effective Nix daemon policy differs from the reviewed system boundary"
+    remediation="repair the owning nix-darwin or NixOS/Nix-daemon configuration; do not use a user nix.conf override"
+  fi
+  system_check_add nix-policy "$owner" true "$status" "$code" "$summary" "$remediation" \
+    "$expected_json" "$actual_json"
+}
+
+probe_container_engine() {
+  local data="$1" platform="$2" user="$3" required=false groups="" docker_group=false mode=unavailable
+  local owner status code summary remediation expected_json actual_json uid socket security
+
+  owner="$(portable_system_owner "$data")"
+  has_capability "$data" containers && required=true
+  if has_system_fixture; then
+    docker_group="$(jq -r '.container.dockerGroup // false' <<<"$system_fixture")"
+    mode="$(jq -r '.container.mode // "unavailable"' <<<"$system_fixture")"
+  else
+    groups="$(id -Gn "$user" 2>/dev/null || true)"
+    word_in_list docker "$groups" && docker_group=true
+    if [[ "$required" == true && "$platform" == darwin ]]; then
+      if docker --context "$(jq -r '.containers.darwin.context' "$system_policy")" \
+        info --format '{{.ServerVersion}}' >/dev/null 2>&1; then
+        mode=orbstack
+      fi
+    elif [[ "$required" == true ]]; then
+      uid="$(id -u "$user" 2>/dev/null || true)"
+      socket="$(jq -r '.containers.linux.socketTemplate' "$system_policy")"
+      socket="${socket//\{uid\}/$uid}"
+      security="$(docker --host "unix://$socket" info --format '{{json .SecurityOptions}}' 2>/dev/null || true)"
+      grep -qi "$(jq -r '.containers.linux.requiredSecurityOption' "$system_policy")" \
+        <<<"$security" && mode=rootless
+    fi
+  fi
+
+  if [[ "$platform" == darwin ]]; then
+    expected_json='{"mode":"orbstack","dockerGroup":false}'
+  else
+    expected_json='{"mode":"rootless","dockerGroup":false}'
+  fi
+  actual_json="$(jq -nc --arg mode "$mode" --argjson dockerGroup "$docker_group" \
+    '{mode:$mode,dockerGroup:$dockerGroup}')"
+  if [[ "$docker_group" == true ]]; then
+    status=incomplete; code="docker-group-membership"
+    summary="the account belongs to the root-equivalent Docker group"
+    remediation="remove Docker-group membership and use a rootless user engine; this command never changes groups"
+  elif [[ "$required" != true ]]; then
+    status=not-applicable; code="capability-not-selected"
+    summary="the containers capability is not selected"; remediation=""
+  elif [[ ( "$platform" == darwin && "$mode" == orbstack ) \
+    || ( "$platform" != darwin && "$mode" == rootless ) ]]; then
+    status=ok; code=""; summary="the declared container engine is reachable without root-equivalent membership"
+    remediation=""
+  else
+    status=incomplete; code="container-engine-unavailable"
+    summary="container clients are installed but the declared engine policy is not operational"
+    if [[ "$platform" == darwin ]]; then
+      remediation="start and repair the nix-darwin-selected OrbStack engine"
+    else
+      remediation="configure a rootless Docker engine at the per-user socket; never add the user to the Docker group"
+    fi
+  fi
+  system_check_add container-engine "$owner" "$required" "$status" "$code" "$summary" "$remediation" \
+    "$expected_json" "$actual_json"
+}
+
+probe_antivirus() {
+  local data="$1" owner present=false binary status code summary remediation
+  local expected_json actual_json reason
+
+  owner="$(portable_system_owner "$data")"
+  reason="$(jq -r '.antivirus.reason' "$system_policy")"
+  if has_system_fixture; then
+    present="$(jq -r '.antivirus.binariesPresent // false' <<<"$system_fixture")"
+  else
+    for binary in clamscan freshclam; do
+      if command -v "$binary" >/dev/null 2>&1; then
+        present=true
+        break
+      fi
+    done
+  fi
+  expected_json='{"managed":false,"binariesPresent":false}'
+  actual_json="$(jq -nc --argjson binariesPresent "$present" \
+    '{managed:false,binariesPresent:$binariesPresent,signatures:null,scanningWorkflow:null}')"
+  if [[ "$present" == true ]]; then
+    status=incomplete; code="unmanaged-antivirus-present"
+    summary="ClamAV binaries are present without owned signatures or a scanning workflow"
+    remediation="remove the undeclared binaries, or first define a system-owned update, scan, and response policy"
+  else
+    status=not-applicable; code="not-configured"
+    summary="ClamAV is intentionally absent because no host owns signatures and scanning"
+    remediation="$reason"
+  fi
+  system_check_add antivirus-data "$owner" false "$status" "$code" \
+    "$summary" "$remediation" \
+    "$expected_json" "$actual_json"
+}
+
+android_rule_roots() {
+  if [[ "$test_hooks" == 1 && -n "${_ATYRODE_TEST_UDEV_ROOT:-}" ]]; then
+    printf '%s\n' "$_ATYRODE_TEST_UDEV_ROOT"
+  else
+    jq -r '.android.linuxRuleRoots[]' "$system_policy"
+  fi
+}
+
+probe_android_policy() {
+  local groups="$1" root file group base rule
+
+  while IFS= read -r root; do
+    [[ -d "$root" ]] || continue
+    for file in "$root"/*.rules; do
+      [[ -f "$file" && -r "$file" ]] || continue
+      base="${file##*/}"
+      case "$base" in
+        *android*|*Android*|*adb*|*ADB*) ;;
+        *) continue ;;
+      esac
+      while IFS= read -r rule || [[ -n "$rule" ]]; do
+        [[ ! "$rule" =~ ^[[:space:]]*# ]] || continue
+        grep -Eq 'ATTR(S)?\{idVendor\}' <<<"$rule" 2>/dev/null || continue
+        if grep -Eq 'TAG\+?=[[:space:]]*"uaccess"' <<<"$rule" 2>/dev/null; then
+          printf 'uaccess\n'
+          return
+        fi
+        while IFS= read -r group; do
+          if grep -Eq "GROUP\\+?=[[:space:]]*\"$group\"" <<<"$rule" 2>/dev/null \
+            && word_in_list "$group" "$groups"; then
+            printf 'group:%s\n' "$group"
+            return
+          fi
+        done < <(jq -r '.android.acceptedGroups[]' "$system_policy")
+      done < "$file"
+    done
+  done < <(android_rule_roots)
+  printf 'missing\n'
+}
+
+probe_device_permissions() {
+  local data="$1" platform="$2" user="$3" required=false adb_available=false policy=not-applicable
+  local owner groups status code summary remediation expected_json actual_json
+
+  owner="$(portable_system_owner "$data")"
+  has_capability "$data" mobile && required=true
+  if [[ "$required" != true ]]; then
+    expected_json='{"policy":null}'
+    actual_json='{"adbAvailable":null,"policy":null}'
+    system_check_add device-permissions "$owner" false not-applicable capability-not-selected \
+      "the mobile capability is not selected" "" "$expected_json" "$actual_json"
+    return
+  fi
+  if [[ "$platform" == darwin ]]; then
+    if has_system_fixture && jq -e 'has("device")' <<<"$system_fixture" >/dev/null; then
+      adb_available="$(jq -r '.device.adbAvailable // false' <<<"$system_fixture")"
+    elif command -v adb >/dev/null 2>&1; then
+      adb_available=true
+    fi
+    expected_json='{"policy":"macos-user-authorization"}'
+    actual_json="$(jq -nc --argjson adbAvailable "$adb_available" \
+      '{adbAvailable:$adbAvailable,policy:"macos-user-authorization"}')"
+    if [[ "$adb_available" == true ]]; then
+      status=ok; code=""
+      summary="ADB is installed; macOS owns per-device authorization at connection time"
+      remediation=""
+    else
+      status=incomplete; code="android-tools-missing"
+      summary="the mobile capability is selected but ADB is unavailable"
+      remediation="reapply the registered host so Home Manager provides Android platform tools"
+    fi
+    system_check_add device-permissions "$owner" true "$status" "$code" \
+      "$summary" "$remediation" "$expected_json" "$actual_json"
+    return
+  fi
+
+  if has_system_fixture && jq -e '.device | has("adbAvailable")' <<<"$system_fixture" >/dev/null; then
+    adb_available="$(jq -r '.device.adbAvailable // false' <<<"$system_fixture")"
+  else
+    command -v adb >/dev/null 2>&1 && adb_available=true
+  fi
+  if has_system_fixture && jq -e '.device | has("policy")' <<<"$system_fixture" >/dev/null; then
+    policy="$(jq -r '.device.policy // "missing"' <<<"$system_fixture")"
+  else
+    groups="$(id -Gn "$user" 2>/dev/null || true)"
+    policy="$(probe_android_policy "$groups")"
+  fi
+  expected_json='{"adbAvailable":true,"policy":["uaccess","reviewed-user-group"]}'
+  actual_json="$(jq -nc --argjson adbAvailable "$adb_available" --arg policy "$policy" \
+    '{adbAvailable:$adbAvailable,policy:$policy}')"
+  if [[ "$adb_available" == true && ( "$policy" == uaccess || "$policy" == group:* ) ]]; then
+    status=ok; code=""; summary="ADB is installed and a reviewed udev access policy is present"; remediation=""
+  else
+    status=incomplete; code="android-device-permissions"
+    summary="Android binaries are installed but Linux device access is not operationally configured"
+    remediation="add a system-owned Android udev uaccess rule or reviewed adbusers/plugdev rule; do not run privileged ADB"
+  fi
+  system_check_add device-permissions "$owner" true "$status" "$code" "$summary" "$remediation" \
+    "$expected_json" "$actual_json"
+}
+
+probe_homebrew_drift() {
+  local platform="$1" available=false drift=true probe_failed=false
+  local check_status=127 cleanup_status=127
+  local status code summary remediation
+  local expected_count expected_json actual_json
+
+  expected_count="$(jq 'length' "$homebrew_cask_inventory")"
+  expected_json="$(jq -nc --argjson casks "$expected_count" '{cleanup:"check",expectedCasks:$casks}')"
+  if [[ "$platform" != darwin ]]; then
+    actual_json='{"available":null,"drift":null}'
+    system_check_add homebrew-drift nix-darwin false not-applicable platform-not-darwin \
+      "Homebrew is not part of the Linux ownership boundary" "" "$expected_json" "$actual_json"
+    return
+  fi
+  if has_system_fixture; then
+    available="$(jq -r '.homebrew.available // false' <<<"$system_fixture")"
+    drift="$(jq -r 'if .homebrew | has("drift") then .homebrew.drift else true end' \
+      <<<"$system_fixture")"
+    probe_failed="$(jq -r '.homebrew.probeFailed // false' <<<"$system_fixture")"
+  elif command -v brew >/dev/null 2>&1; then
+    available=true
+    check_status=0
+    cleanup_status=0
+    env -u HOMEBREW_BUNDLE_FILE HOMEBREW_NO_AUTO_UPDATE=1 \
+      brew bundle check --no-upgrade --file "$homebrew_brewfile" </dev/null >/dev/null 2>&1 || check_status=$?
+    env -u HOMEBREW_BUNDLE_FILE HOMEBREW_NO_AUTO_UPDATE=1 \
+      brew bundle cleanup --file "$homebrew_brewfile" </dev/null >/dev/null 2>&1 || cleanup_status=$?
+    if [[ "$check_status" -gt 1 || "$cleanup_status" -gt 1 ]]; then
+      probe_failed=true
+    fi
+    [[ "$check_status" -eq 0 && "$cleanup_status" -eq 0 ]] && drift=false
+  fi
+  actual_json="$(jq -nc --argjson available "$available" --argjson drift "$drift" \
+    --argjson probeFailed "$probe_failed" \
+    '{available:$available,drift:$drift,probeFailed:$probeFailed,
+      probe:"brew-bundle-check-and-cleanup-without-force"}')"
+  if [[ "$available" != true ]]; then
+    status=incomplete; code="homebrew-unavailable"; summary="nix-darwin expects Homebrew but brew is unavailable"
+    remediation="repair the nix-homebrew installation, then re-run the non-destructive drift check"
+  elif [[ "$probe_failed" == true ]]; then
+    status=incomplete; code="homebrew-probe-failed"
+    summary="Homebrew state could not be compared with the immutable Brewfile"
+    remediation="repair Homebrew or Brew Bundle, then rerun the read-only drift check"
+  elif [[ "$drift" == false ]]; then
+    status=ok; code=""; summary="Homebrew matches the immutable nix-darwin Brewfile"; remediation=""
+  else
+    status=incomplete; code="homebrew-drift"; summary="Homebrew has missing or extra state relative to the generated Brewfile"
+    remediation="review the drift and either declare or manually remove it; automatic uninstall and zap are forbidden"
+  fi
+  system_check_add homebrew-drift nix-darwin true "$status" "$code" "$summary" "$remediation" \
+    "$expected_json" "$actual_json"
+}
+
+doctor_system() {
+  local requested="" json=0 host data platform user system capabilities ok result
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json) json=1; shift ;;
+      --*) die "$EX_USAGE" "unknown doctor system option: $1" ;;
+      *)
+        [[ -z "$requested" ]] || die "$EX_USAGE" "doctor system accepts at most one host"
+        requested="$1"
+        shift
+        ;;
+    esac
+  done
+  host="$(resolve_host "$requested")"
+  doctor_host "$host" 1 >/dev/null || return $?
+  data="$(host_json "$host")"
+  platform="$(jq -r '.platform' <<<"$data")"
+  user="$(jq -r '.username' <<<"$data")"
+  system="$(jq -r '.system' <<<"$data")"
+  capabilities="$(jq -c '.capabilities' <<<"$data")"
+  system_fixture="$(load_system_fixture)"
+  system_checks='[]'
+
+  jq -e '.schemaVersion == 1' "$system_policy" >/dev/null ||
+    die "$EX_SOFTWARE" "unsupported system policy schema"
+  probe_login_shell "$data" "$platform" "$user"
+  probe_nix_daemon "$data" "$platform"
+  probe_nix_policy "$data" "$platform"
+  probe_container_engine "$data" "$platform" "$user"
+  probe_antivirus "$data"
+  probe_device_permissions "$data" "$platform" "$user"
+  probe_homebrew_drift "$platform"
+  jq -e --argjson expected "$(jq -c '.checkOrder' "$system_policy")" \
+    'map(.id) == $expected' <<<"$system_checks" >/dev/null ||
+    die "$EX_SOFTWARE" "system diagnostics do not match the policy order"
+
+  ok=false
+  jq -e 'all(.[]; .status != "incomplete")' <<<"$system_checks" >/dev/null && ok=true
+  result="$(jq -nc --argjson ok "$ok" --arg host "$host" --arg system "$system" \
+    --arg platform "$platform" --argjson capabilities "$capabilities" \
+    --argjson checks "$system_checks" \
+    '{schemaVersion:1,command:"doctor system",ok:$ok,host:$host,system:$system,
+      platform:$platform,capabilities:$capabilities,checks:$checks,mutationBoundary:"read-only probes"}')"
+  if [[ "$json" == 1 ]]; then
+    printf '%s\n' "$result"
+  else
+    jq -r '.checks[] | "\(.id): \(.status) — \(.summary)"' <<<"$result"
+    jq -r '"status: \(if .ok then "ready" else "incomplete" end)"' <<<"$result"
+  fi
+  [[ "$ok" == true ]] || return "$EX_UNAVAILABLE"
+}
+
 apply_config() {
   local requested="" repo="" plan=0 dry=0 json=0 restart=0
   if [[ $# -gt 0 && "$1" != --* ]]; then requested="$1"; shift; fi
@@ -179,7 +688,10 @@ apply_config() {
   done
 
   local host data expected_system expected_user expected_hostname platform default_repo revision dirty backend installable
-  local git_command="${ATYRODE_GIT:-git}"
+  local git_command=git
+  if [[ "$test_hooks" == 1 && -n "${ATYRODE_GIT:-}" ]]; then
+    git_command="$ATYRODE_GIT"
+  fi
   host="$(resolve_host "$requested")"
   data="$(host_json "$host")"
   expected_system="$(jq -r '.system' <<<"$data")"
@@ -211,7 +723,10 @@ apply_config() {
   [[ "$plan" == 0 ]] || return 0
 
   local -a nh_args
-  local nh_command="${ATYRODE_NH:-nh}"
+  local nh_command=nh
+  if [[ "$test_hooks" == 1 && -n "${ATYRODE_NH:-}" ]]; then
+    nh_command="$ATYRODE_NH"
+  fi
   if [[ "$platform" == darwin ]]; then nh_args=("$nh_command" darwin switch "$installable" --diff always)
   else nh_args=("$nh_command" home switch "$installable" --configuration "$host" --backup-extension backup --diff always); fi
   [[ "$dry" == 0 ]] || nh_args+=(--dry)
@@ -239,8 +754,9 @@ main() {
     doctor)
       case "${1:-}" in
         host) shift; local requested="" json=0; if [[ $# -gt 0 && "$1" != --json ]]; then requested="$1"; shift; fi; [[ "${1:-}" != --json ]] || json=1; doctor_host "$requested" "$json" ;;
+        system) shift; doctor_system "$@" ;;
         tools) shift; doctor_tools "$@" ;;
-        *) die "$EX_USAGE" "doctor expects host or tools" ;;
+        *) die "$EX_USAGE" "doctor expects host, system, or tools" ;;
       esac
       ;;
     host) local requested="" json=0; if [[ $# -gt 0 && "$1" != --json ]]; then requested="$1"; shift; fi; [[ "${1:-}" != --json ]] || json=1; doctor_host "$requested" "$json" ;;

--- a/pkgs/atyrode/default.nix
+++ b/pkgs/atyrode/default.nix
@@ -3,8 +3,13 @@
   capabilities,
   codex,
   coreutils,
+  enableTestHooks ? false,
+  findutils,
+  gawk,
   gitMinimal,
+  gnugrep,
   herdr-configured,
+  homebrewCasks,
   hostname,
   hostRegistry,
   jq,
@@ -21,7 +26,21 @@
 
 let
   capabilityInventory = builtins.toFile "atyrode-capabilities.json" (builtins.toJSON capabilities);
+  homebrewCaskInventory = builtins.toFile "atyrode-homebrew-casks.json" (
+    builtins.toJSON homebrewCasks
+  );
+  homebrewBrewfile = builtins.toFile "atyrode-Brewfile" (
+    lib.concatStringsSep "\n" (
+      [
+        ''tap "homebrew/homebrew-core"''
+        ''tap "homebrew/homebrew-cask"''
+      ]
+      ++ map (cask: ''cask "${cask}"'') homebrewCasks
+    )
+    + "\n"
+  );
   registry = builtins.toFile "atyrode-host-registry.json" (builtins.toJSON hostRegistry);
+  systemPolicy = ../../inventory/system-boundary.json;
   tools = builtins.toFile "atyrode-tool-inventory.json" (
     builtins.toJSON [
       {
@@ -153,17 +172,25 @@ stdenvNoCC.mkDerivation {
     install -D -m755 "$src" "$out/bin/atyrode"
     substituteInPlace "$out/bin/atyrode" \
       --replace-fail '@capabilities@' '${capabilityInventory}' \
+      --replace-fail '@homebrew_brewfile@' '${homebrewBrewfile}' \
+      --replace-fail '@homebrew_casks@' '${homebrewCaskInventory}' \
       --replace-fail '@shell@' '${runtimeShell}' \
       --replace-fail '@registry@' '${registry}' \
+      --replace-fail '@system_policy@' '${systemPolicy}' \
+      --replace-fail '@test_hooks@' '${if enableTestHooks then "1" else "0"}' \
       --replace-fail '@tools@' '${tools}'
     wrapProgram "$out/bin/atyrode" \
       --prefix PATH : ${
         lib.makeBinPath [
           coreutils
+          findutils
+          gawk
           gitMinimal
+          gnugrep
           hostname
           jq
           nh
+          nix
         ]
       }
   '';

--- a/scripts/bootstrap-migrate.sh
+++ b/scripts/bootstrap-migrate.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 # This script deliberately uses only Bash 3.2-era features and platform tools:
 # it runs before Nix is guaranteed to exist, including on macOS.
 
+readonly BOOTSTRAP_MIGRATION_TEST_HOOKS=0
+
 migration_id="migration-v1-shell-entrypoints"
 state_root="${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/bootstrap/migrations"
 pending="$state_root/$migration_id.pending"
@@ -225,7 +227,8 @@ resume_prepare() {
     [[ "$(path_kind "$source")" == "$kind" ]] ||
       die "$relative changed type before it could be backed up"
     mv "$source" "$backup"
-    if [[ "${BOOTSTRAP_MIGRATION_FAILPOINT:-}" == "after-${relative#.}" ]]; then
+    if [[ "$BOOTSTRAP_MIGRATION_TEST_HOOKS" == 1 \
+      && "${BOOTSTRAP_MIGRATION_FAILPOINT:-}" == "after-${relative#.}" ]]; then
       printf 'bootstrap migration: interrupted at test failpoint after-%s\n' "${relative#.}" >&2
       exit 75
     fi


### PR DESCRIPTION
# Summary

- publish a per-platform ownership matrix (standalone Home Manager on Linux, nix-darwin, exported-module NixOS) distinguishing binary availability from operational readiness (`docs/system-boundary.md`, policy pinned in `inventory/system-boundary.json` and enforced by the new `system-boundary` check)
- add `atyrode doctor system [HOST] [--json]`: seven ordered read-only probes — login shell, Nix daemon, Nix policy, container engine, antivirus data, device permissions, Homebrew drift — with owner attribution, remediation text, machine-readable schema, and exit 69 on incomplete prerequisites
- make Zsh the real login shell during supported bootstrap via explicit `sudo`/`chsh`, with a conservative `login-shell.incomplete` marker cleared only after doctor verification; the Home Manager `SHELL` override is removed so `$SHELL` is never falsified
- enforce rootless containers on Linux (docker-group membership is diagnosed as a violation, never granted) and OrbStack as the declared Darwin container capability, moved from the desktop profile into an explicit containers capability
- remove ClamAV from the baseline (no registered host owns signatures, updates, or a scanning workflow) and keep Android/ADB in an explicit capability with udev-rule and group diagnostics
- pin Nix daemon ownership per platform: nix-darwin declaratively manages trusted users (root only), the official cache and signing key, `require-sigs`, and store optimisation; Homebrew drift reporting is non-destructive (`cleanup = "check"`, shared cask list, immutable generated Brewfile, no `zap`)
- compile-time-gate all bootstrap/CLI test hooks so production artifacts ignore fixture environment variables; covered by the new `system-boundary` check, hardened `bootstrap` recovery tests, and extended `atyrode-cli` fixture tests on Linux and Darwin

# Validation

- `nix flake check --show-trace` (x86_64-linux, all 29 checks, full builds)
- `nix flake check --all-systems --no-build`
- `bash -n` + `shellcheck -S warning` on `install.sh`, `scripts/bootstrap-migrate.sh`, `pkgs/atyrode/atyrode`
- JSON parse of changed inventories; `git diff --check`
- independent read-only audit of the full diff against the #19 acceptance criteria

Closes #19