### PR TITLE
fix(claude): drop a provider name from the deployed policy

### DIFF
--- a/checks/production-facts.nix
+++ b/checks/production-facts.nix
@@ -1,0 +1,24 @@
+{ pkgs }:
+
+# Public artifacts must carry no production facts: no address literals and no
+# hosting-provider or datacenter identifiers. The rule was cultural until a
+# deployed policy file named a provider (#56); now every tracked file is
+# scanned. Loopback and wildcard addresses stay permitted, and this file is
+# excluded because it defines the patterns it forbids.
+pkgs.runCommand "check-production-facts" { repo = ../.; } ''
+  cd "$repo"
+  fail=0
+  if matches="$(grep -rInE --exclude=production-facts.nix \
+    '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' . \
+    | grep -vE '0\.0\.0\.0|127\.0\.0\.1')"; then
+    printf 'address literal in a public artifact:\n%s\n' "$matches" >&2
+    fail=1
+  fi
+  if matches="$(grep -rIinE --exclude=production-facts.nix \
+    'hetzner|scaleway|ovhcloud|digitalocean|linode|vultr|nbg1|fsn1|hel1|ubuntu-[0-9]+gb' .)"; then
+    printf 'provider or datacenter identifier in a public artifact:\n%s\n' "$matches" >&2
+    fail=1
+  fi
+  test "$fail" -eq 0
+  mkdir "$out"
+''

--- a/docs/portable-profiles.md
+++ b/docs/portable-profiles.md
@@ -121,7 +121,9 @@ Linux systems export `packages.<system>.server-profile-manifest`. Its
 evaluated top-level package names, state ownership boundaries, and actual and
 maximum closure measurements. `home-activation` points at the exact evaluated
 Home Manager generation. The manifest contains no identity or production
-facts.
+facts, and the repository-wide production-facts check enforces the same rule
+for every tracked file: no address literals, providers, or datacenter
+identifiers.
 
 At the pinned 2026-07-10 revision, x86_64 Linux delivers 36 top-level packages
 and measures 2,108,944,256 NAR bytes across 396 store paths. Its review ceilings

--- a/flake.nix
+++ b/flake.nix
@@ -602,6 +602,7 @@
             baseConfig = baseOnlyConfig;
           };
           get-entrypoint = import ./checks/get-sh.nix { inherit pkgs; };
+          production-facts = import ./checks/production-facts.nix { inherit pkgs; };
           home-evaluation = homeEvaluation;
           host-registry = registryCheck;
           package-ownership = import ./checks/package-ownership.nix {

--- a/home/claude/CLAUDE.md
+++ b/home/claude/CLAUDE.md
@@ -16,8 +16,8 @@ delete the branch, matching the repository convention.
 
 ## Working conventions
 
-- The dotfiles are developed on the Hetzner VPS (`~/nix-dotfiles`); other
-  machines only consume them via `atyrode apply`.
+- The dotfiles are developed on the primary Linux development machine
+  (`~/nix-dotfiles`); other machines only consume them via `atyrode apply`.
 - Persist permission rules at the user scope (`~/.claude/settings.json` is
   Nix-managed; machine-local exceptions belong in project
   `settings.local.json`), never in a worktree.


### PR DESCRIPTION
A public-repo disclosure audit found one violation of the repository's own no-production-facts discipline (the rule that keeps hostnames, providers, and addresses out of public artifacts — see the server-profile manifest policy): the managed Claude policy file named the development machine's hosting provider. Introduced in #53; describe the machine by role instead. gitleaks over all 84 commits found no secret leaks; this was the only production-fact disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)