### PR TITLE
feat(claude): deploy operator policy and permissions declaratively

### DIFF
--- a/checks/portable-profiles.nix
+++ b/checks/portable-profiles.nix
@@ -80,6 +80,11 @@ assert lib.assertMsg serverConfig.programs.nix-index-database.comma.enable
   "portable server must enable comma";
 assert lib.assertMsg serverConfig.atyrode.agentTools.enable
   "portable server must enable managed agent tools";
+assert lib.assertMsg (lib.hasInfix "Bash(gh pr merge:*)"
+  serverConfig.home.file.".claude/settings.json".text
+) "portable server must carry the Claude Code standing merge authorization";
+assert lib.assertMsg (builtins.hasAttr ".claude/CLAUDE.md" serverConfig.home.file)
+  "portable server must deploy the managed Claude Code operator policy";
 assert lib.assertMsg (
   !(serverConfig.home.sessionVariables ? ATYRODE_HOST)
 ) "portable profiles must not invent a host identity";

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -14,6 +14,8 @@ Nix owns:
 - the patched bundled agents, custom deep agents, global generic skills, and
   managed-settings guard extension;
 - the `omp`, `ompb`, `ompf`, `ompg`, `ompo`, and restricted `ompu` launchers; and
+- Claude Code's user-scope operator policy: the deployed `~/.claude/CLAUDE.md`
+  instructions and `~/.claude/settings.json` permission rules; and
 - mise itself, with no globally declared mise tools.
 
 OMP and Herdr continue to own mutable runtime data such as authentication,

--- a/home/claude.nix
+++ b/home/claude.nix
@@ -1,0 +1,14 @@
+{ ... }:
+
+{
+  # Nix owns Claude Code's durable operator policy: the standing-authorization
+  # instructions loaded by every session and the user-scope permission rules.
+  # Sessions keep their mutable state (projects, memory, credentials, and
+  # machine-local project settings) outside the store, mirroring the OMP and
+  # Codex ownership split.
+  home.file.".claude/CLAUDE.md".source = ./claude/CLAUDE.md;
+
+  home.file.".claude/settings.json".text = builtins.toJSON {
+    permissions.allow = [ "Bash(gh pr merge:*)" ];
+  };
+}

--- a/home/claude/CLAUDE.md
+++ b/home/claude/CLAUDE.md
@@ -1,0 +1,23 @@
+# Operator policy (Nix-managed)
+
+This file is deployed by atyrode/dotfiles (`home/claude/CLAUDE.md`) to every
+managed machine. Edit it in the repository and reapply; local edits are
+overwritten by the next activation.
+
+## Standing merge authorization
+
+Default to merging PRs autonomously once CI is green and the work is verified —
+Alex trusts this and granted it explicitly (2026-07-11). The evaluation step
+stays, but the default outcome is merge, not ask. Escalate and hold for his
+review only when the merge genuinely warrants it: risky or behavior-changing
+work, anything touching deploy, security posture, or data, scope beyond what he
+asked for, or when confidence in the verification is low. Merge with squash and
+delete the branch, matching the repository convention.
+
+## Working conventions
+
+- The dotfiles are developed on the Hetzner VPS (`~/nix-dotfiles`); other
+  machines only consume them via `atyrode apply`.
+- Persist permission rules at the user scope (`~/.claude/settings.json` is
+  Nix-managed; machine-local exceptions belong in project
+  `settings.local.json`), never in a worktree.

--- a/home/profiles/agent-tools.nix
+++ b/home/profiles/agent-tools.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ../../modules/home/agent-tools.nix
+    ../claude.nix
     ../codex.nix
   ];
 


### PR DESCRIPTION
Requested by the operator: the merge-autonomy agreement and the `gh pr merge` permission rule kept getting lost (project-scoped memory invisible across projects; a hand-written settings.json already deleted once with a cleaned-up worktree). This makes them part of the dotfiles so every redeploy carries them.

## What

- **`home/claude/CLAUDE.md`** (new, repo-versioned) deploys to `~/.claude/CLAUDE.md` via the agent-tools capability — loaded by every Claude Code session on every managed machine. It records the standing merge authorization with its escalation carve-outs (security/deploy/data, scope creep, weak verification) plus two working conventions (dev happens on the VPS; permission rules never belong in worktree scope).
- **`~/.claude/settings.json`** becomes Nix-managed with `permissions.allow: ["Bash(gh pr merge:*)"]` — identical to what the operator hand-wrote today, now durable. Machine-local exceptions stay in mutable project `settings.local.json`.
- Ownership documented in docs/agent-tools.md; the portable-profiles check asserts both files reach the server composition.

Mutable Claude state (projects, memory, credentials) deliberately stays outside the store, mirroring the OMP/Codex ownership split.

## Verification

`nix flake check --no-build` passes; `portable-profiles` and `home-evaluation` build green with the new assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)