### PR TITLE
chore(git): ignore the Claude Code state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ result-*
 # OS
 .DS_Store
 Thumbs.db
+
+# Agent session state and worktrees
+.claude/


### PR DESCRIPTION
`install.sh` preflight correctly refuses dirty checkouts, but Claude Code's `.claude/` state directory (worktrees, session data) made every agent-touched machine permanently "dirty" — blocking bootstrap with `use --allow-dirty only after reviewing`. Ignoring it exempts it from the untracked-files check (`--untracked-files=normal` skips ignored paths) while keeping the preflight strict for everything real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)