### PR TITLE
Seed plain-omp defaults with drift-aware apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ dotfiles/
 ├── modules/                 # Reusable Home Manager modules
 ├── omp/                     # Managed config, presets, agents, and rules
 ├── pkgs/                    # Pinned custom derivations and wrappers
-├── scripts/                 # Activation-time migration logic
+├── scripts/                 # Activation-time migration and seeding logic
 └── home/                  # Home Manager modules
     ├── default.nix        # Main configuration
     ├── linux-desktop.nix  # Optional Linux desktop packages

--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -13,6 +13,7 @@ let
   budgetPreset = ../omp/presets/budget.yml;
   fablePreset = ../omp/presets/fable-primary.yml;
   gptPreset = ../omp/presets/gpt56.yml;
+  plainSeedConfig = ../omp/plain-seed.yml;
 
   stubOmp =
     pkgs.runCommand "omp-stub"
@@ -338,7 +339,8 @@ in
           ${gptPreset} \
           ${untrustedConfig} \
           ${yoloConfig} \
-          ${policyConfig}
+          ${policyConfig} \
+          ${plainSeedConfig}
         do
           while IFS= read -r name; do
             [ -n "$name" ] || continue

--- a/checks/omp-seed.nix
+++ b/checks/omp-seed.nix
@@ -1,0 +1,177 @@
+{ lib, pkgs }:
+
+let
+  seedConfig = ../omp/plain-seed.yml;
+  policyConfig = ../omp/policy.yml;
+in
+pkgs.runCommand "check-omp-seed"
+  {
+    nativeBuildInputs = [
+      pkgs.jq
+      pkgs.yq-go
+      pkgs.omp-seed
+    ];
+  }
+  ''
+    set -euo pipefail
+
+    fail() {
+      echo "FAIL: $1" >&2
+      exit 1
+    }
+
+    seed='${seedConfig}'
+    policy='${policyConfig}'
+
+    # The seed must parse and stay a mapping.
+    yq eval '.' "$seed" >/dev/null || fail "plain-seed.yml is not valid YAML"
+
+    # Where the seed overlaps enforced policy, the values must agree so plain
+    # omp is never seeded weaker (or differently) than managed launchers are
+    # forced. The shared-leaf count is asserted non-zero so this can never
+    # silently become vacuous.
+    seed_json="$(yq eval -o=json '.' "$seed")"
+    policy_json="$(yq eval -o=json '.' "$policy")"
+    overlap="$(jq -n --argjson seed "$seed_json" --argjson policy "$policy_json" '
+      def haspath($doc; $p):
+        $doc
+        | try (reduce ($p[:-1])[] as $k (.; .[$k]) | (type == "object") and has($p[-1]))
+          catch false;
+      [ $policy
+        | paths as $p
+        | select((($p | map(type) | any(. == "number")) | not)
+                 and (($policy | getpath($p) | type) != "object"))
+        | $p ] as $pleaves
+      | { shared: [ $pleaves[] as $p
+            | if haspath($seed; $p) then ($p | join(".")) else empty end ],
+          mismatched: [ $pleaves[] as $p
+            | if haspath($seed; $p) and (($seed | getpath($p)) != ($policy | getpath($p)))
+              then ($p | join("."))
+              else empty
+              end ] }')"
+    [ "$(jq -r '.shared | length' <<<"$overlap")" != 0 ] \
+      || fail "seed/policy overlap assertion is vacuous: no shared leaves found"
+    [ "$(jq -r '.mismatched | length' <<<"$overlap")" = 0 ] \
+      || fail "seed disagrees with enforced policy on: $(jq -r '.mismatched | join(", ")' <<<"$overlap")"
+
+    # Scenario: dry run on a pristine machine writes nothing at all — not
+    # even the state directory or lock file.
+    export HOME="$TMPDIR/pristine"
+    mkdir -p "$HOME"
+    AGENT_TOOLS_DRY_RUN=1 atyrode-omp-seed apply >"$TMPDIR/dry-pristine.log"
+    grep -q 'dry run' "$TMPDIR/dry-pristine.log" || fail "pristine dry run was not announced"
+    [ ! -e "$HOME/.local/state/atyrode/omp-plain-seed" ] || fail "pristine dry run created state"
+    [ ! -e "$HOME/.omp" ] || fail "pristine dry run touched ~/.omp"
+
+    # Scenario: first boot with no config file at all.
+    export HOME="$TMPDIR/firstboot"
+    mkdir -p "$HOME"
+    atyrode-omp-seed apply >"$TMPDIR/firstboot.log"
+    config="$HOME/.omp/agent/config.yml"
+    [ -f "$config" ] || fail "first boot did not create config.yml"
+    [ "$(stat -c '%a' "$config")" = "600" ] || fail "first boot config mode is not 600"
+    [ "$(yq eval '.secrets.enabled' "$config")" = "true" ] || fail "first boot did not seed secrets.enabled"
+
+    # Scenario: a local scalar blocks seed mappings — nothing may be
+    # destroyed, the blocked leaves report drift, everything else seeds.
+    export HOME="$TMPDIR/blocked"
+    mkdir -p "$HOME/.omp/agent"
+    config="$HOME/.omp/agent/config.yml"
+    state="$HOME/.local/state/atyrode/omp-plain-seed"
+    cat >"$config" <<'YAML'
+    task: manual-note
+    dev:
+      autoqa:
+        consent: granted
+    YAML
+    atyrode-omp-seed apply >"$TMPDIR/blocked.log"
+    [ "$(yq eval '.task' "$config")" = "manual-note" ] || fail "local scalar was destroyed by seeding"
+    [ "$(yq eval '.dev.autoqa.consent' "$config")" = "granted" ] || fail "unmanaged key lost in blocked scenario"
+    [ "$(yq eval '.secrets.enabled' "$config")" = "true" ] || fail "blocked scenario did not seed unrelated keys"
+    jq -e '.drift[] | select(.key == "task.isolation.mode" and .reason == "blocked-by-local-value")' \
+      "$state/drift.json" >/dev/null || fail "blocked leaf not reported as drift"
+    # resolve --reset-all may displace the blocking scalar: operator choice.
+    atyrode-omp-seed resolve --reset-all >"$TMPDIR/blocked-resolve.log"
+    [ "$(yq eval '.task.isolation.mode' "$config")" = "auto" ] || fail "reset did not displace the blocking scalar"
+
+    # Main flow: fresh machine with an unmanaged local key.
+    export HOME="$TMPDIR/home"
+    mkdir -p "$HOME/.omp/agent"
+    config="$HOME/.omp/agent/config.yml"
+    state="$HOME/.local/state/atyrode/omp-plain-seed"
+    cat >"$config" <<'YAML'
+    setupVersion: 1
+    dev:
+      autoqa:
+        consent: granted
+    YAML
+
+    atyrode-omp-seed apply >"$TMPDIR/apply-1.log"
+    grep -q 'drifted (kept)' "$TMPDIR/apply-1.log" || fail "apply produced no summary"
+    [ "$(yq eval '.secrets.enabled' "$config")" = "true" ] || fail "fresh seed did not write secrets.enabled"
+    [ "$(yq eval '.task.isolation.mode' "$config")" = "auto" ] || fail "fresh seed did not write task.isolation.mode"
+    [ "$(yq eval '.advisor.syncBacklog' "$config")" = "3" ] || fail "fresh seed did not write advisor.syncBacklog"
+    [ "$(yq eval '.dev.autoqa.consent' "$config")" = "granted" ] || fail "unmanaged key was not preserved"
+    [ -f "$state/last-applied.yml" ] || fail "snapshot was not recorded"
+    [ "$(jq -r '.drift | length' "$state/drift.json")" = 0 ] || fail "fresh seed reported drift"
+    # Array leaves arrive intact.
+    [ "$(yq eval -o=json '.retry.fallbackChains.default' "$config")" = \
+      "$(yq eval -o=json '.retry.fallbackChains.default' "$seed")" ] \
+      || fail "fallback chain array was not seeded verbatim"
+
+    # Scenario: idempotent re-run.
+    atyrode-omp-seed apply >"$TMPDIR/apply-2.log"
+    grep -q '^omp seed: 0 applied' "$TMPDIR/apply-2.log" || fail "re-run applied changes"
+
+    # Scenario: local edits win and are reported, including deletions.
+    yq eval -i '.advisor.syncBacklog = "5"' "$config"
+    yq eval -i 'del(.branchSummary.enabled)' "$config"
+    atyrode-omp-seed apply >"$TMPDIR/apply-3.log"
+    [ "$(yq eval '.advisor.syncBacklog' "$config")" = "5" ] || fail "local edit was overwritten"
+    yq eval '.branchSummary // {} | has("enabled")' "$config" | grep -qx 'false' \
+      || fail "local deletion was re-seeded"
+    [ "$(jq -r '.drift | length' "$state/drift.json")" = 2 ] || fail "expected two drifted keys"
+    jq -e '.drift[] | select(.key == "advisor.syncBacklog" and .reason == "local-edit")' \
+      "$state/drift.json" >/dev/null || fail "edit drift not reported"
+    jq -e '.drift[] | select(.key == "branchSummary.enabled" and .reason == "deleted-locally")' \
+      "$state/drift.json" >/dev/null || fail "deletion drift not reported"
+
+    # Scenario: a repository seed update follows for untouched values but
+    # never for drifted ones.
+    updated_seed="$TMPDIR/updated-seed.yml"
+    cp "$seed" "$updated_seed"
+    yq eval -i '.todo.eager = "always" | .advisor.syncBacklog = "1"' "$updated_seed"
+    OMP_SEED_FILE="$updated_seed" atyrode-omp-seed apply >"$TMPDIR/apply-4.log"
+    [ "$(yq eval '.todo.eager' "$config")" = "always" ] || fail "seed update was not applied"
+    [ "$(yq eval '.advisor.syncBacklog' "$config")" = "5" ] || fail "seed update clobbered local edit"
+    grep -q 'todo.eager' "$TMPDIR/apply-4.log" || fail "seed update was not announced"
+
+    # Scenario: dry run writes nothing once state exists.
+    before="$(sha256sum "$config" "$state/last-applied.yml" | sha256sum)"
+    yq eval -i '.todo.eager = "default"' "$updated_seed"
+    AGENT_TOOLS_DRY_RUN=1 OMP_SEED_FILE="$updated_seed" atyrode-omp-seed apply >"$TMPDIR/apply-dry.log"
+    after="$(sha256sum "$config" "$state/last-applied.yml" | sha256sum)"
+    [ "$before" = "$after" ] || fail "dry run modified state"
+    grep -q 'dry run' "$TMPDIR/apply-dry.log" || fail "dry run was not announced"
+
+    # Scenario: status --json exposes the drift, resolve --reset-all clears it.
+    status_json="$(atyrode-omp-seed status --json)"
+    jq -e '.drift[] | select(.key == "advisor.syncBacklog")' <<<"$status_json" >/dev/null \
+      || fail "status --json misses drift"
+    atyrode-omp-seed resolve --reset-all >"$TMPDIR/resolve.log"
+    [ "$(yq eval '.advisor.syncBacklog' "$config")" = "3" ] || fail "reset-all did not restore the seed value"
+    [ "$(yq eval '.branchSummary.enabled' "$config")" = "true" ] || fail "reset-all did not restore the deleted key"
+    [ "$(jq -r '.drift | length' "$state/drift.json")" = 0 ] || fail "drift report not refreshed after resolve"
+
+    # Scenario: interactive answers apply per key — reset the first drifted
+    # key, keep the rest via keep-all, then quit paths stay safe.
+    yq eval -i '.advisor.syncBacklog = "5" | .todo.eager = "default"' "$config"
+    printf 'r\na\n' | atyrode-omp-seed resolve >"$TMPDIR/resolve-2.log"
+    [ "$(yq eval '.advisor.syncBacklog' "$config")" = "3" ] || fail "interactive reset did not apply"
+    [ "$(yq eval '.todo.eager' "$config")" = "default" ] || fail "keep-all reset a kept value"
+    yq eval -i '.advisor.syncBacklog = "5"' "$config"
+    printf 'k\nq\n' | atyrode-omp-seed resolve >"$TMPDIR/resolve-3.log"
+    [ "$(yq eval '.advisor.syncBacklog' "$config")" = "5" ] || fail "interactive keep reset the value"
+
+    touch "$out"
+  ''

--- a/docs/agent-security.md
+++ b/docs/agent-security.md
@@ -22,7 +22,10 @@ sessions additional tool approval.
 Plain `omp` is deliberately outside this policy: it runs upstream OMP with the
 operator's mutable configuration and no Nix overlay, as the tinkering surface
 for a machine the operator already trusts. Its approval posture, extensions,
-and integrations are whatever that mutable configuration says, so every
+and integrations are whatever that mutable configuration says. The seeded
+defaults start that configuration with secret obfuscation and automatic task
+isolation enabled, but unlike the managed policy the operator can change or
+remove them on the fly — the next apply only reports the drift. Every
 launcher in this table is appropriate only for repositories the operator has
 reviewed; use `ompu` for untrusted repositories.
 

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -11,6 +11,7 @@ Nix owns:
 - the pinned OMP binary and generated Zsh completion;
 - the pinned Herdr flake input and generated OMP integration;
 - the managed OMP defaults, enforced policy, and model presets;
+- the curated plain-omp seed and its drift-aware activation step;
 - the pinned bundled agents, global generic skills, and managed-settings guard
   extension;
 - the `omp`, `ompb`, `ompf`, `ompg`, and restricted `ompu` launchers; and
@@ -55,7 +56,10 @@ rewriting the Bun executable with `patchelf`.
 Plain `omp` executes upstream OMP directly: no extension, defaults, preset, or
 policy overlay is injected, so its models, approvals, and interface belong to
 the operator's mutable configuration and can change on the fly. Only
-`omp update` is blocked, so nothing shadows the Nix-pinned binary.
+`omp update` is blocked, so nothing shadows the Nix-pinned binary. Its
+starting point is not empty, though: activation seeds the curated defaults
+from `omp/plain-seed.yml` into the writable configuration with local edits
+always winning; see [Seeded plain-omp defaults](#seeded-plain-omp-defaults).
 
 The managed defaults use Sol for interactive daily work, keep cheap, fast
 roles on Luna or low-thinking Terra, and reserve Fable/Opus for planning,
@@ -157,6 +161,51 @@ instead.
 The readable managed copies are linked under `~/.config/omp/`. Edit their
 sources in this repository instead of editing the links.
 
+## Seeded plain-omp defaults
+
+`omp/plain-seed.yml` holds the operator's agreed defaults for plain `omp` —
+the trusted-machine guardrails (secret obfuscation, automatic task isolation),
+the bundled-role model map and fallback chains, and interface preferences. It
+is deliberately not a managed layer: OMP's `--config` overlays always outrank
+the writable machine configuration, so a "defaults that lose to local edits"
+layer cannot exist at launch time. Instead, `atyrode-omp-seed apply` runs
+during activation (after the legacy migration) and three-way merges the seed
+into `~/.omp/agent/config.yml` against the last-applied seed recorded in
+`~/.local/state/atyrode/omp-plain-seed/`:
+
+- a key the operator never touched is written and later follows repository
+  updates;
+- a key the operator changed or deleted is left alone and reported as drift,
+  including across later seed updates;
+- unmanaged keys are never modified.
+
+`atyrode apply` prints the drift report after a successful activation and, on
+a terminal, offers a per-key keep-or-reset review; `atyrode-omp-seed status
+[--json]` and `atyrode-omp-seed resolve [--reset-all]` are available directly.
+This keeps the tinkering loop intact: change anything on the fly in plain
+`omp`, then either adopt the change into `omp/plain-seed.yml` or reset it at
+the next apply. `AGENT_TOOLS_DRY_RUN=1` (or a Home Manager dry run) prints the
+plan without writing.
+
+The seed may overlap keys the managed launchers own: managed sessions layer
+`defaults.yml` and `policy.yml` above the machine configuration, so seeded
+values never change managed behavior, and the flake check asserts that seeded
+values agree with the enforced policy wherever they overlap it. One caveat:
+the managed-settings guard restores managed paths in the writable file to
+their session-start state, so reseeding an overlapping key while a managed
+session is running can be reverted and will then surface as drift — resolve
+it at the next apply, or apply while managed sessions are closed.
+
+Known, accepted limits: the writable configuration is machine-formatted (OMP
+itself rewrites it without comments, and so does the seeder); a write aborts
+rather than merges when the file changed between read and write (rerun to
+pick up the new state); a seed path blocked by a local scalar reports drift
+instead of writing; and on the first activation of a legacy machine the v2
+migration removes managed-key copies before seeding writes the repository
+values — the original file survives in the migration backup receipt.
+`ATYRODE_SEED_REVIEW=0` suppresses the interactive apply-time review for
+pty-backed automation.
+
 ## Skills
 
 Generic, cross-project skills belong in `agents/skills/` and Home Manager links
@@ -244,8 +293,8 @@ below remains valid for hand-driven updates:
    (or run `scripts/update-pins.sh`).
 2. Update the Herdr input revision in `flake.nix`, then run
    `nix flake lock --update-input herdr`.
-3. Review model identifiers and routing in `omp/defaults.yml` and
-   `omp/presets/`.
+3. Review model identifiers and routing in `omp/defaults.yml`,
+   `omp/presets/`, and `omp/plain-seed.yml`.
 4. Run `nix flake check --show-trace`.
 5. Apply the profile with `zconf`.
 

--- a/docs/atyrode.md
+++ b/docs/atyrode.md
@@ -41,6 +41,12 @@ revision. `--plan` performs no activation. `--dry-run` uses `nh`'s build-only
 path. A successful real activation records the canonical host atomically;
 failures and dry runs do not update state.
 
+After a successful activation, apply reports plain-omp settings that drifted
+from the seeded repository defaults (see
+[Agent tools](agent-tools.md#seeded-plain-omp-defaults)) and, when running on
+a terminal without `--json`, offers a per-key keep-or-reset review. Drift is
+never resolved automatically; skipping the review keeps every local value.
+
 Linux uses `nh home switch`; macOS uses `nh darwin switch`. Plans name the
 selected host and capabilities, installable, source, backend, revision,
 dirty-tree state, and mutation boundary. Add `--json` for automation.

--- a/flake.nix
+++ b/flake.nix
@@ -274,6 +274,7 @@
             omp = final.callPackage ./pkgs/omp { };
             omp-agents = final.callPackage ./pkgs/omp-agents { };
             omp-configured = final.callPackage ./pkgs/omp-configured { };
+            omp-seed = final.callPackage ./pkgs/omp-seed { };
             atyrode = final.callPackage ./pkgs/atyrode {
               capabilities = capabilityInventory;
               inherit homebrewCasks;
@@ -463,6 +464,7 @@
             omp
             omp-agents
             omp-configured
+            omp-seed
             ;
         }
         // lib.optionalAttrs (lib.hasSuffix "-linux" system) {
@@ -603,6 +605,7 @@
             baseConfig = baseOnlyConfig;
           };
           get-entrypoint = import ./checks/get-sh.nix { inherit pkgs; };
+          omp-seed = import ./checks/omp-seed.nix { inherit lib pkgs; };
           production-facts = import ./checks/production-facts.nix { inherit pkgs; };
           home-evaluation = homeEvaluation;
           host-registry = registryCheck;

--- a/modules/home/agent-tools.nix
+++ b/modules/home/agent-tools.nix
@@ -33,11 +33,21 @@ in
       description = "Back up conflicting legacy agent-tool paths before Home Manager links managed files.";
     };
 
+    seedPlainConfig = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Seed the curated plain-omp defaults into the writable machine
+        configuration with drift reporting. Local edits always win.
+      '';
+    };
+
     ompPackage = lib.mkPackageOption pkgs "omp-configured" { };
     herdrPackage = lib.mkPackageOption pkgs "herdr-configured" { };
     ompAgentsPackage = lib.mkPackageOption pkgs "omp-agents" { };
     herdrIntegrationPackage = lib.mkPackageOption pkgs "herdr-omp-integration" { };
     migrationPackage = lib.mkPackageOption pkgs "agent-tools-migrate" { };
+    seedPackage = lib.mkPackageOption pkgs "omp-seed" { };
   };
 
   config = lib.mkIf cfg.enable {
@@ -45,7 +55,8 @@ in
       cfg.herdrPackage
       herdrCompletions
       cfg.ompPackage
-    ];
+    ]
+    ++ lib.optional cfg.seedPlainConfig cfg.seedPackage;
 
     xdg.configFile = {
       "omp/defaults.yml".source = defaultsConfig;
@@ -63,20 +74,39 @@ in
       };
     };
 
-    home.activation = lib.mkIf cfg.migrateLegacy {
-      migrateLegacyAgentTools = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
-        if [[ -v DRY_RUN ]]; then
-          export AGENT_TOOLS_DRY_RUN=1
-        fi
-        ${lib.getExe cfg.migrationPackage} prepare
-      '';
+    home.activation = lib.mkMerge [
+      (lib.mkIf cfg.migrateLegacy {
+        migrateLegacyAgentTools = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
+          if [[ -v DRY_RUN ]]; then
+            export AGENT_TOOLS_DRY_RUN=1
+          fi
+          ${lib.getExe cfg.migrationPackage} prepare
+        '';
 
-      finalizeLegacyAgentTools = lib.hm.dag.entryAfter [ "installPackages" "linkGeneration" ] ''
-        if [[ -v DRY_RUN ]]; then
-          export AGENT_TOOLS_DRY_RUN=1
-        fi
-        ${lib.getExe cfg.migrationPackage} finalize "$newGenPath/home-files"
-      '';
-    };
+        finalizeLegacyAgentTools = lib.hm.dag.entryAfter [ "installPackages" "linkGeneration" ] ''
+          if [[ -v DRY_RUN ]]; then
+            export AGENT_TOOLS_DRY_RUN=1
+          fi
+          ${lib.getExe cfg.migrationPackage} finalize "$newGenPath/home-files"
+        '';
+      })
+      (lib.mkIf cfg.seedPlainConfig {
+        # Runs after the legacy migration so a first activation seeds the
+        # transformed configuration, never the pre-migration backup source.
+        # Seeding is a convenience: a failure (for example unparseable
+        # operator YAML) warns instead of failing the whole activation.
+        seedPlainOmpConfig =
+          lib.hm.dag.entryAfter
+            ([ "installPackages" "linkGeneration" ] ++ lib.optional cfg.migrateLegacy "finalizeLegacyAgentTools")
+            ''
+              if [[ -v DRY_RUN ]]; then
+                export AGENT_TOOLS_DRY_RUN=1
+              fi
+              if ! ${lib.getExe cfg.seedPackage} apply; then
+                echo "warning: plain-omp seeding failed; inspect with atyrode-omp-seed status" >&2
+              fi
+            '';
+      })
+    ];
   };
 }

--- a/omp/defaults.yml
+++ b/omp/defaults.yml
@@ -71,7 +71,9 @@ branchSummary:
 
 autolearn:
   enabled: true
-  autoContinue: true
+  # One extra billed self-reflection turn at every session end is not a
+  # default; capture lessons deliberately instead (operator review 2026-07-11).
+  autoContinue: false
 
 github:
   enabled: true
@@ -112,7 +114,7 @@ memory:
   backend: local
 
 theme:
-  dark: dark
+  dark: titanium
 
 browser:
   headless: true

--- a/omp/plain-seed.yml
+++ b/omp/plain-seed.yml
@@ -1,0 +1,149 @@
+# Curated defaults for plain `omp`, seeded into the writable machine
+# configuration (`~/.omp/agent/config.yml`) by `atyrode-omp-seed` during
+# activation. Unlike `defaults.yml`, nothing here is enforced: the operator
+# may change any of these values on the fly, local edits always win over a
+# reseed, and drift is reported by `atyrode apply` instead of overwritten.
+#
+# Decision log: operator settings review, 2026-07-11 (issue #61).
+
+# Trusted-machine autonomy with the two cheap guardrails kept on: secret
+# obfuscation in outbound requests and copy-on-write task isolation.
+tools:
+  approvalMode: yolo
+secrets:
+  enabled: true
+task:
+  isolation:
+    mode: auto
+    merge: patch
+  showResolvedModelBadge: true
+
+# Sol for interactive work; cheap Luna/Terra routes for recurring background
+# roles so commit messages, titles, and subtasks never bill at the main tier.
+# Only bundled roles are pinned; custom agents are a managed-launcher concern.
+modelRoles:
+  default: openai-codex/gpt-5.6-sol:medium
+  advisor: openai-codex/gpt-5.6-luna:medium
+  smol: openai-codex/gpt-5.6-luna:low
+  slow: openai-codex/gpt-5.6-sol:xhigh
+  task: openai-codex/gpt-5.6-terra:medium
+  plan: anthropic/claude-fable-5:high
+  tiny: openai-codex/gpt-5.6-luna:minimal
+  commit: openai-codex/gpt-5.6-luna:low
+
+# Cross-provider fallback first for the roles that matter, so a provider-wide
+# outage or a long rate-limit window degrades instead of killing the session.
+retry:
+  enabled: true
+  modelFallback: true
+  fallbackRevertPolicy: cooldown-expiry
+  fallbackChains:
+    default:
+      - anthropic/claude-sonnet-5:medium
+      - openai-codex/gpt-5.6-terra:medium
+    task:
+      - anthropic/claude-sonnet-5:medium
+      - openai-codex/gpt-5.6-sol:medium
+    advisor:
+      - openai-codex/gpt-5.6-terra:low
+    smol:
+      - openai-codex/gpt-5.6-terra:low
+    slow:
+      - anthropic/claude-sonnet-5:high
+      - openai-codex/gpt-5.6-terra:xhigh
+    plan:
+      - openai-codex/gpt-5.6-sol:high
+      - anthropic/claude-sonnet-5:high
+    tiny:
+      - openai-codex/gpt-5.6-terra:low
+    commit:
+      - openai-codex/gpt-5.6-terra:low
+
+# Advisor on a cheap fast model. xhigh thinking on a per-turn watchdog buys
+# latency, not much review quality; subagent advisors multiply calls and can
+# derail cheap mechanical agents (2026-07 advisor drift cost ~$265/day).
+advisor:
+  enabled: true
+  subagents: false
+  syncBacklog: "3"
+
+autolearn:
+  enabled: true
+  # One extra billed self-reflection turn at every session end is not a
+  # default; capture lessons deliberately instead.
+  autoContinue: false
+
+branchSummary:
+  enabled: true
+checkpoint:
+  enabled: true
+github:
+  enabled: true
+
+# Local-first memory: mnemopi SQLite banks, one global bank so recall works
+# across projects (provenance stays in each memory's metadata). Extraction
+# runs on the hosted tiny role (Luna minimal) — better facts than a local
+# 1.2B model, no new provider involved. Storage never leaves the machine.
+memory:
+  backend: mnemopi
+mnemopi:
+  llmMode: smol
+  scoping: global
+  retainEveryNTurns: 3
+providers:
+  anthropic:
+    serverSideFallback: false
+  memoryModel: online
+  webSearch: auto
+
+# Never spend scarce weekly reset credits without the operator.
+codexResets:
+  autoRedeem: "no"
+
+compaction:
+  idleEnabled: true
+features:
+  unexpectedStopDetection: true
+
+defaultThinkingLevel: auto
+personality: pragmatic
+edit:
+  mode: hashline
+
+# Interaction posture.
+steeringMode: one-at-a-time
+doubleEscapeAction: tree
+treeFilterMode: default
+todo:
+  eager: preferred
+stt:
+  enabled: true
+  submitTrigger: say-submit
+speechgen:
+  enabled: true
+inspect_image:
+  enabled: true
+
+# Obsidian integration is deferred work; keep it out of the system prompt.
+vault:
+  enabled: false
+
+# Presentation. The update check stays on as a manual pin-bump reminder.
+theme:
+  dark: titanium
+colorBlindMode: true
+display:
+  shimmer: classic
+  showTokenUsage: false
+  cacheMissMarker: true
+statusLine:
+  sessionAccent: true
+  showHookStatus: true
+terminal:
+  showProgress: true
+startup:
+  checkUpdate: true
+power:
+  sleepPrevention: idle
+collab:
+  displayName: atyrode

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -34,8 +34,10 @@ Usage:
 The host registry is the authority for identity, platform, and capabilities.
 apply activates the published flake by default, resolving REF (default main)
 to an exact commit first; --repo switches to a local checkout for development.
-apply validates everything before invoking nh. Commands reserved for later
-issues: workspace, agent, generations, rollback, and clean.
+apply validates everything before invoking nh, and afterwards reports plain-omp
+settings that drifted from the seeded defaults, offering an interactive
+keep-or-reset review on a terminal. Commands reserved for later issues:
+workspace, agent, generations, rollback, and clean.
 EOF
 }
 
@@ -791,9 +793,30 @@ apply_config() {
     temp="$(mktemp "$state_dir/.dotfiles-config.XXXXXX")"
     printf '%s\n' "$host" >"$temp"
     mv -f "$temp" "$state_file"
+    review_seed_drift "$json"
   fi
   if [[ "$restart" == 1 ]]; then
     printf 'Activation completed. Restart the current shell with: exec zsh -l\n' >&2
+  fi
+}
+
+# After a successful activation, surface plain-omp settings that drifted from
+# the seeded repository defaults and, on a terminal, offer to keep or reset
+# each one. The seeder itself never overwrites local edits; this review is the
+# only place a default is restored, and only on explicit request.
+review_seed_drift() {
+  local json="$1" seed_status drift_count
+  command -v atyrode-omp-seed >/dev/null 2>&1 || return 0
+  seed_status="$(atyrode-omp-seed status --json 2>/dev/null)" || return 0
+  drift_count="$(jq -r '.drift | length' <<<"$seed_status" 2>/dev/null)" || return 0
+  [[ "$drift_count" != 0 ]] || return 0
+  jq -r '"omp seed drift: \(.drift | length) setting(s) kept over the repository defaults",
+    (.drift[] | "  ~ \(.key): local \(.live | tojson) / default \(.seed | tojson)")' \
+    <<<"$seed_status" >&2
+  if [[ "$json" == 0 && "${ATYRODE_SEED_REVIEW:-1}" == 1 && -t 0 && -t 1 ]]; then
+    atyrode-omp-seed resolve || true
+  else
+    printf 'review with: atyrode-omp-seed resolve\n' >&2
   fi
 }
 

--- a/pkgs/omp-seed/default.nix
+++ b/pkgs/omp-seed/default.nix
@@ -1,0 +1,40 @@
+{
+  coreutils,
+  flock,
+  jq,
+  lib,
+  writeShellApplication,
+  yq-go,
+}:
+
+let
+  seedConfig = ../../omp/plain-seed.yml;
+  script = builtins.readFile ../../scripts/omp-seed.sh;
+in
+(writeShellApplication {
+  name = "atyrode-omp-seed";
+  runtimeInputs = [
+    coreutils
+    flock
+    jq
+    yq-go
+  ];
+  # The seed ships from the Nix store but stays overridable so checks can
+  # exercise seed updates against a fixture file.
+  text =
+    ''
+      : "''${OMP_SEED_FILE:=${seedConfig}}"
+      export OMP_SEED_FILE
+    ''
+    + lib.removePrefix "#!/usr/bin/env bash\nset -euo pipefail\n" script;
+  meta = {
+    description = "Drift-aware seeding of curated plain-omp defaults";
+    license = lib.licenses.mit;
+    mainProgram = "atyrode-omp-seed";
+  };
+}).overrideAttrs
+  (previous: {
+    passthru = (previous.passthru or { }) // {
+      inherit seedConfig;
+    };
+  })

--- a/scripts/omp-seed.sh
+++ b/scripts/omp-seed.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Seed curated plain-omp defaults into the writable machine configuration
+# with three-way-merge drift semantics. For every leaf path in the seed:
+#
+#   absent locally, never seeded        -> written (new default)
+#   absent locally, seeded before       -> kept absent, reported as drift
+#   equal to the seed                   -> in sync
+#   changed locally since the last seed -> kept, reported as drift
+#   blocked by a local non-mapping      -> kept, reported as drift
+#   unchanged since a now-updated seed  -> updated to the new default
+#
+# Local edits therefore always win; only values the operator never touched
+# follow the repository. Unmanaged keys are preserved untouched. The last
+# applied seed is recorded so "operator changed it" and "repository changed
+# it" stay distinguishable across updates. The writable file is machine
+# formatted: omp itself rewrites it without comments, and so does this tool.
+
+seed_file="${OMP_SEED_FILE:?OMP_SEED_FILE must point at the seed YAML}"
+state_root="${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/omp-plain-seed"
+snapshot_file="$state_root/last-applied.yml"
+report_file="$state_root/drift.json"
+dry_run="${AGENT_TOOLS_DRY_RUN:-0}"
+
+agent_dir="${PI_CODING_AGENT_DIR:-$HOME/.omp/agent}"
+
+transient_files=()
+cleanup() {
+  local path
+  for path in ${transient_files[@]+"${transient_files[@]}"}; do
+    rm -f -- "$path" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'omp-seed: %s\n' "$1" >&2
+  exit 1
+}
+
+# Prefer config.yml, accept OMP's legacy config.yaml fallback. If the
+# preferred name later starts to exist alongside the legacy one, omp reads
+# the .yml and every previously seeded key in the .yaml reports as drift —
+# a safe failure mode that surfaces the dual-file state without writes.
+resolve_config_path() {
+  if [[ -f "$agent_dir/config.yml" ]]; then
+    printf '%s\n' "$agent_dir/config.yml"
+  elif [[ -f "$agent_dir/config.yaml" ]]; then
+    printf '%s\n' "$agent_dir/config.yaml"
+  else
+    printf '%s\n' "$agent_dir/config.yml"
+  fi
+}
+
+ensure_state_root() {
+  mkdir -p "$state_root"
+  chmod 700 "$state_root"
+}
+
+acquire_lock() {
+  ensure_state_root
+  exec 9>"$state_root/.lock"
+  flock -w 15 9 || fail "another omp-seed run holds the lock"
+}
+
+yaml_to_json() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    yq eval -o=json '. // {}' "$path" || fail "invalid YAML in $path"
+  else
+    printf '{}\n'
+  fi
+}
+
+file_digest() {
+  if [[ -f "$1" ]]; then
+    sha256sum <"$1" | cut -d' ' -f1
+  else
+    printf 'absent\n'
+  fi
+}
+
+# Classify every seed leaf against the live config and the last-applied
+# snapshot. Arrays are atomic leaves; path segments are always object keys
+# because the seed never indexes into arrays. A leaf whose intermediate
+# path is blocked by a local scalar or array is drift, never a write —
+# setpath would otherwise error (or the merge would destroy the local
+# value), so blocked leaves must not reach the set list.
+classify() {
+  local live_json="$1" seed_json="$2" snap_json="$3"
+  jq -n \
+    --argjson live "$live_json" \
+    --argjson seed "$seed_json" \
+    --argjson snap "$snap_json" '
+    def leafpaths:
+      [ paths as $p
+        | select((($p | map(type) | any(. == "number")) | not)
+                 and ((getpath($p) | type) != "object"))
+        | $p ];
+    def haspath($p):
+      try (reduce ($p[:-1])[] as $k (.; .[$k]) | (type == "object") and has($p[-1]))
+      catch false;
+    def pathopen($p):
+      try (reduce ($p[:-1])[] as $k (.; .[$k]) | (type == "object") or (type == "null"))
+      catch false;
+    ($seed | leafpaths) as $paths
+    | reduce $paths[] as $p (
+        {set: [], drift: [], insync: []};
+        ($seed | getpath($p)) as $s
+        | ($live | pathopen($p)) as $open
+        | ($live | haspath($p)) as $lh
+        | ($snap | haspath($p)) as $sh
+        | (if $lh then ($live | getpath($p)) else null end) as $l
+        | (if $sh then ($snap | getpath($p)) else null end) as $v0
+        | if ($open | not)
+          then .drift += [{path: $p, key: ($p | join(".")), live: null, seed: $s, reason: "blocked-by-local-value"}]
+          elif ($lh | not) and ($sh | not)
+          then .set += [{path: $p, key: ($p | join(".")), to: $s, reason: "new"}]
+          elif ($lh | not)
+          then .drift += [{path: $p, key: ($p | join(".")), live: null, seed: $s, reason: "deleted-locally"}]
+          elif $l == $s
+          then .insync += [{key: ($p | join("."))}]
+          elif $sh and ($l == $v0)
+          then .set += [{path: $p, key: ($p | join(".")), from: $l, to: $s, reason: "seed-updated"}]
+          else .drift += [{path: $p, key: ($p | join(".")), live: $l, seed: $s, reason: "local-edit"}]
+          end
+      )
+    | {set, drift, insync}'
+}
+
+# Atomically replace the target with the rendered JSON document. Refuses
+# non-mapping documents so a failed upstream merge can never blank the
+# operator's configuration, follows symlinks so a linked config is updated
+# in place, and aborts when the target changed since it was read (the
+# caller passes the digest captured at load time).
+write_yaml_atomically() {
+  local json="$1" target="$2" expected_digest="$3" mode temp real
+  jq -e 'type == "object"' <<<"$json" >/dev/null 2>&1 \
+    || fail "refusing to write a non-mapping document to $target"
+  real="$(realpath -m -- "$target")"
+  mode=600
+  if [[ -f "$real" ]]; then
+    mode="$(stat -c '%a' "$real")"
+  fi
+  mkdir -p "$(dirname "$real")"
+  temp="$(mktemp "$(dirname "$real")/.omp-seed.XXXXXX")"
+  transient_files+=("$temp")
+  printf '%s\n' "$json" | yq eval -P '.' - >"$temp" || fail "could not render YAML for $target"
+  yq eval '.' "$temp" >/dev/null || fail "rendered YAML for $target failed validation"
+  chmod "$mode" "$temp"
+  if [[ "$(file_digest "$target")" != "$expected_digest" ]]; then
+    fail "$target changed while omp-seed was running; rerun to pick up the new state"
+  fi
+  mv -f -- "$temp" "$real"
+}
+
+write_report() {
+  local classification="$1" config_path="$2" temp
+  ensure_state_root
+  temp="$(mktemp "$state_root/.drift.json.XXXXXX")"
+  transient_files+=("$temp")
+  jq -n \
+    --argjson result "$classification" \
+    --arg config "$config_path" \
+    --arg seed "$seed_file" \
+    --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{generatedAt: $generatedAt, config: $config, seed: $seed,
+      applied: [$result.set[] | {key, reason, to}],
+      drift: [$result.drift[] | {key, reason, live, seed}],
+      inSyncCount: ($result.insync | length)}' >"$temp"
+  chmod 600 "$temp"
+  mv -f -- "$temp" "$report_file"
+}
+
+print_summary() {
+  local classification="$1" verb="$2"
+  local set_count drift_count sync_count
+  set_count="$(jq -r '.set | length' <<<"$classification")"
+  drift_count="$(jq -r '.drift | length' <<<"$classification")"
+  sync_count="$(jq -r '.insync | length' <<<"$classification")"
+  printf 'omp seed: %s %s, %s drifted (kept), %s in sync\n' \
+    "$set_count" "$verb" "$drift_count" "$sync_count"
+  if [[ "$set_count" != 0 ]]; then
+    jq -r '.set[] | "  + \(.key) = \(.to | tojson)\(if .reason == "seed-updated" then " (was \(.from | tojson))" else "" end)"' \
+      <<<"$classification"
+  fi
+  if [[ "$drift_count" != 0 ]]; then
+    jq -r '.drift[] | "  ~ \(.key): local \(.live | tojson) / default \(.seed | tojson) [\(.reason)]"' \
+      <<<"$classification"
+    printf '  review with: atyrode-omp-seed resolve\n'
+  fi
+}
+
+load_documents() {
+  config_path="$(resolve_config_path)"
+  live_digest="$(file_digest "$config_path")"
+  live_json="$(yaml_to_json "$config_path")"
+  seed_json="$(yaml_to_json "$seed_file")"
+  snap_json="$(yaml_to_json "$snapshot_file")"
+  jq -e 'type == "object"' <<<"$live_json" >/dev/null || fail "$config_path is not a YAML mapping"
+  jq -e 'type == "object"' <<<"$seed_json" >/dev/null || fail "seed $seed_file is not a YAML mapping"
+}
+
+apply_sets() {
+  local classification="$1"
+  jq -n \
+    --argjson live "$live_json" \
+    --argjson result "$classification" \
+    'reduce $result.set[] as $s ($live; setpath($s.path; $s.to))'
+}
+
+cmd_apply() {
+  if [[ "$dry_run" == 1 ]]; then
+    load_documents
+    printf 'omp seed: dry run, no files were written\n'
+    print_summary "$(classify "$live_json" "$seed_json" "$snap_json")" "to apply"
+    return 0
+  fi
+
+  acquire_lock
+  load_documents
+  local classification merged
+  classification="$(classify "$live_json" "$seed_json" "$snap_json")"
+
+  if [[ "$(jq -r '.set | length' <<<"$classification")" != 0 ]]; then
+    merged="$(apply_sets "$classification")" \
+      || fail "could not merge seed values into $config_path"
+    write_yaml_atomically "$merged" "$config_path" "$live_digest"
+  fi
+  install -m 600 "$seed_file" "$snapshot_file"
+  write_report "$classification" "$config_path"
+  print_summary "$classification" "applied"
+}
+
+cmd_status() {
+  local json=0
+  [[ "${1:-}" != --json ]] || json=1
+  load_documents
+  local classification
+  classification="$(classify "$live_json" "$seed_json" "$snap_json")"
+  if [[ "$json" == 1 ]]; then
+    jq -n --argjson result "$classification" --arg config "$config_path" --arg seed "$seed_file" \
+      '{config: $config, seed: $seed,
+        pending: [$result.set[] | {key, reason, to}],
+        drift: [$result.drift[] | {key, reason, live, seed}],
+        inSyncCount: ($result.insync | length)}'
+  else
+    print_summary "$classification" "pending"
+  fi
+}
+
+cmd_resolve() {
+  local reset_all=0
+  [[ "${1:-}" != --reset-all ]] || reset_all=1
+  acquire_lock
+  load_documents
+  local classification drift_count
+  classification="$(classify "$live_json" "$seed_json" "$snap_json")"
+  drift_count="$(jq -r '.drift | length' <<<"$classification")"
+  if [[ "$drift_count" == 0 ]]; then
+    printf 'omp seed: no drift to resolve\n'
+    return 0
+  fi
+
+  # Answers come from the TTY when interactive, otherwise from stdin (so
+  # tests and scripts can pipe them). fd 4 keeps a single read position for
+  # file-backed stdin; fd 3 carries the drift list.
+  if [[ "$reset_all" == 0 && -t 0 ]]; then
+    exec 4</dev/tty
+  else
+    exec 4<&0
+  fi
+
+  local updated="$live_json" answer key live_value seed_value keep_all=0
+  while IFS=$'\t' read -r -u 3 key live_value seed_value; do
+    if [[ "$reset_all" == 1 ]]; then
+      answer=r
+    elif [[ "$keep_all" == 1 ]]; then
+      answer=k
+    else
+      printf '%s\n  local:   %s\n  default: %s\n' "$key" "$live_value" "$seed_value"
+      printf '  [k]eep local / [r]eset to default / keep [a]ll / [q]uit: '
+      read -r -u 4 answer || answer=q
+      printf '\n'
+    fi
+    case "$answer" in
+      r|R)
+        # Resetting may need to displace a local non-mapping that blocks the
+        # path; the operator explicitly chose the default here.
+        updated="$(jq --arg key "$key" --argjson result "$classification" '
+          first($result.drift[] | select(.key == $key)) as $d
+          | reduce range(1; $d.path | length) as $i (
+              .;
+              if (try (getpath($d.path[:$i]) | (type == "object") or (type == "null")) catch false)
+              then .
+              else delpaths([$d.path[:$i]])
+              end
+            )
+          | setpath($d.path; $d.seed)' <<<"$updated")" \
+          || fail "could not reset $key"
+        printf '  reset %s\n' "$key"
+        ;;
+      a|A) keep_all=1 ;;
+      q|Q) break ;;
+      *) printf '  kept %s\n' "$key" ;;
+    esac
+  done 3< <(jq -r '.drift[] | [.key, (.live | tojson), (.seed | tojson)] | @tsv' <<<"$classification")
+
+  if [[ "$updated" != "$live_json" ]]; then
+    write_yaml_atomically "$updated" "$config_path" "$live_digest"
+    live_json="$updated"
+    live_digest="$(file_digest "$config_path")"
+  fi
+  classification="$(classify "$live_json" "$seed_json" "$snap_json")"
+  write_report "$classification" "$config_path"
+  print_summary "$classification" "pending"
+}
+
+usage() {
+  cat <<'EOF'
+atyrode-omp-seed <command>
+
+  apply                Seed missing defaults and follow repository updates for
+                       values the operator never changed. Local edits win and
+                       are reported as drift. Honors AGENT_TOOLS_DRY_RUN=1.
+  status [--json]      Report pending seeds and drift without writing.
+  resolve [--reset-all]
+                       Interactively keep or reset each drifted value.
+EOF
+}
+
+case "${1:-}" in
+  apply) shift; cmd_apply "$@" ;;
+  status) shift; cmd_status "$@" ;;
+  resolve) shift; cmd_resolve "$@" ;;
+  -h|--help|help|'') usage ;;
+  *) usage >&2; exit 64 ;;
+esac


### PR DESCRIPTION
Implements #61: the settings agreed in the 2026-07-11 review become the baked-in defaults for plain `omp`, without freezing them.

## What this adds

- **`omp/plain-seed.yml`** — the agreed daily-driver defaults: yolo with the two guardrails restored (`secrets.enabled: true`, `task.isolation: auto/patch`), a bundled-role model map (cheap Luna/Terra routes for commit/tiny/smol/task, Sol default, Fable plan), cross-provider fallback chains, advisor on `luna:medium` without subagent advisors, mnemopi memory with a global bank and hosted tiny-role extraction, and the agreed interface preferences (titanium, colorblind mode, cacheMissMarker, tree double-escape, say-submit STT…).
- **`atyrode-omp-seed`** (new package, on PATH) — three-way merges the seed into `~/.omp/agent/config.yml` during activation against the last-applied seed recorded in `~/.local/state/atyrode/omp-plain-seed/`:
  - never touched → written, and follows later repository updates
  - changed/deleted locally → kept, reported as drift (including across seed updates)
  - blocked by a local scalar → kept, reported as drift
  - unmanaged keys → never modified
- **`atyrode apply` integration** — after a successful activation it prints the drift report and, on a terminal, runs an interactive per-key keep-or-reset review (`ATYRODE_SEED_REVIEW=0` opts out; `atyrode-omp-seed status|resolve` work directly).
- **Managed defaults**: `autolearn.autoContinue: false` and `theme.dark: titanium` per the review decisions.
- **`checks/omp-seed.nix`** — sandbox check covering first boot, idempotency, local-edit/deletion drift, seed updates vs drift, blocked scalars, dry runs (write nothing, including state), interactive resolution, array-leaf integrity, and a non-vacuous static assertion that the seed agrees with `omp/policy.yml` wherever they overlap.

## Hardening (from a 30-agent adversarial review of the diff)

The review confirmed and this PR fixes: a silent whole-config wipe when a seed path crossed a local scalar (failed `jq setpath` in argument position produced an empty document that passed validation); the seed tool missing from `home.packages` (the drift review would never have run); a vacuous policy-overlap assertion in the check; resolve crashing on blocked paths and replaying one answer for file-backed stdin; symlink clobbering + mode-777 leaks; dry-run state writes; read-vs-write races (now digest-guarded, abort-and-rerun); and activation failing hard on operator YAML errors (now a warning).

Accepted limits are documented in `docs/agent-tools.md`: machine-formatted rewrites (omp itself strips comments), the managed-settings-guard revert race while a managed session runs, and the first-activation interplay with the v2 migration (originals survive in the migration backup receipt).

## Verification

- `nix flake check` green on x86_64-linux (all checks, including the new one).
- Shellcheck clean; the new check exercises the seeder end-to-end in a fake HOME, including the config-wipe reproduction from the review.

Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)