### PR TITLE
fix(atyrode): pass nh home a bare flake reference

### DIFF
--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -106,7 +106,8 @@ pkgs.runCommand "check-atyrode-cli"
     unset ATYRODE_NH_FAIL
 
     atyrode apply --repo "$HOME/nix-dotfiles" --dry-run >/dev/null
-    grep -F -- 'home switch ' "$TMPDIR/nh-args" >/dev/null
+    grep -F -- "home switch $HOME/nix-dotfiles --configuration alex-x86_64-linux" \
+      "$TMPDIR/nh-args" >/dev/null
     grep -F -- '--dry' "$TMPDIR/nh-args" >/dev/null
     test "$(cat "$XDG_STATE_HOME/atyrode/dotfiles-config")" = sentinel
 
@@ -120,7 +121,9 @@ pkgs.runCommand "check-atyrode-cli"
     test "$(cat "$XDG_STATE_HOME/atyrode/dotfiles-config")" = sentinel
 
     atyrode apply >/dev/null
-    grep -F -- 'github:atyrode/dotfiles/feedfacefeedfacefeedfacefeedfacefeedface#alex-x86_64-linux' \
+    # nh home must receive the bare flake reference; a #fragment form is
+    # passed to nix verbatim and fails attribute resolution.
+    grep -F -- 'home switch github:atyrode/dotfiles/feedfacefeedfacefeedfacefeedfacefeedface --configuration alex-x86_64-linux' \
       "$TMPDIR/nh-args" >/dev/null
     test "$(cat "$XDG_STATE_HOME/atyrode/dotfiles-config")" = alex-x86_64-linux
 

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -714,7 +714,7 @@ apply_config() {
   done
   [[ -z "$repo" || -z "$ref" ]] || die "$EX_USAGE" "--ref selects a published revision and cannot be combined with --repo"
 
-  local host data expected_system expected_user expected_hostname platform source repository revision dirty backend installable
+  local host data expected_system expected_user expected_hostname platform source repository flake_source revision dirty backend installable
   local git_command=git
   if [[ "$test_hooks" == 1 && -n "${ATYRODE_GIT:-}" ]]; then
     git_command="$ATYRODE_GIT"
@@ -739,6 +739,7 @@ apply_config() {
     revision="$("$git_command" -C "$repo" rev-parse --short=12 HEAD)"
     dirty=false; "$git_command" -C "$repo" diff --quiet --ignore-submodules HEAD -- || dirty=true
     repository="$repo"
+    flake_source="$repo"
     installable="$repo#$host"
   else
     source="remote"
@@ -756,6 +757,7 @@ apply_config() {
     revision="${rev:0:12}"
     dirty=false
     repository="$flake_ref"
+    flake_source="$flake_ref/$rev"
     installable="$flake_ref/$rev#$host"
   fi
   backend="nh-home"; [[ "$platform" != darwin ]] || backend="nh-darwin"
@@ -774,8 +776,11 @@ apply_config() {
   if [[ "$test_hooks" == 1 && -n "${ATYRODE_NH:-}" ]]; then
     nh_command="$ATYRODE_NH"
   fi
+  # nh home passes a #fragment through to nix verbatim instead of treating
+  # it as the configuration name, so the flake reference goes bare and
+  # --configuration carries the host; nh darwin resolves the fragment itself.
   if [[ "$platform" == darwin ]]; then nh_args=("$nh_command" darwin switch "$installable" --diff always)
-  else nh_args=("$nh_command" home switch "$installable" --configuration "$host" --backup-extension backup --diff always); fi
+  else nh_args=("$nh_command" home switch "$flake_source" --configuration "$host" --backup-extension backup --diff always); fi
   [[ "$dry" == 0 ]] || nh_args+=(--dry)
   "${nh_args[@]}" || die "$EX_SOFTWARE" "$backend activation failed"
   if [[ "$dry" == 0 ]]; then


### PR DESCRIPTION
## Problem

First real remote activation on the VPS failed:

```
error: flake 'github:atyrode/dotfiles/4119e8a…' does not provide attribute
'packages.x86_64-linux.alex-x86_64-linux', 'legacyPackages.x86_64-linux.alex-x86_64-linux' or 'alex-x86_64-linux'
```

`nh home switch` passes an installable's `#fragment` through to nix verbatim instead of treating it as the home configuration name, so `github:…#alex-x86_64-linux` resolved as a top-level attribute and failed. The local `--repo` path carried the same latent form (masked in checks by the nh stub; historical activations predate the atyrode/nh flow or used the darwin backend, which resolves fragments itself).

## Fix

`nh home` receives the bare flake reference (local path or pinned `github:…/<rev>`), with the host carried solely by `--configuration`. `nh darwin` keeps the fragment form that works (proven on the Mac tonight). The plan/JSON `installable` field is unchanged as the canonical name.

Verified live before patching: `nh home switch 'github:atyrode/dotfiles/4119e8a…' --configuration alex-x86_64-linux --dry` evaluates and builds the remote generation correctly.

## Verification

- `nix build .#checks.x86_64-linux.atyrode-cli` — the check now asserts the exact fragment-less `home switch <ref> --configuration <host>` invocation for both local and remote sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)