### PR TITLE
feat(bootstrap): add a fetched one-command entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ cd ~/nix-dotfiles
 **Supported fresh-machine command:**
 
 ```bash
-git clone https://github.com/atyrode/dotfiles.git "$HOME/nix-dotfiles" && "$HOME/nix-dotfiles/install.sh" apply --config alex-x86_64-linux
+curl -fsSL https://raw.githubusercontent.com/atyrode/dotfiles/main/get.sh | bash -s -- alex-x86_64-linux
 ```
+
+The fetched `get.sh` only clones the repository and hands off to the cloned
+`install.sh`; cloning first and running `./install.sh apply --config <host>`
+yourself remains equivalent.
 
 Replace the example host with the exact entry from `hosts/default.nix`; bootstrap
 will not guess between desktop, development, or Mac profiles. It uses

--- a/checks/get-sh.nix
+++ b/checks/get-sh.nix
@@ -1,0 +1,79 @@
+{ pkgs }:
+
+pkgs.runCommand "check-get-entrypoint" { } ''
+  export HOME="$TMPDIR/home"
+  mkdir -p "$HOME" "$TMPDIR/bin"
+  export INSTALL_ARGS_FILE="$TMPDIR/install-args"
+  export INSTALL_STDIN_FILE="$TMPDIR/install-stdin"
+
+  cat > "$TMPDIR/install-stub" <<'EOF'
+  #!${pkgs.runtimeShell}
+  printf '%s\n' "$*" > "$INSTALL_ARGS_FILE"
+  cat > "$INSTALL_STDIN_FILE"
+  EOF
+  chmod +x "$TMPDIR/install-stub"
+
+  cat > "$TMPDIR/bin/git" <<'EOF'
+  #!${pkgs.runtimeShell}
+  case "$1" in
+    clone)
+      mkdir -p "$3"
+      cp "$TMPDIR/install-stub" "$3/install.sh"
+      printf '%s\n' "$2" > "$3/origin"
+      ;;
+    -C)
+      [[ "$3 $4" == 'config --get' ]] || exit 1
+      cat "$2/origin"
+      ;;
+    *) exit 1 ;;
+  esac
+  EOF
+  chmod +x "$TMPDIR/bin/git"
+
+  # Without a host argument the usage failure must name the registry.
+  if bash ${../get.sh} >/dev/null 2>"$TMPDIR/usage-err"; then
+    echo 'missing host unexpectedly succeeded' >&2
+    exit 1
+  fi
+  grep -F 'hosts/default.nix' "$TMPDIR/usage-err" >/dev/null
+
+  # git is absent from this build environment until the stub joins PATH.
+  if bash ${../get.sh} alex-x86_64-linux >/dev/null 2>"$TMPDIR/git-err"; then
+    echo 'missing git unexpectedly succeeded' >&2
+    exit 1
+  fi
+  grep -F 'git is required' "$TMPDIR/git-err" >/dev/null
+  export PATH="$TMPDIR/bin:$PATH"
+
+  # A foreign directory at the target must never be reused or clobbered.
+  mkdir -p "$HOME/nix-dotfiles"
+  if bash ${../get.sh} alex-x86_64-linux --yes >/dev/null 2>"$TMPDIR/foreign-err"; then
+    echo 'foreign directory unexpectedly reused' >&2
+    exit 1
+  fi
+  grep -F 'not this repository' "$TMPDIR/foreign-err" >/dev/null
+  rmdir "$HOME/nix-dotfiles"
+
+  # Streamed like curl | bash: stdin is the script, no terminal exists, and
+  # --yes hands off to the cloned install.sh with stdin detached.
+  bash -s -- alex-x86_64-linux --yes < ${../get.sh} >/dev/null
+  test "$(cat "$INSTALL_ARGS_FILE")" = 'apply --config alex-x86_64-linux --yes'
+  test ! -s "$INSTALL_STDIN_FILE"
+
+  # The existing correct-origin clone is reused, and without a terminal the
+  # confirmation cannot be assumed: no --yes means no install.sh run.
+  rm "$INSTALL_ARGS_FILE"
+  if bash ${../get.sh} alex-x86_64-linux >/dev/null 2>"$TMPDIR/tty-err"; then
+    echo 'missing terminal unexpectedly succeeded' >&2
+    exit 1
+  fi
+  grep -F -- '--yes' "$TMPDIR/tty-err" >/dev/null
+  test ! -e "$INSTALL_ARGS_FILE"
+
+  # DOTFILES_DIR relocates the clone and forwards extra install arguments.
+  DOTFILES_DIR="$TMPDIR/elsewhere" bash ${../get.sh} alex-aarch64-darwin --yes --update >/dev/null
+  test -x "$TMPDIR/elsewhere/install.sh"
+  test "$(cat "$INSTALL_ARGS_FILE")" = 'apply --config alex-aarch64-darwin --yes --update'
+
+  mkdir "$out"
+''

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -6,11 +6,11 @@ managed environment is known to work.
 
 ## Fresh-machine command
 
-Choose the host from [`hosts/default.nix`](../hosts/default.nix), then run this
-single command. This example selects the ordinary x86_64 Linux profile:
+Choose the host from [`hosts/default.nix`](../hosts/default.nix), then run one
+command. This example selects the ordinary x86_64 Linux profile:
 
 ```sh
-git clone https://github.com/atyrode/dotfiles.git "$HOME/nix-dotfiles" && "$HOME/nix-dotfiles/install.sh" apply --config alex-x86_64-linux
+curl -fsSL https://raw.githubusercontent.com/atyrode/dotfiles/main/get.sh | bash -s -- alex-x86_64-linux
 ```
 
 Substitute the exact registered host for a Mac or desktop Linux machine.
@@ -19,9 +19,23 @@ the base development machine or the desktop profile. Production NixOS servers
 instead import the [portable Home Manager profile](portable-profiles.md) from
 their infrastructure flake.
 
+`get.sh` is deliberately thin: it verifies Git is present, clones the
+repository to `~/nix-dotfiles` (`DOTFILES_DIR` overrides it; an existing
+directory is reused only when its origin is this repository), and hands off to
+the cloned `install.sh`, which owns every mutation. The 2026-07-10 decision to
+support no `curl | shell` path was revised on 2026-07-11 with these
+mitigations: the fetched script is function-wrapped so a truncated download
+executes nothing, the confirmation prompt reads from the terminal and a
+non-interactive run requires an explicit `--yes`, and the transactional
+bootstrap below still executes only from cloned, inspectable code. The
+clone-first command remains supported and equivalent:
+
+```sh
+git clone https://github.com/atyrode/dotfiles.git "$HOME/nix-dotfiles" && "$HOME/nix-dotfiles/install.sh" apply --config alex-x86_64-linux
+```
+
 The unmanaged prerequisites are Git, Bash, `curl`, `tar`, and either
-`sha256sum` or `shasum`. The command clones inspectable code before executing
-it; there is no supported `curl | shell` path.
+`sha256sum` or `shasum`.
 
 ## Phases and source policy
 
@@ -156,3 +170,9 @@ failure, interruption before and after transaction publication, resumable
 migration, collisions, corrupt and dual receipts, missing backups, symlinked
 state namespaces, rollback, receipt privacy, and idempotence. The same check
 runs natively in all four CI jobs.
+
+`checks/get-sh.nix` covers the fetched entry point: the usage and missing-Git
+failures, refusal to reuse a foreign target directory, the streamed
+piped-stdin handoff to the cloned `install.sh` with `--yes` and recorded
+arguments, the refusal to proceed without a terminal or `--yes`, and the
+`DOTFILES_DIR` override with forwarded install arguments.

--- a/flake.nix
+++ b/flake.nix
@@ -527,6 +527,7 @@
             inherit lib pkgs;
             baseConfig = baseOnlyConfig;
           };
+          get-entrypoint = import ./checks/get-sh.nix { inherit pkgs; };
           home-evaluation = homeEvaluation;
           host-registry = registryCheck;
           package-ownership = import ./checks/package-ownership.nix {

--- a/get.sh
+++ b/get.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Fresh-machine entry point for atyrode/dotfiles:
+#
+#   curl -fsSL https://raw.githubusercontent.com/atyrode/dotfiles/main/get.sh \
+#     | bash -s -- <registered-host> [install-args...]
+#
+# This fetched script only checks prerequisites and clones the repository;
+# every mutation runs through the cloned, inspectable install.sh transaction.
+# The body is function-wrapped so a truncated download defines functions but
+# executes nothing.
+set -euo pipefail
+
+readonly origin_https='https://github.com/atyrode/dotfiles.git'
+readonly origin_ssh='git@github.com:atyrode/dotfiles.git'
+
+die() {
+  printf 'get.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+main() {
+  [[ $# -ge 1 && "$1" != -* ]] ||
+    die 'usage: get.sh <registered-host> [install-args...]; hosts are declared in hosts/default.nix (for example alex-aarch64-darwin or alex-x86_64-linux)'
+  local host="$1"
+  shift
+
+  command -v git >/dev/null ||
+    die 'git is required first; install Xcode Command Line Tools (xcode-select --install) on macOS or your distribution git package on Linux'
+
+  local dir="${DOTFILES_DIR:-$HOME/nix-dotfiles}"
+  if [[ -e "$dir" ]]; then
+    local existing
+    existing="$(git -C "$dir" config --get remote.origin.url 2>/dev/null || true)"
+    [[ "$existing" == "$origin_https" || "$existing" == "$origin_ssh" ]] ||
+      die "$dir exists and is not this repository; move it aside or set DOTFILES_DIR"
+  else
+    git clone "$origin_https" "$dir"
+  fi
+
+  # Under `curl | bash` stdin carries the script itself, so the bootstrap
+  # confirmation must read from the terminal. Without one, only an explicit
+  # --yes may stand in for the operator.
+  local -a install_args=(apply --config "$host" "$@")
+  if { : </dev/tty; } 2>/dev/null; then
+    exec "$dir/install.sh" "${install_args[@]}" </dev/tty
+  fi
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == --yes ]]; then
+      exec "$dir/install.sh" "${install_args[@]}" </dev/null
+    fi
+  done
+  die 'no interactive terminal for the confirmation prompt; append --yes to accept the printed plan'
+}
+
+main "$@"


### PR DESCRIPTION
## What

The devtool-style fresh-machine bootstrap:

```sh
curl -fsSL https://raw.githubusercontent.com/atyrode/dotfiles/main/get.sh | bash -s -- alex-aarch64-darwin
```

`get.sh` is deliberately thin: check Git exists → clone to `~/nix-dotfiles` (`DOTFILES_DIR` overrides; an existing directory is reused only when its origin is this repository, never clobbered) → `exec` the cloned `install.sh apply --config <host>`, forwarding any extra arguments. All mutation, Nix installation, migrations, receipts, and rollback stay in the existing transactional `install.sh`.

## Security posture

This revises the documented 2026-07-10 "no `curl | shell` path" decision (per explicit owner choice), with the mitigations recorded in docs/bootstrap.md:

- The fetched script is function-wrapped: a truncated download defines functions but executes nothing.
- Under `curl | bash`, stdin carries the script, so the bootstrap confirmation reads from `/dev/tty`; without a terminal, an explicit `--yes` is required or the run refuses.
- The code that mutates the machine is still the cloned, inspectable, hash-verifying `install.sh`; the clone-first command remains supported and equivalent.

## Verification

- `nix build .#checks.x86_64-linux.get-entrypoint` — new check covering: usage failure naming the registry, missing-git failure, foreign-directory refusal, streamed piped-stdin handoff with `--yes` and recorded arguments plus detached stdin, no-terminal/no-`--yes` refusal (install.sh not invoked), and the `DOTFILES_DIR` override with forwarded arguments.
- `shellcheck get.sh` — clean.
- `nix flake check --no-build` — all outputs evaluate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)