### PR TITLE
fix(codex): repair store-symlinked live configs on converge

### DIFF
--- a/checks/codex-use.nix
+++ b/checks/codex-use.nix
@@ -69,6 +69,29 @@ pkgs.runCommand "check-codex-use"
     grep -F 'friendly' "$HOME/.codex/atyrode.config.toml" >/dev/null
     test "$(cat "$HOME/.codex/config.toml")" = 'local project trust'
 
+    # A live config symlinked into the store breaks Codex trust persistence;
+    # converge must repair it into a mutable copy seeded from the target.
+    ln -sfn ${configV1} "$HOME/.codex/config.toml"
+    ${codexUseV2}/bin/codex-use converge
+    test ! -L "$HOME/.codex/config.toml"
+    test "$(cat "$HOME/.codex/config.toml")" = 'personality = "pragmatic"'
+    test "$(stat -c %a "$HOME/.codex/config.toml")" = 600
+
+    # A dangling store link seeds an empty mutable file instead of failing.
+    ln -sfn /nix/store/00000000000000000000000000000000-gone-config.toml "$HOME/.codex/config.toml"
+    ${codexUseV2}/bin/codex-use converge
+    test ! -L "$HOME/.codex/config.toml"
+    test ! -s "$HOME/.codex/config.toml"
+
+    # Symlinks the user points elsewhere are their own business; leave them.
+    printf '%s\n' 'hand-rolled config' > "$HOME/user-config.toml"
+    ln -sfn "$HOME/user-config.toml" "$HOME/.codex/config.toml"
+    ${codexUseV2}/bin/codex-use converge
+    test -L "$HOME/.codex/config.toml"
+
+    rm "$HOME/.codex/config.toml"
+    printf '%s\n' 'local project trust' > "$HOME/.codex/config.toml"
+
     ${codexUseV2}/bin/codex-use alt
     test "$(cat "$HOME/.codex-profiles/.active-profile")" = alt
     test "$(cat "$HOME/.codex-profiles/default/config.toml")" = 'local project trust'

--- a/pkgs/codex-use/codex-use
+++ b/pkgs/codex-use/codex-use
@@ -58,9 +58,25 @@ install_link() {
   temp="$path.next.$$"; rm -f "$temp"; ln -s "$source" "$temp"; mv -f "$temp" "$path"
 }
 
+# Codex persists trust decisions and settings edits into config.toml and
+# follows symlinks to the write target, so a live config linked into the
+# read-only Nix store fails every such write. Repair that state into the
+# mutable real file the layout promises, seeded from the link target.
+ensure_mutable_config() {
+  local path="$1/config.toml" target temp
+  [[ -L "$path" ]] || return 0
+  target="$(readlink -f "$path" || true)"
+  [[ "$target" == /nix/store/* ]] || return 0
+  temp="$path.next.$$"; rm -f "$temp"
+  if [[ -r "$target" ]]; then cp "$target" "$temp"; else : >"$temp"; fi
+  chmod 600 "$temp"; mv -f "$temp" "$path"
+  printf 'Replaced store-symlinked %s with a mutable copy\n' "$path" >&2
+}
+
 install_managed_files() {
   install_link "$1" AGENTS.md "$managed_agents"
   install_link "$1" "$profile_name.config.toml" "$managed_config"
+  ensure_mutable_config "$1"
 }
 
 clear_journal() { [[ ! -d "$journal" ]] || { rm -f "$journal"/*; rmdir "$journal"; }; }


### PR DESCRIPTION
## Problem

Trusting a directory in the Codex TUI failed on the Mac:

```
Failed to set trust for /Users/alex: config/batchWrite failed in TUI: config/batchWrite
failed: failed to persist config.toml: failed to persist config at
/nix/store/hax58caifynmiwzf4pk2jlqgw745d1bk-config.toml (code -32603)
```

Codex persists trust decisions (and TUI settings edits) into `~/.codex/config.toml`, resolving symlink chains to the final target (`resolve_symlink_write_paths` in codex-rs). On that machine the live `config.toml` is a symlink into the read-only Nix store, so every such write fails. Nothing in this repo creates that link today — the layout deliberately keeps `config.toml` mutable and only links `atyrode.config.toml` — but pre-repo setups left this state behind, and nothing repaired it.

## Fix

`codex-use converge` (runs on every activation) now enforces the mutability the layout promises: a `config.toml` that is a symlink resolving into `/nix/store` is replaced with a 600-mode mutable copy seeded from the link target (empty when the target is a dangling store path). Symlinks pointing outside the store are the owner's business and are left alone.

## Verification

- `checks/codex-use.nix` gains three scenarios: store-symlinked config is healed with content + mode preserved, dangling store link seeds an empty file, non-store symlink is untouched.
- `nix flake check` passes on x86_64-linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)