### PR TITLE
feat(omp): trusted autonomy policy and a mutable plain launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ atyrode doctor host   # Validate the managed machine identity
 
 ### Agent Tools
 ```bash
-omp           # Balanced GPT-5.6 Terra profile
+omp           # Mutable user-owned OMP; unmanaged except the blocked update
 ompb          # Budget profile
 ompg          # OpenAI-only high-capability profile
 ompo          # GPT profile with selected Opus fallbacks

--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -105,15 +105,17 @@ in
           --config ${policyConfig} \
           --json >/dev/null
 
-        test "$(yq eval '.modelRoles.default' ${defaultsConfig})" = "openai-codex/gpt-5.6-terra:medium"
+        test "$(yq eval '.modelRoles.default' ${defaultsConfig})" = "openai-codex/gpt-5.6-sol:medium"
+        test "$(yq eval '.modelRoles.task' ${defaultsConfig})" = "openai-codex/gpt-5.6-terra:medium"
         test "$(yq eval '.tools.approvalMode' ${defaultsConfig})" = "null"
         test "$(yq eval '.secrets.enabled' ${defaultsConfig})" = "null"
-        test "$(yq eval '.tools.approvalMode' ${policyConfig})" = "write"
+        test "$(yq eval '.tools.approvalMode' ${policyConfig})" = "yolo"
         test "$(yq eval '.secrets.enabled' ${policyConfig})" = "true"
         test "$(yq eval 'keys | sort | join(",")' ${policyConfig})" = "secrets,task,tools"
         test "$(yq eval '.tools | keys | sort | join(",")' ${policyConfig})" = "approval,approvalMode"
         for tool in bash eval browser task github; do
-          test "$(yq eval ".tools.approval.$tool" ${policyConfig})" = "prompt"
+          test "$(yq eval ".tools.approval.$tool" ${policyConfig})" = "allow"
+          test "$(yq eval ".tools.approval.$tool" ${yoloConfig})" = "allow"
         done
         test "$(yq eval '.secrets | keys | join(",")' ${policyConfig})" = "enabled"
         test "$(yq eval '.task.isolation.mode' ${policyConfig})" = "auto"
@@ -124,7 +126,7 @@ in
         test "$(yq eval '.tools.approval.browser' ${untrustedConfig})" = "deny"
         test "$(yq eval '.tools.approval.github' ${untrustedConfig})" = "deny"
         test "$(yq eval '.tools.approval.eval' ${untrustedConfig})" = "deny"
-        test "$(yq eval '.tools.approval.bash' ${yoloConfig})" = "allow"
+        test "$(yq eval '.tools.approvalMode' ${yoloConfig})" = "null"
         test "$(yq eval '.retry.modelFallback' ${fablePreset})" = "false"
 
         for command in omp ompb ompf ompg ompo ompu; do
@@ -153,7 +155,7 @@ in
         jq -e '.models | type == "array"' "$TMPDIR/models.json" >/dev/null
 
         set +e
-        ${pkgs.omp-configured}/bin/omp acp \
+        ${pkgs.omp-configured}/bin/ompg acp \
           --config "$TMPDIR/missing-one-shot.yml" \
           > "$TMPDIR/acp.out" 2> "$TMPDIR/acp.err"
         acp_status=$?
@@ -431,8 +433,8 @@ in
             printf 'models\n--json\n' > "$TMPDIR/expected"
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
-            ${configuredStub}/bin/ompo --profile work config path > "$TMPDIR/actual"
-            printf '%s\n' '--profile' 'work' 'config' 'path' > "$TMPDIR/expected"
+            ${configuredStub}/bin/ompo config path > "$TMPDIR/actual"
+            printf '%s\n' 'config' 'path' > "$TMPDIR/expected"
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
             ${configuredStub}/bin/ompo --no-extensions models --json > "$TMPDIR/actual"
@@ -440,14 +442,14 @@ in
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
             set +e
-            ${configuredStub}/bin/omp --no-extensions --mode rpc \
+            ${configuredStub}/bin/ompg --no-extensions --mode rpc \
               > "$TMPDIR/no-extensions.out" 2> "$TMPDIR/no-extensions.err"
             no_extensions_status=$?
             set -e
             test "$no_extensions_status" -eq 2
             grep -q 'Nix-owned settings guard' "$TMPDIR/no-extensions.err"
 
-            ${configuredStub}/bin/omp --resume models > "$TMPDIR/actual"
+            ${configuredStub}/bin/ompg --resume models > "$TMPDIR/actual"
             cat > "$TMPDIR/expected" <<EOF
         --extension
         ${configuredStub.platformRoot}
@@ -460,11 +462,43 @@ in
         --config
         $XDG_CONFIG_HOME/omp/local.yml
         --config
+        ${configuredStub.presets.gpt}
+        --config
         ${configuredStub.policyConfig}
         --resume
         models
         EOF
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
+
+            # Plain omp is deliberately unmanaged: every user argument passes
+            # through verbatim, and only the Nix-owned update path is blocked.
+            ${configuredStub}/bin/omp \
+              --config "$TMPDIR/plain.yml" \
+              --extension user-extension \
+              --profile work \
+              --resume models -- --config literal > "$TMPDIR/actual"
+            cat > "$TMPDIR/expected" <<EOF
+        --config
+        $TMPDIR/plain.yml
+        --extension
+        user-extension
+        --profile
+        work
+        --resume
+        models
+        --
+        --config
+        literal
+        EOF
+            diff -u "$TMPDIR/expected" "$TMPDIR/actual"
+
+            set +e
+            ${configuredStub}/bin/omp update \
+              > "$TMPDIR/plain-update.out" 2> "$TMPDIR/plain-update.err"
+            plain_update_status=$?
+            set -e
+            test "$plain_update_status" -eq 2
+            grep -q 'managed by Nix' "$TMPDIR/plain-update.err"
 
             ${configuredStub}/bin/omp --help config > "$TMPDIR/actual"
             printf '%s\n' '--help' 'config' > "$TMPDIR/expected"
@@ -484,7 +518,7 @@ in
             do
               read -r -a args <<< "$invocation"
               set +e
-              ${configuredStub}/bin/omp "''${args[@]}" \
+              ${configuredStub}/bin/ompg "''${args[@]}" \
                 > "$TMPDIR/refused.out" 2> "$TMPDIR/refused.err"
               refused_status=$?
               set -e
@@ -502,9 +536,9 @@ in
               "$TMPDIR/managed.json" >/dev/null
             jq -e '.effectiveManaged.modelRoles["machine-only"] == "machine/model:low"' \
               "$TMPDIR/managed.json" >/dev/null
-            jq -e '.effectiveManaged.tools.approvalMode == "write"' "$TMPDIR/managed.json" >/dev/null
+            jq -e '.effectiveManaged.tools.approvalMode == "yolo"' "$TMPDIR/managed.json" >/dev/null
             jq -e '.effectiveManaged.tools.approval == {
-              "bash":"prompt","eval":"prompt","browser":"prompt","task":"prompt","github":"prompt"
+              "bash":"allow","eval":"allow","browser":"allow","task":"allow","github":"allow"
             }' "$TMPDIR/managed.json" >/dev/null
             jq -e '.effectiveManaged.secrets.enabled == true' "$TMPDIR/managed.json" >/dev/null
             jq -e '.effectiveManaged.task.isolation == {
@@ -513,8 +547,8 @@ in
             jq -e '.effectiveManaged.privateToken == null' "$TMPDIR/managed.json" >/dev/null
             ! grep -q 'do-not-print' "$TMPDIR/managed.json"
             jq -e '.enforcedPolicy == {
-              "tools":{"approvalMode":"write","approval":{
-                "bash":"prompt","eval":"prompt","browser":"prompt","task":"prompt","github":"prompt"
+              "tools":{"approvalMode":"yolo","approval":{
+                "bash":"allow","eval":"allow","browser":"allow","task":"allow","github":"allow"
               }},
               "secrets":{"enabled":true},
               "task":{"isolation":{"mode":"auto","merge":"patch","commits":"generic"}}
@@ -533,7 +567,18 @@ in
               '.sources[] | select(.kind == "one-shot-config") | .path == $oneShot' \
               "$TMPDIR/managed.json" >/dev/null
 
-            PI_SMOL_MODEL=env/smol:low ${configuredStub}/bin/omp \
+            # Model-preset launchers are routing overlays only: all of them
+            # share the default profile and the normal persisted state root,
+            # so switching launchers never requires re-authentication.
+            for launcher in ompb ompf ompg ompo; do
+              ${configuredStub}/bin/"$launcher" config managed --json \
+                > "$TMPDIR/launcher-state.json"
+              jq -e '.profile == "default"' "$TMPDIR/launcher-state.json" >/dev/null
+              jq -e '.statePath == $ENV.HOME + "/.omp/agent"' \
+                "$TMPDIR/launcher-state.json" >/dev/null
+            done
+
+            PI_SMOL_MODEL=env/smol:low ${configuredStub}/bin/ompg \
               --approval-mode yolo \
               --model runtime/default:high \
               --smol runtime/smol:medium \
@@ -571,14 +616,14 @@ in
             jq -e '[.sources[].kind] | index("one-session-unattended-policy") != null' \
               "$TMPDIR/runtime-managed.json" >/dev/null
 
-            ${configuredStub}/bin/omp --yolo --mode rpc \
+            ${configuredStub}/bin/ompg --yolo --mode rpc \
               > "$TMPDIR/yolo.out" 2> "$TMPDIR/yolo.err"
             grep -q 'unattended yolo mode is enabled for this process only' "$TMPDIR/yolo.err"
             grep -Fx -- '--config' "$TMPDIR/yolo.out" >/dev/null
             grep -Fx -- '${configuredStub.yoloConfig}' "$TMPDIR/yolo.out" >/dev/null
 
             PI_SMOL_MODEL=env/smol:low PI_SLOW_MODEL=env/slow:high PI_PLAN_MODEL=env/plan:medium \
-              ${configuredStub}/bin/omp config managed --json > "$TMPDIR/runtime-env.json"
+              ${configuredStub}/bin/ompg config managed --json > "$TMPDIR/runtime-env.json"
             jq -e '
               .effectiveManaged.modelRoles.smol == "env/smol:low"
               and .effectiveManaged.modelRoles.slow == "env/slow:high"
@@ -586,11 +631,11 @@ in
             ' "$TMPDIR/runtime-env.json" >/dev/null
 
             PI_CODING_AGENT_DIR="$TMPDIR/custom-agent" \
-              ${configuredStub}/bin/omp config managed --json > "$TMPDIR/custom-state.json"
+              ${configuredStub}/bin/ompg config managed --json > "$TMPDIR/custom-state.json"
             jq -e --arg state "$TMPDIR/custom-agent" '.statePath == $state' \
               "$TMPDIR/custom-state.json" >/dev/null
 
-            ${configuredStub}/bin/omp --profile work \
+            ${configuredStub}/bin/ompg --profile work \
               config managed --json > "$TMPDIR/profile-state.json"
             jq -e --arg state "$HOME/.omp/profiles/work/agent" \
               '.profile == "work" and .statePath == $state' \
@@ -598,13 +643,13 @@ in
 
             OMP_PROFILE=default PI_PROFILE=work \
               PI_CODING_AGENT_DIR="$HOME/.omp/profiles/work/agent" \
-              ${configuredStub}/bin/omp config managed --json > "$TMPDIR/default-profile-state.json"
+              ${configuredStub}/bin/ompg config managed --json > "$TMPDIR/default-profile-state.json"
             jq -e --arg state "$HOME/.omp/agent" \
               '.profile == "default" and .statePath == $state' \
               "$TMPDIR/default-profile-state.json" >/dev/null
 
             set +e
-            ${configuredStub}/bin/omp --profile ../../escape config managed --json \
+            ${configuredStub}/bin/ompg --profile ../../escape config managed --json \
               > "$TMPDIR/invalid-profile.out" 2> "$TMPDIR/invalid-profile.err"
             invalid_profile_status=$?
             set -e
@@ -612,7 +657,7 @@ in
             grep -q 'Invalid OMP profile' "$TMPDIR/invalid-profile.err"
 
             PI_CONFIG_DIR=.custom-omp \
-              ${configuredStub}/bin/omp config managed --json > "$TMPDIR/config-root.json"
+              ${configuredStub}/bin/ompg config managed --json > "$TMPDIR/config-root.json"
             jq -e --arg state "$HOME/.custom-omp/agent" '.statePath == $state' \
               "$TMPDIR/config-root.json" >/dev/null
 
@@ -623,7 +668,7 @@ in
           yaml-machine: machine/yaml:low
         EOF
             HOME="$yaml_home" XDG_CONFIG_HOME="$yaml_home/.config" \
-              ${configuredStub}/bin/omp --cwd "$project" config managed --json \
+              ${configuredStub}/bin/ompg --cwd "$project" config managed --json \
                 > "$TMPDIR/yaml-state.json"
             jq -e --arg path "$yaml_home/.omp/agent/config.yaml" '
               .sources[0].path == $path
@@ -631,7 +676,7 @@ in
               and .effectiveManaged.modelRoles["yaml-machine"] == "machine/yaml:low"
             ' "$TMPDIR/yaml-state.json" >/dev/null
 
-            ${configuredStub}/bin/omp --system-prompt --cwd \
+            ${configuredStub}/bin/ompg --system-prompt --cwd \
               config managed --json > "$TMPDIR/arity.json"
             jq -e --arg project "$project/.omp/config.yml" \
               '.sources[] | select(.format == "config.yml") | .path == $project' \
@@ -640,24 +685,24 @@ in
             mkdir -p "$HOME/tmp/.omp" "$HOME/.omp"
             cat > "$HOME/.omp/config.yml" <<'EOF'
         modelRoles:
-          default: home/project:high
+          workspace-role: home/project:high
         EOF
             cat > "$HOME/tmp/.omp/config.yml" <<'EOF'
         modelRoles:
-          default: tmp/project:low
+          workspace-role: tmp/project:low
         EOF
             (
               cd "$HOME"
               XDG_CONFIG_HOME="$TMPDIR/auto-xdg" \
-                ${configuredStub}/bin/omp config managed --json > "$TMPDIR/home-auto.json"
+                ${configuredStub}/bin/ompg config managed --json > "$TMPDIR/home-auto.json"
               XDG_CONFIG_HOME="$TMPDIR/auto-xdg" \
-                ${configuredStub}/bin/omp --allow-home config managed --json > "$TMPDIR/home-allowed.json"
+                ${configuredStub}/bin/ompg --allow-home config managed --json > "$TMPDIR/home-allowed.json"
             )
             jq -e --arg cwd "$HOME/tmp" '
-              .effectiveCwd == $cwd and .effectiveManaged.modelRoles.default == "tmp/project:low"
+              .effectiveCwd == $cwd and .effectiveManaged.modelRoles["workspace-role"] == "tmp/project:low"
             ' "$TMPDIR/home-auto.json" >/dev/null
             jq -e --arg cwd "$HOME" '
-              .effectiveCwd == $cwd and .effectiveManaged.modelRoles.default == "home/project:high"
+              .effectiveCwd == $cwd and .effectiveManaged.modelRoles["workspace-role"] == "home/project:high"
             ' "$TMPDIR/home-allowed.json" >/dev/null
 
             legacy_project="$TMPDIR/legacy-project"
@@ -673,7 +718,7 @@ in
         modelRoles:
           default: relative/one-shot:high
         EOF
-            ${configuredStub}/bin/omp \
+            ${configuredStub}/bin/ompg \
               --cwd "$legacy_project" \
               --config relative.yml \
               config managed --json > "$TMPDIR/legacy-managed.json"
@@ -686,23 +731,24 @@ in
             ' "$TMPDIR/legacy-managed.json" >/dev/null
 
             set +e
-            ${configuredStub}/bin/omp config get modelRoles --json \
+            ${configuredStub}/bin/ompg config get modelRoles --json \
               > "$TMPDIR/get.out" 2> "$TMPDIR/get.err"
             get_status=$?
             set -e
             test "$get_status" -eq 2
             grep -q 'only reads writable machine state' "$TMPDIR/get.err"
 
-            ${configuredStub}/bin/omp config list > "$TMPDIR/list.out" 2> "$TMPDIR/list.err"
+            ${configuredStub}/bin/ompg config list > "$TMPDIR/list.out" 2> "$TMPDIR/list.err"
             grep -q 'shows writable machine state' "$TMPDIR/list.err"
 
-            ${configuredStub}/bin/omp setup --help > "$TMPDIR/setup.out" 2> "$TMPDIR/setup.err"
+            ${configuredStub}/bin/ompg setup --help > "$TMPDIR/setup.out" 2> "$TMPDIR/setup.err"
             printf '%s\n' setup --help > "$TMPDIR/expected"
             diff -u "$TMPDIR/expected" "$TMPDIR/setup.out"
             grep -q 'writes writable machine state' "$TMPDIR/setup.err"
 
+            # Plain omp is unmanaged and has no Nix-declared default model;
+            # the managed defaults file is asserted directly with yq above.
             declare -A expected_default_models=(
-              [omp]='openai-codex/gpt-5.6-terra:medium'
               [ompb]='openai-codex/gpt-5.6-terra:low'
               [ompf]='anthropic/claude-fable-5:high'
               [ompg]='openai-codex/gpt-5.6-sol:high'
@@ -711,7 +757,7 @@ in
             policy_home="$TMPDIR/policy-home"
             policy_project="$TMPDIR/policy-project"
             mkdir -p "$policy_home" "$policy_project"
-            for command in omp ompb ompf ompg ompo; do
+            for command in ompb ompf ompg ompo; do
               HOME="$policy_home" XDG_CONFIG_HOME="$policy_home/.config" \
                 ${configuredStub}/bin/"$command" --cwd "$policy_project" \
                   config managed --json > "$TMPDIR/$command-policy.json"

--- a/docs/agent-security.md
+++ b/docs/agent-security.md
@@ -6,19 +6,25 @@ repository trustworthy, and it is not an operating-system sandbox.
 
 ## Normal sessions
 
-Normal launchers use workspace-write approval, secret filtering, and explicit
-prompts for shell/eval, browser, task spawning, and GitHub capabilities. Task
-isolation uses OMP's automatic backend selection and patch merging. A managed
-extension fails closed when a `task` call that can write omits
-`isolated: true`, including any item in a task batch.
+Managed preset launchers (`ompb`, `ompf`, `ompg`, `ompo`) use the
+trusted-machine unattended approval policy: workspace edits, shell/eval,
+browser, task spawning, and GitHub operations do not prompt. Secret filtering
+remains enabled, and task isolation uses OMP's automatic backend selection and
+patch merging. A managed extension fails closed when a `task` call that can
+write omits `isolated: true`, including any item in a task batch.
 
 The policy overlay is applied after writable machine, project, preset, and
 one-shot configuration. Repositories can still choose non-security settings,
-but cannot persistently weaken managed approvals, secret filtering, or task
-isolation. The untrusted profile additionally fixes MCP and integration policy.
-Explicit yolo flags are the sole normal-session exception: they apply an allow
-overlay for that process, print a warning, and must be chosen again for every
-session.
+but cannot change managed approvals, secret filtering, or task isolation.
+Explicit yolo flags remain accepted for compatibility, but do not grant these
+sessions additional tool approval.
+
+Plain `omp` is deliberately outside this policy: it runs upstream OMP with the
+operator's mutable configuration and no Nix overlay, as the tinkering surface
+for a machine the operator already trusts. Its approval posture, extensions,
+and integrations are whatever that mutable configuration says, so every
+launcher in this table is appropriate only for repositories the operator has
+reviewed; use `ompu` for untrusted repositories.
 
 ## Untrusted projects
 

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -44,24 +44,30 @@ rewriting the Bun executable with `patchelf`.
 
 | Command | Intended use | Primary route |
 | --- | --- | --- |
-| `omp` | Balanced daily work | GPT-5.6 Terra at medium thinking |
+| `omp` | Mutable daily driver; user-owned configuration | Whatever the operator's own OMP config selects; unmanaged apart from the blocked `update` |
 | `ompb` | Cost-conscious routine work | GPT-5.6 Terra/Luna at lower thinking |
 | `ompg` | OpenAI-only difficult work | GPT-5.6 Sol with Terra/Luna fallbacks |
 | `ompo` | Expensive review and deep reasoning | GPT-5.6 with Opus fallbacks for selected roles |
 | `ompf` | Fable-first work with predictable routing | Fable for primary/deliberative roles, with automatic fallback disabled |
 | `ompu` | Deliberately untrusted repositories | Dedicated state, sanitized credentials, restricted integrations, and isolated writing tasks |
 
-The balanced profile keeps cheap, fast roles on Luna or low-thinking Terra,
-uses Sol for the hardest debugging and testing, and reserves Fable/Opus for
-planning, design, architecture, and review where their higher cost is most
-useful. The presets are policy, not provider pricing data; revisit the routes
-when model quality or pricing changes.
+Plain `omp` executes upstream OMP directly: no extension, defaults, preset, or
+policy overlay is injected, so its models, approvals, and interface belong to
+the operator's mutable configuration and can change on the fly. Only
+`omp update` is blocked, so nothing shadows the Nix-pinned binary.
+
+The managed defaults use Sol for interactive daily work, keep cheap, fast
+roles on Luna or low-thinking Terra, and reserve Fable/Opus for planning,
+design, architecture, and review where their higher cost is most useful. The
+presets are policy, not provider pricing data; revisit the routes when model
+quality or pricing changes.
 
 The balanced routing rationale is:
 
 | Role or role group | Capability and intended use | Thinking | Cost posture and fallback rationale |
 | --- | --- | --- | --- |
-| `default`, `task` | General implementation on Terra | Medium | Mid-cost default; Sonnet then Sol covers provider or capability failures |
+| `default` | Interactive daily work on Sol | Medium | Sol is the user-selected default; Sonnet then Terra preserve cross-provider fallback |
+| `task` | General implementation on Terra | Medium | Mid-cost worker route; Sonnet then Sol covers provider or capability failures |
 | `librarian` | Repository and documentation research on Terra | Medium | Sonnet adds cross-provider depth; Luna is the economical final fallback |
 | `advisor`, `smol`, `sonic`, `tiny`, `commit` | Fast review, lookup, naming, and commit-message work on Luna | Minimal–low | Cheapest recurring work; Terra is the first quality step-up |
 | `explore` | Repository exploration on Terra | Low | Keeps discovery economical; Luna or Sonnet can take over when needed |
@@ -77,7 +83,7 @@ The balanced routing rationale is:
 the preset files intentionally change parts of this table for budget,
 OpenAI-only, Fable-first, and Opus-assisted sessions.
 
-Normal sessions load configuration in this order:
+Managed preset launchers load configuration in this order:
 
 1. OMP's writable machine config at `~/.omp/agent/config.yml`, with
    `config.yaml` accepted as OMP's legacy fallback when `config.yml` is absent;
@@ -91,23 +97,25 @@ Normal sessions load configuration in this order:
 7. the Nix-managed enforced policy; and
 8. explicit runtime flags such as `--model` or `--approval-mode`.
 
-Later layers win. The enforced policy fixes workspace-write approval, secret
-obfuscation, explicit prompts for shell/eval, browser, task spawning, and
-GitHub capabilities, plus automatic task isolation with patch merging. Machine,
-project, preset, and one-shot config files cannot weaken those controls. `omp
-acp` receives the same layers in the same order, with the overlays placed after
-the `acp` subcommand as required by OMP's parser.
+Later layers win. The enforced policy fixes trusted-machine yolo approvals for
+workspace edits, shell/eval, browser, task spawning, and GitHub capabilities,
+plus secret obfuscation and automatic task isolation with patch merging.
+Machine, project, preset, and one-shot config files cannot change those
+controls. `omp acp` receives the same layers in the same order, with the
+overlays placed after the `acp` subcommand as required by OMP's parser.
 
-Unattended yolo mode is available only through an explicit `--yolo`,
-`--auto-approve`, or `--approval-mode yolo` runtime flag. The wrapper prints a
-warning and applies a one-process approval overlay after the enforced policy.
-There is intentionally no persistent yolo config, profile, or alias.
+Managed preset launchers are unattended trusted-machine profiles. Explicit
+`--yolo`, `--auto-approve`, and `--approval-mode yolo` flags remain supported
+for compatibility, but do not grant those sessions additional tool approval.
+Plain `omp` carries none of these layers: its approval posture is whatever the
+operator's mutable configuration selects. Use `ompu` for deliberately
+untrusted repositories.
 
 OMP maintenance subcommands are passed directly to OMP because their parsers do
 not consistently accept interactive launch flags. Preset launchers preserve
-that passthrough instead of prepending their preset to a maintenance command.
-`omp setup` warns that it writes lower-priority machine state and points back to
-the effective diagnostic.
+that passthrough instead of prepending their preset to a maintenance command,
+and their `setup` warns that it writes lower-priority machine state and points
+back to the effective diagnostic.
 `omp update` and `herdr update` are refused so they cannot shadow the
 Nix-managed versions.
 

--- a/omp/defaults.yml
+++ b/omp/defaults.yml
@@ -5,7 +5,7 @@ symbolPreset: unicode
 colorBlindMode: true
 
 modelRoles:
-  default: openai-codex/gpt-5.6-terra:medium
+  default: openai-codex/gpt-5.6-sol:medium
   advisor: openai-codex/gpt-5.6-luna:low
   smol: openai-codex/gpt-5.6-luna:low
   task: openai-codex/gpt-5.6-terra:medium
@@ -32,7 +32,7 @@ retry:
   fallbackChains:
     default:
       - anthropic/claude-sonnet-5:medium
-      - openai-codex/gpt-5.6-sol:medium
+      - openai-codex/gpt-5.6-terra:medium
     advisor:
       - openai-codex/gpt-5.6-terra:low
       - anthropic/claude-sonnet-5:medium

--- a/omp/policy.yml
+++ b/omp/policy.yml
@@ -1,11 +1,11 @@
 tools:
-  approvalMode: write
+  approvalMode: yolo
   approval:
-    bash: prompt
-    eval: prompt
-    browser: prompt
-    task: prompt
-    github: prompt
+    bash: allow
+    eval: allow
+    browser: allow
+    task: allow
+    github: allow
 
 secrets:
   enabled: true

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -966,7 +966,16 @@ let
       '';
     };
 
-  ompDefault = mkOmpCommand "omp" [ ];
+  ompDefault = writeShellApplication {
+    name = "omp";
+    text = ''
+      if [[ "''${1:-}" == update ]]; then
+        printf '%s\n' 'OMP is managed by Nix. Update the pinned derivation, then run zconf.' >&2
+        exit 2
+      fi
+      exec ${lib.getExe omp} "$@"
+    '';
+  };
   ompBudget = mkOmpCommand "ompb" [ presets.budget ];
   ompFable = mkOmpCommand "ompf" [ presets.fable ];
   ompGpt = mkOmpCommand "ompg" [ presets.gpt ];


### PR DESCRIPTION
Completes the work-in-progress from the operator's omp config-review session (`omp --resume 019f4f7b-…`), explicitly requested and authorized by the operator. The session's uncommitted diff in `~/nix-dotfiles` was ported here unchanged; the unapplied parts of its plan (check restructuring, docs reconciliation) are finished on top. The original working tree was left untouched.

## What changes

**Trusted-machine autonomy (the "no more approval prompts" ask).** `omp/policy.yml` moves from `approvalMode: write` + prompt-per-tool to `approvalMode: yolo` with bash/eval/browser/task/GitHub allowed. Secret filtering and automatic task isolation (patch merge, generic commits, fail-closed task guard) remain enforced. `ompu` stays fully restricted for untrusted repositories.

**Plain `omp` becomes mutable (the "keep regular omp tinkerable" ask).** It now executes upstream OMP directly — no extension, defaults, preset, or policy overlay — so models, approvals, and UI live in the operator's own config and can change on the fly. Only `omp update` stays blocked so nothing shadows the Nix-pinned binary. The preset launchers (`ompb`/`ompf`/`ompg`/`ompo`) and `ompu` remain immutable Nix policy.

**Managed default model → Sol** (`openai-codex/gpt-5.6-sol:medium`), fallback chain swapped accordingly.

**Launcher auth (the "re-authenticate for each alias" ask).** The session's investigation concluded no product change is needed: preset launchers already share the default profile and persisted auth state; re-auth requests were provider coverage (`ompf`/`ompo` route to Anthropic), and `omph` never existed. A new regression loop asserts every preset launcher reports `profile == "default"` and the shared `~/.omp/agent` state root.

**Checks and docs reconciled with the ownership model:** managed stub diagnostics moved from plain `omp` to `ompg` (preset-layer argv adjustments, neutral fixture role keys), plain-`omp` passthrough and `update`-refusal coverage added, and README/agent-tools/agent-security now document three tiers — mutable `omp`, immutable trusted-autonomy presets, isolated `ompu`.

## Security note

This deliberately widens agent authority on trusted machines and removes the prompt gate — the operator's explicit, stated choice. The docs record that every non-`ompu` launcher is appropriate only for reviewed repositories.

## Verification

- `nix build .#checks.x86_64-linux.{omp-wrapper,omp-stack,agent-tools-migration}` — pass, including the new shared-state loop, passthrough/update-refusal coverage, and relocated managed diagnostics.
- `nix flake check --no-build` — all outputs evaluate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)