### PR TITLE
fix(codex): stop injecting --profile into non-runtime subcommands

### DIFF
--- a/checks/codex-use.nix
+++ b/checks/codex-use.nix
@@ -139,6 +139,14 @@ pkgs.runCommand "check-codex-use"
     grep -F -- '--profile atyrode exec task' "$CODEX_ARGS_FILE" >/dev/null
     ${configuredCodex}/bin/codex -p custom exec task
     test "$(cat "$CODEX_ARGS_FILE")" = '-p custom exec task'
+    ${configuredCodex}/bin/codex
+    test "$(cat "$CODEX_ARGS_FILE")" = '--profile atyrode'
+    ${configuredCodex}/bin/codex -c features.code_mode_host=true app-server --listen unix:///tmp/sock
+    test "$(cat "$CODEX_ARGS_FILE")" = '-c features.code_mode_host=true app-server --listen unix:///tmp/sock'
+    ${configuredCodex}/bin/codex login --api-key key
+    test "$(cat "$CODEX_ARGS_FILE")" = 'login --api-key key'
+    ${configuredCodex}/bin/codex resume --last
+    test "$(cat "$CODEX_ARGS_FILE")" = '--profile atyrode resume --last'
 
     mkdir "$out"
   ''

--- a/pkgs/codex-configured/default.nix
+++ b/pkgs/codex-configured/default.nix
@@ -7,9 +7,25 @@
 writeShellApplication {
   name = "codex";
   text = ''
+    # Codex accepts --profile only on runtime commands (and `codex mcp`);
+    # every other subcommand — notably `codex app-server`, which the Codex
+    # desktop app bootstraps over SSH — hard-fails on the flag. Classify the
+    # invocation by its first recognized subcommand token and inject the
+    # managed profile only where it is valid. Both token lists mirror the
+    # release pinned in pkgs/codex-bin; revisit them when bumping it.
     for argument in "$@"; do
       case "$argument" in
         --profile|-p|--profile=*)
+          exec ${lib.getExe codex} "$@"
+          ;;
+      esac
+    done
+    for argument in "$@"; do
+      case "$argument" in
+        exec|e|review|resume|archive|delete|unarchive|fork|mcp|sandbox)
+          break
+          ;;
+        login|logout|plugin|mcp-server|app-server|remote-control|completion|update|doctor|debug|apply|a|cloud|exec-server|features|help)
           exec ${lib.getExe codex} "$@"
           ;;
       esac


### PR DESCRIPTION
## Problem

Codex desktop's SSH remote to the hetzner box fails with **"SSH connection failed (socket hang up)"**.

The desktop app bootstraps `codex app-server` on the remote through the login shell. That resolves to the `codex-configured` wrapper, which unconditionally injects `--profile atyrode` — but codex restricts `--profile` to runtime commands, so the app-server dies instantly:

```
Error: --profile only applies to runtime commands and `codex mcp`: `codex`, `codex exec`, ...
```

(`~/.codex/app-server-control/app-server.log`, timestamped at the failed connection attempt.)

The bug has been latent since #38: an npm-installed codex at `~/.local/bin/codex` shadowed the wrapper in the login-shell PATH, so desktop bootstraps never hit it. That shim is gone now, unmasking the failure.

## Fix

The wrapper classifies the invocation by its first recognized subcommand token and injects the managed profile only for the commands codex accepts it on (`exec`, `review`, `resume`, `archive`, `delete`, `unarchive`, `fork`, `mcp`, `sandbox`, and bare/interactive). Everything else — `app-server`, `login`, `mcp-server`, etc. — passes through untouched. Both token lists mirror the release pinned in `pkgs/codex-bin` and carry a comment to revisit on bumps.

## Verification

- `nix build .#checks.x86_64-linux.codex-use` passes, with new assertions pinning the exact desktop bootstrap shape (`-c features.code_mode_host=true app-server --listen unix://...` → no injection), `login` pass-through, and injection for bare / `exec` / `resume --last`.
- Smoke test against the real 0.144.1 binary: the desktop bootstrap invocation through the fixed wrapper starts and stays up (previously exit 1 with the usage error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)