### PR TITLE
fix(shell): derive COLORTERM for ghostty ssh sessions

### DIFF
--- a/checks/shell-surface.nix
+++ b/checks/shell-surface.nix
@@ -36,6 +36,13 @@ pkgs.runCommand "check-shell-surface"
     zsh -dfi -c 'source ${../home/shell/startup.zsh}; [[ -e "$HOME/local-loaded" ]]' </dev/null
     test ! -e "$HOME/fastfetch-ran"
 
+    COLORTERM= TERM=xterm-ghostty zsh -dfc \
+      'source ${../home/shell/colorterm.zsh}; [[ "$COLORTERM" == truecolor ]]'
+    COLORTERM=16color TERM=xterm-ghostty zsh -dfc \
+      'source ${../home/shell/colorterm.zsh}; [[ "$COLORTERM" == 16color ]]'
+    COLORTERM= TERM=vt100 zsh -dfc \
+      'source ${../home/shell/colorterm.zsh}; [[ -z "$COLORTERM" ]]'
+
     zsh -dfc '
       source ${../home/shell/nix.zsh}
       whence -w zconf >/dev/null

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -19,6 +19,7 @@ single retained Oh My Zsh `git` plugin. Projects own language environments.
 | large `zconf` workflow | replaced by #7 | `atyrode apply`; a thin `zconf` compatibility function remains until 2026-10-01. |
 | Python/venv helpers | removed by #20 | Project dev shell, `mise.toml`, or native manifest. |
 | `local.zsh` | retained, narrow | Interactive machine-local behavior only; no portable project, runtime, credential, or shared tool policy. |
+| `COLORTERM` derivation | added | sshd's default `AcceptEnv` drops Ghostty's forwarded `COLORTERM`; `colorterm.zsh` restates `truecolor` when `TERM=xterm-ghostty` and never overrides an existing value. |
 | Oh My Zsh `git` | retained | Transparent Git aliases/completion used by the interactive shell. |
 | Oh My Zsh tmux/docker plugins | removed | Herdr and explicit container capabilities own those workflows; plugins were loaded on unrelated hosts. |
 
@@ -29,8 +30,9 @@ compatibility surface and has a recorded removal date.
 
 The checked smoke test proves that non-interactive shells do not load
 `local.zsh`, interactive shells do, fastfetch is not executed, removed aliases
-and functions are unavailable, completion remains enabled, and fzf, zoxide,
-and nix-direnv are Home Manager-owned.
+and functions are unavailable, completion remains enabled, fzf, zoxide,
+and nix-direnv are Home Manager-owned, and `COLORTERM` is derived only for
+`xterm-ghostty` sessions that arrive without one.
 
 On 2026-07-10, ten clean source-tree interactive runs measured with Hyperfine
 before this refactor averaged **26.9 ms ± 2.6 ms**. The equivalent command after

--- a/home/ghostty.nix
+++ b/home/ghostty.nix
@@ -11,8 +11,10 @@ lib.mkIf pkgs.stdenv.isDarwin {
       # Ghostty defaults are deliberately kept: fonts, truecolor, and
       # local COLORTERM already behave without configuration. Remote
       # shells need the SSH integration opted in so xterm-ghostty
-      # terminfo is installed on the host and COLORTERM survives the
-      # connection; without it remote prompts fall back to 256 colors.
+      # terminfo is installed on the host. ssh-env also sends COLORTERM,
+      # but sshd only admits variables listed in AcceptEnv (stock installs
+      # accept LANG/LC_* only), so home/shell/colorterm.zsh re-derives it
+      # from TERM on the remote side.
       shell-integration-features = "ssh-env,ssh-terminfo";
     };
   };

--- a/home/shell/colorterm.zsh
+++ b/home/shell/colorterm.zsh
@@ -1,0 +1,12 @@
+############################################
+# Terminal capability derivation
+############################################
+
+# Ghostty's ssh-env integration sends COLORTERM, but sshd filters client
+# variables through AcceptEnv and stock installs only accept LANG/LC_*, so
+# the value rarely survives onto a server. TERM=xterm-ghostty still arrives
+# (ssh-terminfo) and only ever names a terminal that renders 24-bit color,
+# so restate the capability for environment-probing tools such as omp.
+if [[ -z "$COLORTERM" && "$TERM" == xterm-ghostty ]]; then
+  export COLORTERM=truecolor
+fi

--- a/home/zsh.nix
+++ b/home/zsh.nix
@@ -16,6 +16,7 @@
     # Load custom shell functions (in order)
     initContent = ''
       # Load shell configuration modules
+      source ${./shell/colorterm.zsh}
       source ${./shell/nix.zsh}
       source ${./shell/startup.zsh}
     '';


### PR DESCRIPTION
## Problem

SSH sessions from Ghostty into the VPS arrive with `TERM=xterm-ghostty` and working terminfo, but an empty `COLORTERM`. Tools that detect color support from the environment rather than probing the terminal — omp among them — therefore downgrade to 256-color approximations even though the pipe renders 24-bit color fine.

Root cause: `ghostty.nix` already opts into `shell-integration-features = "ssh-env,ssh-terminfo"`, and ssh-env does send `COLORTERM` — but OpenSSH servers only admit client-sent variables listed in `AcceptEnv`, and stock Ubuntu sshd accepts only `LANG LC_*`. The variable is silently dropped server-side; terminfo survives because it travels a different path.

## Fix

- `home/shell/colorterm.zsh` (new): restate `COLORTERM=truecolor` when `TERM=xterm-ghostty` and `COLORTERM` is empty. Conditioned on TERM rather than exported unconditionally so a non-truecolor client is never lied to, and an already-present value is never overridden. Ships to the VPS via the `base` capability of the portable server profile.
- `home/zsh.nix`: source the new module.
- `home/ghostty.nix`: correct the comment that claimed ssh-env alone makes `COLORTERM` survive.
- `checks/shell-surface.nix`: smoke-test all three cases (derived, preserved, untouched).
- `docs/shell.md`: record the new surface in the disposition inventory.

The alternative — `AcceptEnv COLORTERM` in the VPS's sshd config — is privileged per-host policy this repo deliberately doesn't own; the shell derivation is portable and covers every host the profile lands on.

## Verification

`nix build .#checks.x86_64-linux.shell-surface` passes, including the three new assertions. After merge, run `atyrode apply` on the VPS, reconnect, and `echo $COLORTERM` should print `truecolor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)