### PR TITLE
Cache the Nix store across CI runs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,9 +39,23 @@ jobs:
           persist-credentials: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          nix_conf: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      # Restore the newest Nix store cache for this platform; without it every
+      # run rebuilds all local derivations from an empty store (~13 min).
+      # Saving happens only on pushes to main so pull requests never pay the
+      # multi-gigabyte save step; GitHub's 10 GiB LRU quota evicts old entries.
+      # The store is deliberately not garbage-collected before saving: a
+      # `nix flake check` store has no GC roots, so collection would empty it.
+      - name: Restore Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-${{ matrix.system }}-${{ hashFiles('flake.lock', '**/*.nix', 'checks/**', 'darwin/**', 'home/**', 'hosts/**', 'inventory/**', 'modules/**', 'pkgs/**', 'scripts/**', 'install.sh') }}
+          restore-prefixes-first-match: nix-${{ matrix.system }}-
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check flake
         run: nix flake check --show-trace


### PR DESCRIPTION
# Summary

- switch CI Nix installation to `nixbuild/nix-quick-install-action` (single-user, store owned by the runner user, ~1–5 s installs, flakes enabled by default; all four matrix platforms ship upstream archives)
- restore the newest per-platform Nix store cache with `nix-community/cache-nix-action` before `nix flake check`, keyed by a content hash of the flake and everything the checks consume, so unchanged derivations substitute from cache instead of rebuilding
- save caches only on pushes to `main`: pull requests restore for free and never pay the multi-gigabyte save step; superseded generations age out via GitHub's 10 GiB LRU eviction
- deliberately skip store garbage collection before saving — a `nix flake check` store has no GC roots, so collection would empty the cache

Today every run starts from an empty store and rebuilds all local derivations on all four platforms (~11–13 min wall, e.g. 12.6 min of `nix flake check` on `x86_64-darwin`, dominated by Rust/Zig toolchains and the omp/atyrode/Home Manager closures). With a warm cache, runs should drop to roughly eval + restore time.

Measured on the current x86_64-linux check set: 7.9 GiB uncompressed build closure (upper bound, dev-store realized every graph output), expected ~2 GiB compressed per platform. After the first post-merge push to `main` saves caches, `gh cache list` will show actual sizes; if a full generation approaches the 10 GiB quota, the follow-up is narrowing cached paths or explicit purging — never a correctness issue, worst case is today's cold-run behavior.

# Validation

- `actionlint` on the workflow (clean)
- action pins resolved to the commit SHAs of `nixbuild/nix-quick-install-action` v35 and `nix-community/cache-nix-action` v7, matching the repo's SHA-pinning convention
- upstream release assets confirmed for all four platforms (`nix-2.34.7-{x86_64,aarch64}-{linux,darwin}.tar.zstd`)
- this PR's own run exercises the new install + restore path end to end (restore misses by design until a cache exists on `main`)