### PR TITLE
feat(atyrode): describe capabilities and offer preset selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ curl -fsSL https://raw.githubusercontent.com/atyrode/dotfiles/main/get.sh | bash
 
 The fetched `get.sh` only clones the repository and hands off to the cloned
 `install.sh`; cloning first and running `./install.sh apply --config <host>`
-yourself remains equivalent.
+yourself remains equivalent. Omit the host to pick interactively from the
+registered presets for this machine, each described with what it installs;
+`atyrode capabilities list` shows the same descriptions per capability later.
 
 Replace the example host with the exact entry from `hosts/default.nix`; bootstrap
 will not guess between desktop, development, or Mac profiles. It uses

--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -38,8 +38,24 @@ pkgs.runCommand "check-atyrode-cli"
     export _ATYRODE_TEST_SYSTEM="x86_64-linux"
     export _ATYRODE_TEST_USER="alex"
 
-    atyrode capabilities list --json | jq -e 'index("base") and index("server")' >/dev/null
-    atyrode capabilities show alex-linux --json | jq -e '.host == "alex-x86_64-linux"' >/dev/null
+    atyrode capabilities list --json | jq -e '
+      (map(.name) | index("base") and index("server"))
+      and all(.[]; .description | length > 0)
+      and (.[] | select(.name == "base") | .active)
+      and ((.[] | select(.name == "desktop") | .active) | not)
+    ' >/dev/null
+    atyrode capabilities show alex-linux --json | jq -e '
+      .host == "alex-x86_64-linux"
+      and (.description | length > 0)
+      and (.capabilities | map(.name) | index("agent-tools"))
+      and all(.capabilities[]; .description | length > 0)
+    ' >/dev/null
+
+    # On a machine whose identity is ambiguous the list degrades to
+    # unmarked instead of dying.
+    mv "$XDG_CONFIG_HOME/atyrode/host.json" "$TMPDIR/host.json"
+    atyrode capabilities list --json | jq -e 'all(.[]; .active | not)' >/dev/null
+    mv "$TMPDIR/host.json" "$XDG_CONFIG_HOME/atyrode/host.json"
     atyrode doctor host --json | jq -e '.ok and .registered.id == "alex-x86_64-linux"' >/dev/null
     tools="$(atyrode doctor tools --json || true)"
     jq -e '

--- a/checks/get-sh.nix
+++ b/checks/get-sh.nix
@@ -17,8 +17,9 @@ pkgs.runCommand "check-get-entrypoint" { } ''
   #!${pkgs.runtimeShell}
   case "$1" in
     clone)
-      mkdir -p "$3"
+      mkdir -p "$3/inventory"
       cp "$TMPDIR/install-stub" "$3/install.sh"
+      cp "$TMPDIR/hosts.tsv" "$3/inventory/hosts.tsv"
       printf '%s\n' "$2" > "$3/origin"
       ;;
     -C)
@@ -29,13 +30,7 @@ pkgs.runCommand "check-get-entrypoint" { } ''
   esac
   EOF
   chmod +x "$TMPDIR/bin/git"
-
-  # Without a host argument the usage failure must name the registry.
-  if bash ${../get.sh} >/dev/null 2>"$TMPDIR/usage-err"; then
-    echo 'missing host unexpectedly succeeded' >&2
-    exit 1
-  fi
-  grep -F 'hosts/default.nix' "$TMPDIR/usage-err" >/dev/null
+  cp ${../inventory/hosts.tsv} "$TMPDIR/hosts.tsv"
 
   # git is absent from this build environment until the stub joins PATH.
   if bash ${../get.sh} alex-x86_64-linux >/dev/null 2>"$TMPDIR/git-err"; then
@@ -68,6 +63,16 @@ pkgs.runCommand "check-get-entrypoint" { } ''
     exit 1
   fi
   grep -F -- '--yes' "$TMPDIR/tty-err" >/dev/null
+  test ! -e "$INSTALL_ARGS_FILE"
+
+  # Without a host and without a terminal, the picker refuses and names the
+  # presets registered for this system instead of guessing.
+  if bash ${../get.sh} </dev/null >/dev/null 2>"$TMPDIR/picker-err"; then
+    echo 'host-less run without a terminal unexpectedly succeeded' >&2
+    exit 1
+  fi
+  grep -F 'alex-x86_64-linux' "$TMPDIR/picker-err" >/dev/null
+  grep -F 'alex-x86_64-linux-desktop' "$TMPDIR/picker-err" >/dev/null
   test ! -e "$INSTALL_ARGS_FILE"
 
   # DOTFILES_DIR relocates the clone and forwards extra install arguments.

--- a/checks/get-sh.nix
+++ b/checks/get-sh.nix
@@ -1,5 +1,17 @@
 { pkgs }:
 
+let
+  # The picker filters presets by the build platform, so the refusal
+  # message names a different host per system.
+  expectedPickerHost =
+    {
+      "aarch64-darwin" = "alex-aarch64-darwin";
+      "aarch64-linux" = "alex-aarch64-linux";
+      "x86_64-darwin" = "alex-x86_64-darwin";
+      "x86_64-linux" = "alex-x86_64-linux";
+    }
+    .${pkgs.stdenv.hostPlatform.system};
+in
 pkgs.runCommand "check-get-entrypoint" { } ''
   export HOME="$TMPDIR/home"
   mkdir -p "$HOME" "$TMPDIR/bin"
@@ -71,8 +83,8 @@ pkgs.runCommand "check-get-entrypoint" { } ''
     echo 'host-less run without a terminal unexpectedly succeeded' >&2
     exit 1
   fi
-  grep -F 'alex-x86_64-linux' "$TMPDIR/picker-err" >/dev/null
-  grep -F 'alex-x86_64-linux-desktop' "$TMPDIR/picker-err" >/dev/null
+  grep -F 'pass one of:' "$TMPDIR/picker-err" >/dev/null
+  grep -F '${expectedPickerHost}' "$TMPDIR/picker-err" >/dev/null
   test ! -e "$INSTALL_ARGS_FILE"
 
   # DOTFILES_DIR relocates the clone and forwards extra install arguments.

--- a/checks/portable-profiles.nix
+++ b/checks/portable-profiles.nix
@@ -141,7 +141,8 @@ builtins.deepSeq evaluationPaths (
     ''
       atyrode capabilities show ${externalFixture.hostId} --json | jq -e '
         .host == "${externalFixture.hostId}"
-        and .capabilities == ["base", "server", "agent-tools"]
+        and (.capabilities | map(.name)) == ["agent-tools", "base", "server"]
+        and all(.capabilities[]; .description | length > 0)
       ' >/dev/null
 
       jq -e '

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -13,9 +13,13 @@ command. This example selects the ordinary x86_64 Linux profile:
 curl -fsSL https://raw.githubusercontent.com/atyrode/dotfiles/main/get.sh | bash -s -- alex-x86_64-linux
 ```
 
-Substitute the exact registered host for a Mac or desktop Linux machine.
-Bootstrap never infers a profile from architecture alone: x86_64 Linux can be
-the base development machine or the desktop profile. Production NixOS servers
+Substitute the exact registered host for a Mac or desktop Linux machine, or
+omit the host entirely: `get.sh` then lists the registered presets for this
+machine's system — each with its description and capability breakdown from
+`inventory/hosts.tsv` — and prompts for an explicit choice on the terminal
+(without one, it refuses and names the valid IDs). Bootstrap never infers a
+profile from architecture alone: x86_64 Linux can be the base development
+machine or the desktop profile. Production NixOS servers
 instead import the [portable Home Manager profile](portable-profiles.md) from
 their infrastructure flake.
 

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -2,8 +2,11 @@
 
 `hosts/default.nix` is the authoritative registry for supported dotfiles
 configurations. A host entry contains stable, non-secret facts: its canonical
-configuration ID, system, platform, user, home directory, optional hostname,
-compatibility aliases, and selected capabilities.
+configuration ID, a one-line description, system, platform, user, home
+directory, optional hostname, compatibility aliases, and selected
+capabilities. Hosts are the offered presets: `inventory/hosts.tsv` is the
+committed flat projection the bootstrap picker reads before Nix exists, and
+the host-registry check keeps it identical to the registry.
 
 Capabilities are declarative Home Manager modules, not imperative `nix
 profile` state. Home Manager generations remain activation history and rollback
@@ -25,6 +28,14 @@ points; OMP and Codex profiles remain harness-specific mutable-state boundaries.
 - `server`: marks a Linux-only headless composition. The reviewed portable
   server selection combines it with `base` and `agent-tools`.
 
+The same descriptions live as data in `home/profiles/descriptions.nix`
+(checked to cover the capability set exactly), surface in
+`atyrode capabilities list` — which marks the resolved host's active
+capabilities — and in `atyrode capabilities show`, and export to flake
+consumers as `lib.capabilityDescriptions`. Adding a capability to a machine is
+a registry edit: extend the host's `capabilities` list, merge, and run
+`atyrode apply` on that machine.
+
 Project compilers and runtimes are owned by committed dev shells, `mise.toml`,
 and native manifests. See [Package ownership](package-ownership.md) for the
 checked matrix and harness boundaries.
@@ -44,18 +55,22 @@ modules through the [portable profile contract](portable-profiles.md).
 
 1. Add one canonical entry to `hosts/default.nix`.
 2. Declare a supported `system`, matching `platform`, non-empty `username`,
-   absolute `homeDirectory`, and at least one valid capability.
+   absolute `homeDirectory`, a non-empty one-line `description`, and at least
+   one valid capability.
 3. Add only compatibility names that must remain accepted to `aliases`.
 4. Add or reuse capability modules under `home/profiles/`; do not put
    host-specific packages directly in the registry.
-5. Run `nix flake check --all-systems --no-build --show-trace`. The aggregate
+5. Regenerate `inventory/hosts.tsv` to match (the host-registry check diffs
+   it against the registry).
+6. Run `nix flake check --all-systems --no-build --show-trace`. The aggregate
    home and Darwin checks evaluate every canonical host on its native system.
 
 Registry evaluation refuses unsupported systems, platform mismatches, empty
 users, relative home directories, missing base capabilities, server/desktop
 or server/development conflicts, non-Linux server selections, duplicate or
 unknown capabilities, duplicate aliases, and aliases that collide with
-canonical host IDs.
+canonical host IDs. Portable consumers may omit `description`; for this
+repository's own registry the host-registry check requires it non-empty.
 
 ## Renaming or retiring a host
 

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,15 @@
         };
       };
       knownCapabilities = builtins.attrNames capabilityModules;
+      capabilityDescriptions = import ./home/profiles/descriptions.nix;
+      capabilityInventory =
+        assert lib.assertMsg (
+          builtins.attrNames capabilityDescriptions == knownCapabilities
+        ) "capability descriptions must cover the capability set exactly";
+        map (name: {
+          inherit name;
+          description = capabilityDescriptions.${name};
+        }) knownCapabilities;
       serverPolicy = builtins.fromJSON (builtins.readFile ./inventory/server-profile.json);
       serverCapabilities = serverPolicy.capabilities;
       darwinModule = ./darwin;
@@ -154,12 +163,16 @@
         assert lib.assertMsg (
           builtins.isString host.homeDirectory && lib.hasPrefix "/" host.homeDirectory
         ) "host ${name} must declare an absolute homeDirectory";
+        assert lib.assertMsg (builtins.isString (
+          host.description or ""
+        )) "host ${name} description must be a string";
         assert lib.assertMsg (
           builtins.length aliases == builtins.length (lib.unique aliases)
         ) "host ${name} declares duplicate aliases";
         host
         // {
           inherit aliases capabilities;
+          description = host.description or "";
           hostname = host.hostname or null;
         };
 
@@ -185,6 +198,7 @@
         inherit (host)
           aliases
           capabilities
+          description
           homeDirectory
           hostname
           platform
@@ -194,6 +208,15 @@
       };
       publicHosts = lib.mapAttrs publicHost hosts;
       hostRegistryJson = builtins.toJSON publicHosts;
+      # Flat projection consumed by get.sh before Nix exists on the machine;
+      # the host-registry check keeps the committed copy honest.
+      hostsTsv = lib.concatMapStrings (
+        name:
+        let
+          host = publicHosts.${name};
+        in
+        "${name}\t${host.system}\t${lib.concatStringsSep "," host.capabilities}\t${host.description}\n"
+      ) (builtins.attrNames publicHosts);
 
       mkHostIdentityModule =
         {
@@ -249,7 +272,7 @@
             omp-agents = final.callPackage ./pkgs/omp-agents { };
             omp-configured = final.callPackage ./pkgs/omp-configured { };
             atyrode = final.callPackage ./pkgs/atyrode {
-              capabilities = knownCapabilities;
+              capabilities = capabilityInventory;
               hostRegistry = publicRegistry;
             };
           })
@@ -402,6 +425,7 @@
           selectHomeManagerProfiles
           ;
         capabilities = knownCapabilities;
+        inherit capabilityDescriptions;
         hostRegistry = publicHosts;
         serverProfile = serverPolicy;
       };
@@ -501,9 +525,14 @@
                     and (.system | type == "string")
                     and (.username | type == "string")
                     and (.homeDirectory | startswith("/"))
+                    and (.description | type == "string" and length > 0)
                     and (.capabilities | length > 0))
                   and ([.[].capabilities[]] | index("server") | not)
                 ' ${registryFile} >/dev/null
+                if ! diff ${pkgs.writeText "hosts-expected.tsv" hostsTsv} ${./inventory/hosts.tsv}; then
+                  echo 'inventory/hosts.tsv is out of date with hosts/default.nix' >&2
+                  exit 1
+                fi
                 mkdir "$out"
               '';
           baseOnlyConfig = home-manager.lib.homeManagerConfiguration {

--- a/get.sh
+++ b/get.sh
@@ -4,11 +4,13 @@
 # Fresh-machine entry point for atyrode/dotfiles:
 #
 #   curl -fsSL https://raw.githubusercontent.com/atyrode/dotfiles/main/get.sh \
-#     | bash -s -- <registered-host> [install-args...]
+#     | bash -s -- [registered-host] [install-args...]
 #
-# This fetched script only checks prerequisites and clones the repository;
-# every mutation runs through the cloned, inspectable install.sh transaction.
-# The body is function-wrapped so a truncated download defines functions but
+# Without a host argument it lists the registry's presets for this machine's
+# system and prompts for a choice. This fetched script only checks
+# prerequisites, clones the repository, and selects a configuration; every
+# mutation runs through the cloned, inspectable install.sh transaction. The
+# body is function-wrapped so a truncated download defines functions but
 # executes nothing.
 set -euo pipefail
 
@@ -20,11 +22,48 @@ die() {
   exit 1
 }
 
+pick_host() {
+  local dir="$1" inventory="$1/inventory/hosts.tsv" system
+  [[ -r "$inventory" ]] || die 'host inventory missing from the clone; pass a registered host explicitly'
+  case "$(uname -s):$(uname -m)" in
+    Darwin:arm64) system='aarch64-darwin' ;;
+    Darwin:x86_64) system='x86_64-darwin' ;;
+    Linux:arm64|Linux:aarch64) system='aarch64-linux' ;;
+    Linux:x86_64) system='x86_64-linux' ;;
+    *) die "unsupported platform: $(uname -s) $(uname -m)" ;;
+  esac
+
+  local -a ids=() lines=()
+  local id host_system capabilities description
+  while IFS=$'\t' read -r id host_system capabilities description; do
+    [[ "$host_system" == "$system" ]] || continue
+    ids+=("$id")
+    lines+=("$id - $description [$capabilities]")
+  done <"$inventory"
+  [[ ${#ids[@]} -gt 0 ]] || die "no registered configuration targets $system"
+
+  if ! { : </dev/tty; } 2>/dev/null; then
+    die "no interactive terminal to choose a configuration; pass one of: ${ids[*]}"
+  fi
+  printf 'Registered %s configurations:\n' "$system" >&2
+  local i
+  for i in "${!ids[@]}"; do
+    printf '  %d) %s\n' "$((i + 1))" "${lines[$i]}" >&2
+  done
+  local choice
+  read -r -p "Select a configuration [1-${#ids[@]}]: " choice </dev/tty
+  if [[ ! "$choice" =~ ^[0-9]+$ ]] || ((choice < 1 || choice > ${#ids[@]})); then
+    die "invalid selection: $choice"
+  fi
+  printf '%s\n' "${ids[$((choice - 1))]}"
+}
+
 main() {
-  [[ $# -ge 1 && "$1" != -* ]] ||
-    die 'usage: get.sh <registered-host> [install-args...]; hosts are declared in hosts/default.nix (for example alex-aarch64-darwin or alex-x86_64-linux)'
-  local host="$1"
-  shift
+  local host=""
+  if [[ $# -ge 1 && "$1" != -* ]]; then
+    host="$1"
+    shift
+  fi
 
   command -v git >/dev/null ||
     die 'git is required first; install Xcode Command Line Tools (xcode-select --install) on macOS or your distribution git package on Linux'
@@ -38,6 +77,8 @@ main() {
   else
     git clone "$origin_https" "$dir"
   fi
+
+  [[ -n "$host" ]] || host="$(pick_host "$dir")"
 
   # Under `curl | bash` stdin carries the script itself, so the bootstrap
   # confirmation must read from the terminal. Without one, only an explicit

--- a/home/profiles/descriptions.nix
+++ b/home/profiles/descriptions.nix
@@ -1,0 +1,14 @@
+# One-line "contains/installs" summary per capability, surfaced by
+# `atyrode capabilities`, the bootstrap preset picker, and flake consumers.
+# Keys must match ./default.nix exactly; the flake asserts the correspondence.
+{
+  agent-tools = "Codex, OMP, Herdr, managed agents, and their configuration";
+  base = "shell, Git/GitHub, search, direnv/nix-direnv, mise, on-demand lookup, diagnostics, and Home Manager itself";
+  containers = "container clients and inspection tools; the daemon stays system-owned";
+  desktop = "operator-selected graphical applications";
+  development = "cross-repository Nix and shell quality tools, not project language runtimes";
+  media = "audio/video conversion and inspection";
+  mobile = "Android device tooling";
+  security = "declared scanning and network diagnostics";
+  server = "marker for a Linux-only headless composition; the portable server combines it with base and agent-tools";
+}

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -1,5 +1,6 @@
 {
   "alex-aarch64-darwin" = {
+    description = "Primary Apple Silicon Mac with the full development, agent, and desktop stack";
     system = "aarch64-darwin";
     platform = "darwin";
     username = "alex";
@@ -17,6 +18,7 @@
   };
 
   "alex-x86_64-darwin" = {
+    description = "Intel Mac variant of the primary Mac profile";
     system = "x86_64-darwin";
     platform = "darwin";
     username = "alex";
@@ -34,6 +36,7 @@
   };
 
   "alex-aarch64-linux" = {
+    description = "Headless arm64 Linux development machine with agent tooling";
     system = "aarch64-linux";
     platform = "linux";
     username = "alex";
@@ -47,6 +50,7 @@
   };
 
   "alex-x86_64-linux" = {
+    description = "Headless x86_64 Linux development machine with agent tooling";
     system = "x86_64-linux";
     platform = "linux";
     username = "alex";
@@ -63,6 +67,7 @@
   };
 
   "alex-x86_64-linux-desktop" = {
+    description = "x86_64 Linux workstation adding the desktop, mobile, media, and container stack";
     system = "x86_64-linux";
     platform = "linux";
     username = "alex";

--- a/inventory/hosts.tsv
+++ b/inventory/hosts.tsv
@@ -1,0 +1,5 @@
+alex-aarch64-darwin	aarch64-darwin	base,development,agent-tools,desktop,mobile,media,containers	Primary Apple Silicon Mac with the full development, agent, and desktop stack
+alex-aarch64-linux	aarch64-linux	base,development,agent-tools	Headless arm64 Linux development machine with agent tooling
+alex-x86_64-darwin	x86_64-darwin	base,development,agent-tools,desktop,mobile,media,containers	Intel Mac variant of the primary Mac profile
+alex-x86_64-linux	x86_64-linux	base,development,agent-tools	Headless x86_64 Linux development machine with agent tooling
+alex-x86_64-linux-desktop	x86_64-linux	base,development,agent-tools,desktop,mobile,media,containers	x86_64 Linux workstation adding the desktop, mobile, media, and container stack

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -125,17 +125,38 @@ capabilities() {
   [[ "${1:-}" != --json ]] || json=1
   case "$action" in
     list)
+      # Mark the capabilities selected by the resolved host when one
+      # resolves; on unregistered machines the list stays unmarked.
+      local active="[]" host=""
+      # die inside the substitution exits the subshell itself, so the
+      # unresolved-host guard has to sit outside it.
+      host="$(resolve_host 2>/dev/null)" || host=""
+      [[ -z "$host" ]] || active="$(host_json "$host" | jq -c '.capabilities')"
       if [[ "$json" == 1 ]]; then
-        jq -c 'sort | unique' "$capability_inventory"
+        jq -c --argjson active "$active" \
+          'sort_by(.name) | map(. + {active: (.name as $n | $active | index($n) != null)})' \
+          "$capability_inventory"
       else
-        jq -r 'sort | unique[]' "$capability_inventory"
+        jq -r --argjson active "$active" \
+          'sort_by(.name)[] | "\(.name)\(if (.name as $n | $active | index($n)) then " [active]" else "" end): \(.description)"' \
+          "$capability_inventory"
       fi
       ;;
     show)
-      local host data
+      local host data selected
       host="$(resolve_host "$requested")"; data="$(host_json "$host")"
-      if [[ "$json" == 1 ]]; then jq -c '{host:.id,capabilities}' <<<"$data"
-      else jq -r '.capabilities[]' <<<"$data"; fi
+      selected="$(jq -c '.capabilities' <<<"$data")"
+      if [[ "$json" == 1 ]]; then
+        jq -c --argjson data "$data" --argjson selected "$selected" \
+          '{host: $data.id, description: $data.description,
+            capabilities: [sort_by(.name)[] | select(.name as $n | $selected | index($n))]}' \
+          "$capability_inventory"
+      else
+        jq -r '"\(.id): \(.description)"' <<<"$data"
+        jq -r --argjson selected "$selected" \
+          'sort_by(.name)[] | select(.name as $n | $selected | index($n)) | "  \(.name): \(.description)"' \
+          "$capability_inventory"
+      fi
       ;;
     *) die "$EX_USAGE" "capabilities expects list or show" ;;
   esac


### PR DESCRIPTION
Implements #48. **Stacked on #47** (evolves its `get.sh`); merge #47 first and this PR retargets to `main` automatically. One-line overlap with #45 in `flake.nix` (`publicHost` inherit list) — I'll rebase whichever lands second.

## What you get

**Descriptions everywhere.** Capability summaries now live as checked data (`home/profiles/descriptions.nix`, asserted to cover the capability set exactly) instead of docs prose:

```
$ atyrode capabilities list
agent-tools [active]: Codex, OMP, Herdr, managed agents, and their configuration
base [active]: shell, Git/GitHub, search, direnv/nix-direnv, mise, ...
containers: container clients and inspection tools; the daemon stays system-owned
...
$ atyrode capabilities show alex-linux-desktop
alex-x86_64-linux-desktop: x86_64 Linux workstation adding the desktop, mobile, media, and container stack
  agent-tools: Codex, OMP, Herdr, managed agents, and their configuration
  ...
```

`list` marks the resolved host's active capabilities and degrades to unmarked on unregistered/ambiguous machines; `--json` carries `{name, description, active}`. Also exported as `lib.capabilityDescriptions`.

**Presets at bootstrap.** Hosts gain a one-line `description` in the registry, projected into a committed `inventory/hosts.tsv` (the host-registry check diffs it against the registry, so it cannot drift). `get.sh` without a host argument lists the presets registered for this machine's system — description plus capability breakdown — and prompts on `/dev/tty`; without a terminal it refuses and names the valid IDs. `install.sh` keeps its explicit `--config` contract.

**Adding onto a machine stays declarative**: extend the host's `capabilities` list in the registry, merge, `atyrode apply` — now documented in docs/hosts.md, with the annotated `capabilities list` as the discovery surface.

Portable-consumer note: `description` is optional in the exported host contract (fixtures unbroken); only this repository's registry requires it non-empty.

## Fixed in passing

`resolve_host` failures inside `$( … || true)` weren't caught — `die`'s `exit` kills the substitution subshell before `|| true` evaluates — so `capabilities list` crashed on ambiguous-identity machines. The guard now sits outside the substitution, with a regression case in the check.

## Verification

- `nix build .#checks.x86_64-linux.{atyrode-cli,get-entrypoint,host-registry,portable-profiles}` — all pass, including new assertions for descriptions, active marking, the ambiguous-identity degradation, the TSV/registry diff, and the host-less picker refusal listing IDs.
- `shellcheck get.sh` clean; `nix flake check --no-build` passes.
- Built CLI exercised on this machine (output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)