### PR TITLE
fix(darwin): enable flakes for the sudo activation phase

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -15,6 +15,15 @@
     stateVersion = 7;
   };
 
+  # nh's system-profile step runs nix under sudo, where the process-scoped
+  # NIX_CONFIG from bootstrap does not reach; root falls back to
+  # /etc/nix/nix.conf, which the upstream installer writes without flakes.
+  # Owning the setting here keeps every activation phase self-sufficient.
+  nix.settings.experimental-features = [
+    "flakes"
+    "nix-command"
+  ];
+
   users.users.${username}.home = homeDirectory;
 
   home-manager = {


### PR DESCRIPTION
## Problem

`atyrode apply` (via `zconf`) on the Mac builds the darwin system fine, then dies setting the system profile:

```
error: experimental Nix feature 'nix-command' is disabled; add '--extra-experimental-features nix-command' to enable it
```

The build phase runs with the caller's environment, where flakes are enabled process-scoped (bootstrap intentionally never writes a user `nix.conf` — see docs/bootstrap.md). The profile-set phase runs under `sudo`, which strips that environment; root's nix reads `/etc/nix/nix.conf`, which the upstream installer writes without `experimental-features`.

## Change

Declare `nix.settings.experimental-features = [ "flakes" "nix-command" ]` in `darwin/default.nix`, so nix-darwin owns `/etc/nix/nix.conf` and every activation phase — including the sudo'd ones — is self-sufficient.

## One-time unblock

The first activation after this merge still runs against the old root config, so it needs the flag seeded by hand once:

```sh
echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
```

Subsequent activations are self-sustaining: nix-darwin manages the file from then on.

## Verification

`nix eval .#darwinConfigurations.alex-aarch64-darwin.config.nix.settings.experimental-features` → `[ "flakes" "nix-command" ]` (cross-evaluated from Linux; darwin builds run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)