### PR TITLE
feat(codex): own the release binary pin on every platform

### DIFF
--- a/docs/package-ownership.md
+++ b/docs/package-ownership.md
@@ -36,7 +36,7 @@ and #30; neither is pulled into the baseline for harness symmetry.
 | Harness/surface | Hosts | Version owner | Mutable state | Supported launch modes |
 |---|---|---|---|---|
 | Claude Code CLI | `agent-tools` | pinned nixpkgs | `~/.claude`, `~/.claude.json` | interactive, print |
-| Codex CLI | `agent-tools` | pinned nixpkgs; pinned upstream release binary on aarch64-darwin | `~/.codex`, isolated profiles | interactive, exec |
+| Codex CLI | `agent-tools` | pinned upstream release binaries (repository derivation) | `~/.codex`, isolated profiles | interactive, exec |
 | OMP | `agent-tools` | repository derivation | profile-scoped auth, sessions, MCP, caches | normal, preset, untrusted, ACP |
 | Herdr + tmux adapter | `agent-tools` | repository derivation + pinned nixpkgs | workspace registry and tmux server | workspace, agent |
 | bubblewrap backend | Linux `agent-tools` | pinned nixpkgs | none | OMP task isolation |

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,6 @@
         "arduino-ide"
         "chatgpt"
         "claude-code"
-        "codex"
         "obsidian"
         "orbstack"
         "parsec-bin"
@@ -265,13 +264,9 @@
           herdr.overlays.default
           (final: previous: {
             agent-tools-migrate = final.callPackage ./pkgs/agent-tools-migrate { };
-            # nixpkgs codex depends on livekit-libwebrtc, which fails to build
-            # on aarch64-darwin; the official release binary stands in there.
-            codex =
-              if final.stdenv.hostPlatform.system == "aarch64-darwin" then
-                final.callPackage ./pkgs/codex-bin { }
-              else
-                previous.codex;
+            # Repository-owned on every platform: upstream releases outpace
+            # nixpkgs, which also cannot build codex on aarch64-darwin.
+            codex = final.callPackage ./pkgs/codex-bin { };
             codex-configured = final.callPackage ./pkgs/codex-configured { };
             codex-use = final.callPackage ./pkgs/codex-use { };
             herdr-configured = final.callPackage ./pkgs/herdr-configured { };

--- a/pkgs/atyrode/default.nix
+++ b/pkgs/atyrode/default.nix
@@ -89,7 +89,7 @@ let
         command = "codex";
         capability = "agent-tools";
         version = lib.getVersion codex;
-        versionOwner = "pinned nixpkgs";
+        versionOwner = "repository package derivation";
         mutableState = "~/.codex and ~/.codex-profiles";
         launchModes = [
           "interactive"

--- a/pkgs/codex-bin/default.nix
+++ b/pkgs/codex-bin/default.nix
@@ -4,24 +4,44 @@
   stdenvNoCC,
 }:
 
-# nixpkgs builds codex from source against livekit-libwebrtc, which does not
-# build on aarch64-darwin (linker failure upstream). Track the official
-# release binary there, mirroring the ghostty-bin and omp repackages; drop
-# this when livekit-libwebrtc builds on aarch64-darwin in nixpkgs again.
-stdenvNoCC.mkDerivation (finalAttrs: {
+# Codex is repository-owned: upstream releases outpace nixpkgs (which also
+# fails to build codex on aarch64-darwin against livekit-libwebrtc), so every
+# platform tracks the official release binaries, mirroring the omp repackage.
+# The Linux assets are static musl builds and need no loader fixup.
+let
+  version = "0.144.1";
+  sources = {
+    "aarch64-darwin" = {
+      asset = "codex-aarch64-apple-darwin";
+      hash = "sha256-iOcqyL0wgV99GOYtrDM9wgzjrRy6lL4WSaGXfdm/27g=";
+    };
+    "x86_64-linux" = {
+      asset = "codex-x86_64-unknown-linux-musl";
+      hash = "sha256-hAka4gxl/MfUEg25fRvVfX/435x2Cft4HHjC671PWig=";
+    };
+    "aarch64-linux" = {
+      asset = "codex-aarch64-unknown-linux-musl";
+      hash = "sha256-ufjvX5jkbO1Nu9N1akIj4+4pmkV/9IijMFvqRV2otbg=";
+    };
+  };
+  source =
+    sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported codex platform: ${stdenvNoCC.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation {
   pname = "codex";
-  version = "0.142.5";
+  inherit version;
 
   src = fetchurl {
-    url = "https://github.com/openai/codex/releases/download/rust-v${finalAttrs.version}/codex-aarch64-apple-darwin.tar.gz";
-    hash = "sha256-cVaxmWJzXJz7VVzde6voxA55dogfhxK3gRmSGdLjpwc=";
+    url = "https://github.com/openai/codex/releases/download/rust-v${version}/${source.asset}.tar.gz";
+    inherit (source) hash;
   };
 
   sourceRoot = ".";
 
   installPhase = ''
     runHook preInstall
-    install -Dm755 codex-aarch64-apple-darwin "$out/bin/codex"
+    install -Dm755 ${source.asset} "$out/bin/codex"
     runHook postInstall
   '';
 
@@ -30,7 +50,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/openai/codex";
     license = lib.licenses.asl20;
     mainProgram = "codex";
-    platforms = [ "aarch64-darwin" ];
+    platforms = builtins.attrNames sources;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-})
+}


### PR DESCRIPTION
## Problem

Upstream codex is at 0.144.1; nixpkgs unstable ships 0.142.5 (and cannot build codex on aarch64-darwin at all — see #51's repackage). The operator needs current agent tooling without machine-local updates, which drift and get shadowed (tonight's stale-npm-codex incident being the case study).

## Approach

Codex becomes repository-owned on every platform, exactly like omp: `pkgs/codex-bin` tracks the official release binaries with pinned SRI hashes for aarch64-darwin and both Linux systems (static musl builds, no loader fixup). The overlay drops the darwin-only conditional, the unfree allowlist entry for the abandoned nixpkgs build is pruned (the upstream binary is Apache-2.0), and the atyrode tool inventory plus ownership matrix record the new version owner.

**The update loop is now:** bump `version` + three hashes in `pkgs/codex-bin/default.nix` → merge → `atyrode apply` everywhere. No nixpkgs dependency, no per-machine installs, no drift. (Automating the bump belongs to #13's update automation.)

## Verification

- Smoke test: the pinned x86_64-linux binary runs and reports `codex-cli 0.144.1`.
- `atyrode-cli` and `server-profile` checks green (closure fits existing budgets); `nix flake check --no-build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)