### PR TITLE
feat(pins): update omp to 16.4.4 and automate binary pin refresh

### DIFF
--- a/.github/workflows/update-pins.yml
+++ b/.github/workflows/update-pins.yml
@@ -1,0 +1,65 @@
+name: Update pins
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: update-pins
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+
+      - name: Refresh pins
+        id: refresh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          summary="$(./scripts/update-pins.sh)"
+          {
+            printf 'summary<<SUMMARY_EOF\n%s\nSUMMARY_EOF\n' "$summary"
+            if [ -n "$summary" ]; then printf 'changed=true\n'; fi
+          } >> "$GITHUB_OUTPUT"
+
+      # Bot-created pushes and pull requests do not trigger workflows, so CI
+      # is dispatched explicitly and the merge waits for its verdict. A red
+      # run leaves the pull request open: bundled-content changes usually
+      # need patch or fixture curation before the bump can land.
+      - name: Open and land the bump
+        if: steps.refresh.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SUMMARY: ${{ steps.refresh.outputs.summary }}
+        run: |
+          branch="bot/update-pins"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add pkgs
+          git commit -m "chore(pins): refresh repository-owned binaries" -m "$SUMMARY"
+          git push -f origin "$branch"
+          gh pr create --base main --head "$branch" \
+            --title "chore(pins): refresh repository-owned binaries" \
+            --body "$SUMMARY" \
+            || true
+          gh workflow run nix.yml --ref "$branch"
+          sleep 30
+          run_id="$(gh run list --workflow nix.yml --branch "$branch" --limit 1 --json databaseId --jq '.[0].databaseId')"
+          gh run watch "$run_id" --exit-status
+          gh pr merge "$branch" --squash --delete-branch
+          gh workflow run nix.yml --ref main

--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -16,7 +16,7 @@ let
   opusPreset = ../omp/presets/opus-fallback.yml;
 
   stubOmp =
-    pkgs.runCommand "omp-16.3.14-stub"
+    pkgs.runCommand "omp-stub"
       {
         meta = {
           mainProgram = "omp";
@@ -37,7 +37,7 @@ let
     omp = stubOmp;
   };
   untrustedStubOmp =
-    pkgs.runCommand "omp-16.3.14-untrusted-stub"
+    pkgs.runCommand "omp-untrusted-stub"
       {
         meta = stubOmp.meta;
       }
@@ -84,7 +84,7 @@ in
 
         raw_omp=${lib.escapeShellArg (lib.getExe pkgs.omp)}
         raw_version="$("$raw_omp" --version)"
-        test "''${raw_version##*/}" = "16.3.14"
+        test "''${raw_version##*/}" = "${lib.getVersion pkgs.omp}"
 
         for config in \
           ${defaultsConfig} \
@@ -131,7 +131,7 @@ in
 
         for command in omp ompb ompf ompg ompo ompu; do
           command_version="$(${pkgs.omp-configured}/bin/"$command" --version)"
-          test "''${command_version##*/}" = "16.3.14"
+          test "''${command_version##*/}" = "${lib.getVersion pkgs.omp}"
         done
         test ! -e ${pkgs.omp-configured}/bin/pi
         test "$(
@@ -170,7 +170,8 @@ in
           | env HOME="$acp_home" PI_CODING_AGENT_DIR="$acp_home/agent" \
             timeout 20 ${pkgs.omp-configured}/bin/omp acp > "$TMPDIR/acp-init.jsonl"
         jq -e \
-          '.id == 1 and .result.protocolVersion == 1 and .result.agentInfo.version == "16.3.14"' \
+          '.id == 1 and .result.protocolVersion == 1 and .result.agentInfo.version == $version' \
+          --arg version "${lib.getVersion pkgs.omp}" \
           "$TMPDIR/acp-init.jsonl" >/dev/null
         test ! -e "$acp_home/.pi"
 
@@ -307,10 +308,10 @@ in
 
         test "$(
           find ${pkgs.omp-agents}/share/omp/agents -maxdepth 1 -name '*.md' | wc -l
-        )" -eq 13
+        )" -eq 11
         grep -q 'HERDR_INTEGRATION_ID=omp' \
           ${pkgs.herdr-omp-integration}/share/omp/extensions/herdr-omp-agent-state.ts
-        test "$(find ${pkgs.omp-configured.platformRoot}/agents -maxdepth 1 -name '*.md' | wc -l)" -eq 13
+        test "$(find ${pkgs.omp-configured.platformRoot}/agents -maxdepth 1 -name '*.md' | wc -l)" -eq 11
         test -f ${pkgs.omp-configured.platformRoot}/extensions/managed-settings-guard.ts
         test -f ${pkgs.omp-configured.platformRoot}/extensions/task-isolation-guard.ts
         test -f ${pkgs.omp-configured.platformRoot}/rules/no-shell-text-surgery.md

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -233,7 +233,15 @@ files.
 
 ## Updating
 
-1. Update OMP's version, asset names, and hashes in `pkgs/omp/default.nix`.
+The `update-pins` workflow refreshes the repository-owned binary pins (OMP
+and Codex) every six hours: `scripts/update-pins.sh` bumps versions and
+hashes, a bot pull request runs the full dispatched CI, and a green run
+merges itself. A red run leaves the pull request open for curation — that is
+the expected outcome when upstream changes bundled content. The manual flow
+below remains valid for hand-driven updates:
+
+1. Update OMP's version, asset names, and hashes in `pkgs/omp/default.nix`
+   (or run `scripts/update-pins.sh`).
 2. Update the Herdr input revision in `flake.nix`, then run
    `nix flake lock --update-input herdr`.
 3. Review model identifiers and routing in `omp/defaults.yml` and

--- a/omp/agents/escalation.patch
+++ b/omp/agents/escalation.patch
@@ -55,23 +55,3 @@
 +
 +Do not escalate to bypass safety, security, or policy refusals. Escalation is only for benign tasks that need stronger reasoning or more context.
 +</escalation>
---- a/Tester.md
-+++ b/Tester.md
-@@ -25,6 +25,17 @@
- 
- You are a staff test engineer with taste. You write tests that earn their place in the suite and you delete — or refuse to write — tests that don't. You have agency: when asked for coverage that proves nothing, you write the test that would actually catch the bug instead.
- 
-+<escalation>
-+If you are blocked by model capability, context size, repeated tool/API failure, or low confidence on a high-impact test strategy, stop and return:
-+ESCALATE_TO_DEEP
-+- attempted:
-+- evidence:
-+- unresolved test contract:
-+- recommended next agent: tester-deep
-+
-+Do not escalate to bypass safety, security, or policy refusals. Escalation is only for benign tasks that need stronger reasoning or more context.
-+</escalation>
-+
- <stakes>
- A test suite is a liability until it pays for itself. Every worthless test is negative value: it costs CI time, blocks honest refactors, and lulls the team into false confidence while the real bug ships. A test's only job is to FAIL when behavior breaks and PASS otherwise. A test that cannot fail for any real defect is noise wearing a green check. You are here because models flood codebases with exactly that noise. You write the opposite.
- </stakes>

--- a/pkgs/omp-agents/default.nix
+++ b/pkgs/omp-agents/default.nix
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation {
     cp bundled/*.md "$agents_dir/"
     cp ${../../omp/agents/deep}/*.md "$agents_dir/"
 
-    test "$(find "$agents_dir" -maxdepth 1 -name '*.md' | wc -l)" -eq 13
+    test "$(find "$agents_dir" -maxdepth 1 -name '*.md' | wc -l)" -eq 11
 
     runHook postInstall
   '';

--- a/pkgs/omp/default.nix
+++ b/pkgs/omp/default.nix
@@ -6,23 +6,23 @@
 }:
 
 let
-  version = "16.3.14";
+  version = "16.4.4";
   sources = {
     "x86_64-linux" = {
       asset = "omp-linux-x64";
-      hash = "sha256-i3zj/IJJS1uB9DlFTbAzvHnaipTnUUEYLrr+Ed2zlZk=";
+      hash = "sha256-gQ2l2r5rLpQovmTtqhafJF+bT/kyrq4BiKcn6bcRr1U=";
     };
     "aarch64-linux" = {
       asset = "omp-linux-arm64";
-      hash = "sha256-zoBJyPF6Sho25Ax2bxzqi2H5EeSKfP1v9eiwW5i/eIA=";
+      hash = "sha256-eW3zm8WDZ+EKpJ1FucIPsA28s0YdQLQ37GlBxFb3/AU=";
     };
     "x86_64-darwin" = {
       asset = "omp-darwin-x64";
-      hash = "sha256-jUalGmV60WPWUZyCRxTE2O8FBqzWOsQv8MGq9vhswC4=";
+      hash = "sha256-qyTZfzJJ7rv+l6s/GXaAWrFieWdUjnHmD5NopyfsCgg=";
     };
     "aarch64-darwin" = {
       asset = "omp-darwin-arm64";
-      hash = "sha256-O9ZXURhA1jF6BE1qm/j5AzjjjrIMh8stDkvUq4IuPXQ=";
+      hash = "sha256-hubECoiYl+WhJ+QPAewU9yTfOa+JloeCOewQkSVBq2I=";
     };
   };
   source =

--- a/scripts/update-pins.sh
+++ b/scripts/update-pins.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Refresh the repository-owned binary pins (omp, codex) to the latest
+# upstream releases. Prints one line per bumped package; exits quietly when
+# everything is already current. Requires curl, jq, awk, and nix.
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+latest_tag() {
+  curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+    "https://api.github.com/repos/$1/releases/latest" | jq -er .tag_name
+}
+
+current_version() {
+  grep -oE 'version = "[0-9.]+"' "$1" | head -n 1 | grep -oE '[0-9.]+'
+}
+
+replace_hash() { # file asset new_hash
+  awk -v asset="$2" -v hash="$3" '
+    index($0, "\"" asset "\"") { pending = 1 }
+    pending && $1 == "hash" { sub(/sha256-[A-Za-z0-9+\/=]+/, hash); pending = 0 }
+    { print }
+  ' "$1" > "$1.bump" && mv "$1.bump" "$1"
+}
+
+bump() { # name file repo tag_prefix url_template assets...
+  local name="$1" file="$2" repo="$3" tag_prefix="$4" url_template="$5"
+  shift 5
+  local current version tag tmp asset url hash
+  current="$(current_version "$file")"
+  tag="$(latest_tag "$repo")"
+  version="${tag#"$tag_prefix"}"
+  [[ "$version" != "$current" ]] || return 0
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  sed -i "s/version = \"$current\"/version = \"$version\"/" "$file"
+  for asset in "$@"; do
+    url="${url_template//@tag@/$tag}"
+    url="${url//@asset@/$asset}"
+    curl -fsSL "$url" -o "$tmp/${asset//\//-}"
+    hash="$(nix hash file --sri "$tmp/${asset//\//-}")"
+    replace_hash "$file" "$asset" "$hash"
+  done
+  printf '%s %s -> %s\n' "$name" "$current" "$version"
+}
+
+bump omp "$repo_root/pkgs/omp/default.nix" can1357/oh-my-pi v \
+  'https://github.com/can1357/oh-my-pi/releases/download/@tag@/@asset@' \
+  omp-linux-x64 omp-linux-arm64 omp-darwin-x64 omp-darwin-arm64
+
+bump codex "$repo_root/pkgs/codex-bin/default.nix" openai/codex rust-v \
+  'https://github.com/openai/codex/releases/download/@tag@/@asset@.tar.gz' \
+  codex-aarch64-apple-darwin codex-x86_64-unknown-linux-musl codex-aarch64-unknown-linux-musl


### PR DESCRIPTION
## What

- **omp 16.3.14 → 16.4.4** — produced by the new updater script itself, with the curation the bump demanded: upstream removed the bundled `Tester` agent (escalation patch hunk retired) and shipped `librarian`/`scout`/`sonic` (count guards updated to 11); the checks' hardcoded version literals now derive from the package so future bumps don't break them.
- **`scripts/update-pins.sh`** — queries latest upstream releases (oh-my-pi, codex), rewrites versions + SRI hashes for every pinned asset per platform. Shellcheck-clean; no-op output when current.
- **`.github/workflows/update-pins.yml`** — every 6 hours (+ manual dispatch): runs the script; if anything moved, pushes a bot branch, opens a PR, explicitly dispatches the nix CI on it (bot events don't trigger workflows), **merges on green**, then dispatches CI on main so the cache/attestation run still happens. A red run leaves the bot PR open for curation — exactly what this omp bump would have done.

## Trade-off, stated plainly

This auto-lands upstream binary bumps unattended within hours when CI passes. The gate is real — the checks execute the new binaries (this bump failed three times before passing) — but it is supply-chain trust in upstream releases + CI, not human review. Remove the `gh pr merge` line to switch to review-mode if that posture ever feels wrong.

## Verification

- `omp-wrapper`, `omp-stack`, `agent-tools-migration`, `atyrode-cli` checks all green with 16.4.4.
- Script exercised live (it produced this PR's bump); `nix flake check --no-build` passes.

Note: this PR adds a workflow file, which the merge-scope-limited session token cannot merge — needs your click (or `gh auth refresh -s workflow` once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)