### PR TITLE
feat(desktop): deliver ghostty terminal on darwin

### DIFF
--- a/home/ghostty.nix
+++ b/home/ghostty.nix
@@ -1,0 +1,19 @@
+{ lib, pkgs, ... }:
+
+lib.mkIf pkgs.stdenv.isDarwin {
+  programs.ghostty = {
+    enable = true;
+    # The ghostty source package does not build on darwin; the binary
+    # repackage tracks the official release and stays pinned to nixpkgs.
+    package = pkgs.ghostty-bin;
+
+    settings = {
+      # Ghostty defaults are deliberately kept: fonts, truecolor, and
+      # local COLORTERM already behave without configuration. Remote
+      # shells need the SSH integration opted in so xterm-ghostty
+      # terminfo is installed on the host and COLORTERM survives the
+      # connection; without it remote prompts fall back to 256 colors.
+      shell-integration-features = "ssh-env,ssh-terminfo";
+    };
+  };
+}

--- a/home/profiles/desktop.nix
+++ b/home/profiles/desktop.nix
@@ -5,7 +5,10 @@ let
   };
 in
 {
-  imports = [ ../linux-desktop.nix ];
+  imports = [
+    ../ghostty.nix
+    ../linux-desktop.nix
+  ];
 
   # Retention of desktop applications reflects operator use, not the agent
   # baseline. Homebrew-owned applications remain in the nix-darwin module.

--- a/inventory/packages.json
+++ b/inventory/packages.json
@@ -37,7 +37,7 @@
     "versionOwner": "pinned nixpkgs",
     "mutableState": "application-owned user data and caches",
     "closureClass": "very-large",
-    "packages": ["arduino-ide", "chatgpt", "godot", "lichess", "obsidian", "orbstack", "parsec-bin", "plugdata", "postman", "prismlauncher", "reaper", "signal-desktop", "spotify", "steam", "steamcmd", "vital", "vlc", "vlc-bin", "vscode", "whatsapp-for-mac"]
+    "packages": ["arduino-ide", "chatgpt", "ghostty-bin", "godot", "lichess", "obsidian", "orbstack", "parsec-bin", "plugdata", "postman", "prismlauncher", "reaper", "signal-desktop", "spotify", "steam", "steamcmd", "vital", "vlc", "vlc-bin", "vscode", "whatsapp-for-mac"]
   },
   {
     "owner": "mobile",


### PR DESCRIPTION
## What

Adds [Ghostty](https://ghostty.org) to the macOS package set as the terminal emulator, delivered through the `desktop` capability.

- **`home/ghostty.nix`** — new darwin-gated module enabling `programs.ghostty` with `pkgs.ghostty-bin` (1.3.1 at the current pin; the `ghostty` source package is Linux-only). Delivered via home-manager rather than a Homebrew cask, per the repo convention that casks are reserved for what nixpkgs cannot deliver on darwin.
- **`home/profiles/desktop.nix`** — imports the new module.
- **`inventory/packages.json`** — registers `ghostty-bin` under the `desktop` owner.

## Config philosophy

Ghostty's defaults are deliberately kept (fonts, truecolor, local `COLORTERM` all work with zero config). Exactly one setting is baked in:

```
shell-integration-features = ssh-env,ssh-terminfo
```

This opts into Ghostty's SSH integration: `xterm-ghostty` terminfo is copied to remote hosts on connect and `COLORTERM=truecolor` survives the SSH connection — fixing the OMP prompt falling back to 256 colors in remote sessions.

## Verification

- `darwinConfigurations.alex-aarch64-darwin.system` and both darwin `homeConfigurations` instantiate cleanly
- `homeConfigurations.alex-x86_64-linux-desktop` keeps `programs.ghostty.enable = false` (darwin-gated as intended)
- Rendered `~/.config/ghostty/config` contains exactly the one line above
- `checks.x86_64-linux.{package-ownership,shell-surface,home-evaluation,host-registry}` all build

🤖 Generated with [Claude Code](https://claude.com/claude-code)