### PR TITLE
ci(nix): save platform caches from pull request runs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: read
+  # cache-nix-action purges superseded platform caches after saving.
+  actions: write
 
 concurrency:
   group: nix-${{ github.workflow }}-${{ github.ref }}
@@ -46,16 +48,21 @@ jobs:
 
       # Restore the newest Nix store cache for this platform; without it every
       # run rebuilds all local derivations from an empty store (~13 min).
-      # Saving happens only on pushes to main so pull requests never pay the
-      # multi-gigabyte save step; GitHub's 10 GiB LRU quota evicts old entries.
-      # The store is deliberately not garbage-collected before saving: a
-      # `nix flake check` store has no GC roots, so collection would empty it.
+      # Every run saves on a primary-key miss, so a pull request that changes
+      # flake.lock pays the cold rebuild once instead of on every push; the
+      # purge inputs then keep only the newest cache per platform inside
+      # GitHub's 10 GiB quota. The store is deliberately not garbage-collected
+      # before saving: a `nix flake check` store has no GC roots, so
+      # collection would empty it.
       - name: Restore Nix store
         uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
         with:
           primary-key: nix-${{ matrix.system }}-${{ hashFiles('flake.lock', '**/*.nix', 'checks/**', 'darwin/**', 'home/**', 'hosts/**', 'inventory/**', 'modules/**', 'pkgs/**', 'scripts/**', 'install.sh') }}
           restore-prefixes-first-match: nix-${{ matrix.system }}-
-          save: ${{ github.ref == 'refs/heads/main' }}
+          purge: true
+          purge-prefixes: nix-${{ matrix.system }}-
+          purge-created: 0
+          purge-primary-key: never
 
       - name: Check flake
         run: nix flake check --show-trace


### PR DESCRIPTION
Caches previously saved only on pushes to main, so a pull request that changed `flake.lock` rebuilt the new closure on **every push** until merge — the nixpkgs bump in #51 costs 12–15 macOS minutes per iteration against a 3.7-minute warm run.

Every run now saves on a primary-key miss, and cache-nix-action's purge inputs keep only the newest cache per platform, so PR churn cannot evict another platform's entry from the 10 GiB quota. Purging needs the added `actions: write` permission.

First cold push still pays once; every subsequent push of the same PR restores the previously saved store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)