### PR TITLE
feat(atyrode): activate the published flake without a checkout

### DIFF
--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -21,6 +21,7 @@ pkgs.runCommand "check-atyrode-cli"
       *rev-parse\ --is-inside-work-tree*) echo true ;;
       *rev-parse\ --short=12\ HEAD*) echo 0123456789ab ;;
       *diff\ --quiet*) exit 0 ;;
+      *ls-remote*) printf 'feedfacefeedfacefeedfacefeedfacefeedface\trefs/heads/main\n' ;;
       *) exit 1 ;;
     esac
     EOF
@@ -51,6 +52,7 @@ pkgs.runCommand "check-atyrode-cli"
     atyrode apply --repo "$HOME/nix-dotfiles" --plan --json | jq -e '
       .host == "alex-x86_64-linux"
       and .backend == "nh-home"
+      and .source == "local"
       and .revision == "0123456789ab"
       and .mutationBoundary == "activation only after preflight"
     ' >/dev/null
@@ -73,6 +75,29 @@ pkgs.runCommand "check-atyrode-cli"
     grep -F -- 'home switch ' "$TMPDIR/nh-args" >/dev/null
     grep -F -- '--dry' "$TMPDIR/nh-args" >/dev/null
     test "$(cat "$XDG_STATE_HOME/atyrode/dotfiles-config")" = sentinel
+
+    atyrode apply --plan --json | jq -e '
+      .source == "remote"
+      and .revision == "feedfacefeed"
+      and .installable == "github:atyrode/dotfiles/feedfacefeedfacefeedfacefeedfacefeedface#alex-x86_64-linux"
+      and (.dirty | not)
+      and .repository == "github:atyrode/dotfiles"
+    ' >/dev/null
+    test "$(cat "$XDG_STATE_HOME/atyrode/dotfiles-config")" = sentinel
+
+    atyrode apply >/dev/null
+    grep -F -- 'github:atyrode/dotfiles/feedfacefeedfacefeedfacefeedfacefeedface#alex-x86_64-linux' \
+      "$TMPDIR/nh-args" >/dev/null
+    test "$(cat "$XDG_STATE_HOME/atyrode/dotfiles-config")" = alex-x86_64-linux
+
+    atyrode apply --ref 0123456789012345678901234567890123456789 --plan --json | jq -e '
+      .source == "remote" and .revision == "012345678901"
+    ' >/dev/null
+
+    if atyrode apply --ref main --repo "$HOME/nix-dotfiles" --plan >/dev/null 2>&1; then
+      echo '--ref with --repo unexpectedly succeeded' >&2
+      exit 1
+    fi
 
     if atyrode apply alex-aarch64-linux --plan >/dev/null 2>&1; then
       echo 'cross-system host selection unexpectedly succeeded' >&2

--- a/docs/atyrode.md
+++ b/docs/atyrode.md
@@ -8,28 +8,43 @@ or maintain a second mutable profile database.
 ## Applying a configuration
 
 ```sh
+atyrode apply            # activate the latest published main; no checkout needed
 atyrode apply --plan
 atyrode apply --dry-run
-atyrode apply
 ```
 
 The default host comes from `ATYRODE_HOST`, then the managed host identity file,
-then an unambiguous user/system/hostname match. The checkout is the host's
-declared `dotfilesDirectory`. Selecting either differently is intentional:
+then an unambiguous user/system/hostname match.
+
+Without `--repo`, apply activates the published flake. It resolves the
+requested ref (default `main`) to an exact commit with `git ls-remote`, then
+activates the pinned `github:atyrode/dotfiles/<commit>`. No local checkout is
+involved, so the command behaves identically from any directory on any
+machine, and pinning the resolved commit bypasses the flake tarball cache: an
+apply immediately after a merge activates that merge. `--ref` selects a
+branch, tag, or full commit instead of `main`:
+
+```sh
+atyrode apply --ref feature-branch --plan
+```
+
+`--repo PATH` switches to a local checkout for development, for example to
+activate work in progress before pushing. It additionally validates the
+checkout and Git repository and reports a dirty tree:
 
 ```sh
 atyrode apply alex-x86_64-linux-desktop --repo /home/alex/nix-dotfiles --plan
 ```
 
-Before calling `nh`, the CLI validates the host, user, system, checkout, Git
-repository, backend, and revision. `--plan` performs no activation. `--dry-run`
-uses `nh`'s build-only path. A successful real activation records the canonical
-host atomically; failures and dry runs do not update state.
+Before calling `nh`, the CLI validates the host, user, system, backend, and
+revision. `--plan` performs no activation. `--dry-run` uses `nh`'s build-only
+path. A successful real activation records the canonical host atomically;
+failures and dry runs do not update state.
 
 Linux uses `nh home switch`; macOS uses `nh darwin switch`. Plans name the
-selected host and capabilities, installable, backend, revision, dirty-tree
-state, and mutation boundary. Add `--json` for automation. Activation shows a
-generation package diff.
+selected host and capabilities, installable, source, backend, revision,
+dirty-tree state, and mutation boundary. Add `--json` for automation.
+Activation shows a generation package diff.
 
 `--restart-shell` only prints the explicit restart action after success. It
 never replaces an embedded terminal. The historical `zconf` command is now a

--- a/flake.nix
+++ b/flake.nix
@@ -160,7 +160,6 @@
         host
         // {
           inherit aliases capabilities;
-          dotfilesDirectory = host.dotfilesDirectory or "${host.homeDirectory}/nix-dotfiles";
           hostname = host.hostname or null;
         };
 
@@ -186,7 +185,6 @@
         inherit (host)
           aliases
           capabilities
-          dotfilesDirectory
           homeDirectory
           hostname
           platform

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -5,6 +5,8 @@ set -euo pipefail
 readonly registry='@registry@'
 readonly capability_inventory='@capabilities@'
 readonly tool_inventory='@tools@'
+readonly flake_ref='@flakeRef@'
+readonly flake_remote_url="https://github.com/${flake_ref#github:}"
 readonly EX_USAGE=64 EX_DATAERR=65 EX_NOINPUT=66 EX_UNAVAILABLE=69 EX_SOFTWARE=70
 
 die() {
@@ -17,16 +19,18 @@ die() {
 usage() {
   cat <<'EOF'
 Usage:
-  atyrode apply [HOST] [--repo PATH] [--plan|--dry-run] [--json] [--restart-shell]
+  atyrode apply [HOST] [--ref REF] [--repo PATH] [--plan|--dry-run] [--json] [--restart-shell]
   atyrode capabilities list [--json]
   atyrode capabilities show [HOST] [--json]
   atyrode doctor host [HOST] [--json]
   atyrode doctor tools [--json]
   atyrode host [HOST] [--json]
 
-The host registry is the authority for identity, platform, capabilities, and
-the default checkout. apply validates everything before invoking nh. Commands
-reserved for later issues: workspace, agent, generations, rollback, and clean.
+The host registry is the authority for identity, platform, and capabilities.
+apply activates the published flake by default, resolving REF (default main)
+to an exact commit first; --repo switches to a local checkout for development.
+apply validates everything before invoking nh. Commands reserved for later
+issues: workspace, agent, generations, rollback, and clean.
 EOF
 }
 
@@ -164,11 +168,12 @@ doctor_tools() {
 }
 
 apply_config() {
-  local requested="" repo="" plan=0 dry=0 json=0 restart=0
+  local requested="" repo="" ref="" plan=0 dry=0 json=0 restart=0
   if [[ $# -gt 0 && "$1" != --* ]]; then requested="$1"; shift; fi
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --repo) [[ $# -ge 2 ]] || die "$EX_USAGE" "--repo requires a path"; repo="$2"; shift 2 ;;
+      --ref) [[ $# -ge 2 ]] || die "$EX_USAGE" "--ref requires a branch, tag, or full commit"; ref="$2"; shift 2 ;;
       --plan) plan=1; shift ;;
       --dry-run) dry=1; shift ;;
       --json) json=1; shift ;;
@@ -177,8 +182,9 @@ apply_config() {
       *) die "$EX_USAGE" "unknown apply option: $1" ;;
     esac
   done
+  [[ -z "$repo" || -z "$ref" ]] || die "$EX_USAGE" "--ref selects a published revision and cannot be combined with --repo"
 
-  local host data expected_system expected_user expected_hostname platform default_repo revision dirty backend installable
+  local host data expected_system expected_user expected_hostname platform source repository revision dirty backend installable
   local git_command="${ATYRODE_GIT:-git}"
   host="$(resolve_host "$requested")"
   data="$(host_json "$host")"
@@ -186,28 +192,48 @@ apply_config() {
   expected_user="$(jq -r '.username' <<<"$data")"
   expected_hostname="$(jq -r '.hostname // empty' <<<"$data")"
   platform="$(jq -r '.platform' <<<"$data")"
-  default_repo="$(jq -r '.dotfilesDirectory' <<<"$data")"
-  repo="${repo:-$default_repo}"
-  [[ "$repo" == /* ]] || die "$EX_USAGE" "repository path must be absolute: $repo"
-  [[ -f "$repo/flake.nix" ]] || die "$EX_NOINPUT" "not a flake checkout: $repo"
   [[ "$(actual_system)" == "$expected_system" ]] || die "$EX_DATAERR" "host $host requires $expected_system, found $(actual_system)"
   [[ "$(actual_user)" == "$expected_user" ]] || die "$EX_DATAERR" "host $host requires user $expected_user, found $(actual_user)"
   [[ -z "$expected_hostname" || "$(actual_hostname)" == "$expected_hostname" ]] || die "$EX_DATAERR" "host $host requires hostname $expected_hostname, found $(actual_hostname)"
   command -v nh >/dev/null || die "$EX_UNAVAILABLE" "nh is unavailable"
   command -v "$git_command" >/dev/null || die "$EX_UNAVAILABLE" "git is unavailable"
-  "$git_command" -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "$EX_DATAERR" "repository is not a Git checkout: $repo"
-  revision="$("$git_command" -C "$repo" rev-parse --short=12 HEAD)"
-  dirty=false; "$git_command" -C "$repo" diff --quiet --ignore-submodules HEAD -- || dirty=true
+
+  if [[ -n "$repo" ]]; then
+    source="local"
+    [[ "$repo" == /* ]] || die "$EX_USAGE" "repository path must be absolute: $repo"
+    [[ -f "$repo/flake.nix" ]] || die "$EX_NOINPUT" "not a flake checkout: $repo"
+    "$git_command" -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "$EX_DATAERR" "repository is not a Git checkout: $repo"
+    revision="$("$git_command" -C "$repo" rev-parse --short=12 HEAD)"
+    dirty=false; "$git_command" -C "$repo" diff --quiet --ignore-submodules HEAD -- || dirty=true
+    repository="$repo"
+    installable="$repo#$host"
+  else
+    source="remote"
+    ref="${ref:-main}"
+    # Resolving the ref to an exact commit keeps the activation deterministic
+    # and bypasses the flake tarball cache, which can serve a branch name
+    # stale for up to an hour.
+    local rev=""
+    if [[ "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+      rev="$ref"
+    else
+      rev="$("$git_command" ls-remote "$flake_remote_url" "refs/heads/$ref" "refs/tags/$ref" | head -n 1 | cut -f 1)" || true
+      [[ -n "$rev" ]] || die "$EX_UNAVAILABLE" "cannot resolve $ref on $flake_remote_url; check the ref name and network"
+    fi
+    revision="${rev:0:12}"
+    dirty=false
+    repository="$flake_ref"
+    installable="$flake_ref/$rev#$host"
+  fi
   backend="nh-home"; [[ "$platform" != darwin ]] || backend="nh-darwin"
-  installable="$repo#$host"
 
   local output
-  output="$(jq -nc --arg host "$host" --arg repo "$repo" --arg system "$expected_system" \
-    --arg user "$expected_user" --arg backend "$backend" --arg revision "$revision" \
+  output="$(jq -nc --arg host "$host" --arg repository "$repository" --arg system "$expected_system" \
+    --arg user "$expected_user" --arg backend "$backend" --arg revision "$revision" --arg source "$source" \
     --arg installable "$installable" --argjson dirty "$dirty" --argjson capabilities "$(jq -c '.capabilities' <<<"$data")" \
-    '{host:$host,installable:$installable,system:$system,user:$user,capabilities:$capabilities,backend:$backend,revision:$revision,dirty:$dirty,repository:$repo,mutationBoundary:"activation only after preflight"}')"
+    '{host:$host,installable:$installable,source:$source,system:$system,user:$user,capabilities:$capabilities,backend:$backend,revision:$revision,dirty:$dirty,repository:$repository,mutationBoundary:"activation only after preflight"}')"
   if [[ "$json" == 1 ]]; then printf '%s\n' "$output"
-  else jq -r '"host: \(.host)\ninstallable: \(.installable)\nsystem: \(.system)\nuser: \(.user)\ncapabilities: \(.capabilities | join(", "))\nbackend: \(.backend)\nrevision: \(.revision)\ndirty: \(.dirty)\nmutation boundary: \(.mutationBoundary)"' <<<"$output"; fi
+  else jq -r '"host: \(.host)\ninstallable: \(.installable)\nsource: \(.source)\nsystem: \(.system)\nuser: \(.user)\ncapabilities: \(.capabilities | join(", "))\nbackend: \(.backend)\nrevision: \(.revision)\ndirty: \(.dirty)\nmutation boundary: \(.mutationBoundary)"' <<<"$output"; fi
   [[ "$plan" == 0 ]] || return 0
 
   local -a nh_args

--- a/pkgs/atyrode/default.nix
+++ b/pkgs/atyrode/default.nix
@@ -3,6 +3,9 @@
   capabilities,
   codex,
   coreutils,
+  # Published flake activated by `atyrode apply` without --repo. Must stay a
+  # github: ref; the CLI derives the ls-remote URL from it.
+  flakeRef ? "github:atyrode/dotfiles",
   gitMinimal,
   herdr-configured,
   hostname,
@@ -153,6 +156,7 @@ stdenvNoCC.mkDerivation {
     install -D -m755 "$src" "$out/bin/atyrode"
     substituteInPlace "$out/bin/atyrode" \
       --replace-fail '@capabilities@' '${capabilityInventory}' \
+      --replace-fail '@flakeRef@' '${flakeRef}' \
       --replace-fail '@shell@' '${runtimeShell}' \
       --replace-fail '@registry@' '${registry}' \
       --replace-fail '@tools@' '${tools}'


### PR DESCRIPTION
## Problem

`atyrode apply` required a local checkout at the registry's declared `dotfilesDirectory` (defaulting to `~/nix-dotfiles`), which baked a per-machine filesystem path into the configuration the CLI exists to locate. Any machine that cloned elsewhere — e.g. `~/dotfiles` on the Mac — failed with `not a flake checkout` even when run from inside the repo.

## Change

`apply` without `--repo` now activates the **published flake** and needs no checkout anywhere:

1. Resolves the requested ref (default `main`) to an exact commit via `git ls-remote` — a tiny unauthenticated network call.
2. Activates the pinned `github:atyrode/dotfiles/<commit>` through the same `nh` backends as before.

Pinning the resolved commit makes the activation deterministic and sidesteps Nix's flake tarball cache, whose TTL can serve a branch name up to an hour stale — `apply` right after a merge activates that merge.

- `--ref BRANCH|TAG|SHA` activates something other than `main` (e.g. test a PR branch on the VPS without cloning).
- `--repo PATH` remains the local-development escape hatch with its existing checkout, Git, and dirty-tree validation. `install.sh` always passes `--repo`, so bootstrap is unchanged.
- Plan output and JSON gain a `source: remote|local` field.
- `dotfilesDirectory` is removed from the host registry and its public JSON: nothing reads it anymore, and a checkout location is machine state the registry should never have owned.

## Verification

- `nix build .#checks.x86_64-linux.atyrode-cli` — extended with remote-mode coverage: pinned installable and revision in the plan JSON, `nh` invoked with the pinned remote installable, state recording, full-SHA `--ref` short-circuiting `ls-remote`, and `--ref`+`--repo` rejection.
- `nix build .#checks.x86_64-linux.{portable-profiles,bootstrap,package-ownership}` — pass with the registry field removal.
- `nix flake check --no-build` — all outputs evaluate.
- End-to-end: `nix build --dry-run 'github:atyrode/dotfiles/c0ea47f…#homeConfigurations."alex-x86_64-linux".activationPackage'` fetched and evaluated the full home configuration from GitHub with no local checkout — the exact path `nh` takes.

## Rollout

Each machine needs one last old-style apply to pick up the new CLI (`atyrode apply --repo <checkout>`); after that, `atyrode apply` works from any directory with no checkout. Server checkouts (e.g. `~/nix-dotfiles` on the VPS) become deletable; development clones can live anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)