### PR TITLE
docs(agent-tools): fix CI matrix claim

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -257,4 +257,4 @@ still exists in that unpacked set, so an upstream agent rename or removal
 fails the build instead of silently misrouting models.
 
 GitHub Actions runs the same flake checks natively on x86_64 and aarch64 Linux
-and macOS.
+and aarch64 macOS.


### PR DESCRIPTION
## Summary
Correct the sentence to match .github/workflows/nix.yml's actual matrix: three
runners (x86_64-linux, aarch64-linux, aarch64-darwin), not four platforms.

## Test plan
- [x] Verified no other docs repeat the four-platform claim
- [x] Checked all references in README.md and docs/ — bootstrap.md already correctly states "x86_64/aarch64 Linux and aarch64 Darwin" and "all three CI jobs"

🤖 Generated with Claude Code