### PR TITLE
feat(omp): render the managed routing as an omph terminal page

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ omp           # Mutable user-owned OMP; unmanaged except the blocked update
 ompb          # Budget profile
 ompg          # OpenAI-only high-capability profile
 ompf          # Fable-first profile with fallback disabled
+omph          # Show the managed routing: roles, models, fallbacks per profile
 ompu          # Restricted launcher for deliberately untrusted repositories
 herdr         # Persistent terminal workspace manager
 ```

--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -129,8 +129,19 @@ in
         test ! -e ${pkgs.omp-configured}/bin/pi
         test "$(
           find ${pkgs.omp-configured}/bin -mindepth 1 -maxdepth 1 -printf '%f\n' | sort | paste -sd, -
-        )" = "omp,ompb,ompf,ompg,ompu"
+        )" = "omp,ompb,ompf,ompg,omph,ompu"
         test "$(${pkgs.herdr-configured}/bin/herdr --version)" = "herdr 0.7.3"
+
+        ${pkgs.omp-configured}/bin/omph > "$TMPDIR/omph.txt"
+        ! grep -q $'\e' "$TMPDIR/omph.txt"
+        grep -q "OMP managed routing — oh-my-pi ${lib.getVersion pkgs.omp}" "$TMPDIR/omph.txt"
+        grep -q 'bundled agents: designer librarian reviewer scout sonic task' "$TMPDIR/omph.txt"
+        grep -q '^ompb  Cost-conscious routine work$' "$TMPDIR/omph.txt"
+        grep -q '^ompg  OpenAI-only difficult work$' "$TMPDIR/omph.txt"
+        grep -q '^ompf  Fable-first work with predictable routing$' "$TMPDIR/omph.txt"
+        grep -q 'gpt-5.6-sol:high' "$TMPDIR/omph.txt"
+        grep -q 'claude-fable-5:high' "$TMPDIR/omph.txt"
+        grep -q 'scout is deliberately unpinned' "$TMPDIR/omph.txt"
 
         for invocation in 'update' '--handoff update' 'update --handoff'; do
           read -r -a args <<< "$invocation"

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -14,7 +14,8 @@ Nix owns:
 - the curated plain-omp seed and its drift-aware activation step;
 - the pinned bundled agents, global generic skills, and managed-settings guard
   extension;
-- the `omp`, `ompb`, `ompf`, `ompg`, and restricted `ompu` launchers; and
+- the `omp`, `ompb`, `ompf`, `ompg`, and restricted `ompu` launchers, plus the
+  `omph` routing view; and
 - Claude Code's user-scope operator policy: the deployed `~/.claude/CLAUDE.md`
   instructions and `~/.claude/settings.json` permission rules; and
 - mise itself, with no globally declared mise tools.
@@ -26,9 +27,9 @@ belong in this repository or the Nix store.
 This subsystem deliberately owns neither a `pi` executable nor a `.pi`
 mutable-state namespace. The bounded Pi experiment in #29 may therefore install
 alongside OMP without an executable collision, shared authentication/session
-state, or any parity requirement. The package check asserts the exact five OMP
-launcher names and verifies that an OMP clean-home startup does not create
-`.pi` state. Security boundaries and the untrusted-project launcher are
+state, or any parity requirement. The package check asserts the exact managed
+OMP binary set — five launchers plus the `omph` routing view — and verifies
+that an OMP clean-home startup does not create `.pi` state. Security boundaries and the untrusted-project launcher are
 documented in [Agent security](agent-security.md).
 
 Agents, rules, the settings guard, and the Herdr extension are assembled into
@@ -84,6 +85,13 @@ The bundled `scout` agent (upstream's rename of `explore`) is deliberately not
 pinned: its frontmatter declares the `smol` model role, so repository
 exploration follows the smol route and its fallback chain without a separate
 entry that could go stale.
+
+`omph` prints the effective routing as a terminal page: for each preset
+launcher, every role's primary model, its fallback chain, and any diverging
+task-agent override, with agent-backed roles marked. The page is rendered at
+package build time from the same defaults and preset files, so it always
+matches the deployed configuration. Provider is encoded as a colorblind-safe
+blue/orange pair; piped or `NO_COLOR` output falls back to plain text.
 
 `omp/defaults.yml` is the authoritative role map and fallback-chain definition;
 the preset files intentionally change parts of this table for budget,

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -979,6 +979,37 @@ let
   ompBudget = mkOmpCommand "ompb" [ presets.budget ];
   ompFable = mkOmpCommand "ompf" [ presets.fable ];
   ompGpt = mkOmpCommand "ompg" [ presets.gpt ];
+  routeSpecs = [
+    "ompb|Cost-conscious routine work|${presets.budget}"
+    "ompg|OpenAI-only difficult work|${presets.gpt}"
+    "ompf|Fable-first work with predictable routing|${presets.fable}"
+  ];
+  routesHelp =
+    runCommand "omp-routes-help-${lib.getVersion omp}"
+      {
+        nativeBuildInputs = [
+          jq
+          yq-go
+        ];
+      }
+      ''
+        mkdir -p "$out/share/omp"
+        OMP_ROUTES_COLOR=1 bash ${./render-omp-routes.sh} '${lib.getVersion omp}' \
+          ${omp-agents}/share/omp/agents ${defaultsConfig} \
+          ${lib.escapeShellArgs routeSpecs} > "$out/share/omp/routes.ansi"
+        OMP_ROUTES_COLOR=0 bash ${./render-omp-routes.sh} '${lib.getVersion omp}' \
+          ${omp-agents}/share/omp/agents ${defaultsConfig} \
+          ${lib.escapeShellArgs routeSpecs} > "$out/share/omp/routes.plain"
+      '';
+  ompHelp = writeShellApplication {
+    name = "omph";
+    text = ''
+      if [[ -t 1 && -z ''${NO_COLOR:-} ]]; then
+        exec cat ${routesHelp}/share/omp/routes.ansi
+      fi
+      exec cat ${routesHelp}/share/omp/routes.plain
+    '';
+  };
   trustedUntrustedPath = lib.makeBinPath [
     bash
     coreutils
@@ -1213,6 +1244,7 @@ runCommand "omp-configured-${lib.getVersion omp}"
     ln -s ${lib.getExe ompBudget} "$out/bin/ompb"
     ln -s ${lib.getExe ompFable} "$out/bin/ompf"
     ln -s ${lib.getExe ompGpt} "$out/bin/ompg"
+    ln -s ${lib.getExe ompHelp} "$out/bin/omph"
     ln -s ${lib.getExe ompUntrusted} "$out/bin/ompu"
     ln -s ${omp}/share/zsh/site-functions/_omp "$out/share/zsh/site-functions/_omp"
   ''

--- a/pkgs/omp-configured/render-omp-routes.sh
+++ b/pkgs/omp-configured/render-omp-routes.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Renders the managed OMP routing — every preset launcher's role → model map
+# with fallback chains — as a terminal help page. Runs at package build time,
+# so the page is regenerated from the YAML sources on every apply and cannot
+# drift from the deployed configuration.
+set -euo pipefail
+
+[[ $# -ge 4 ]] || {
+  echo 'usage: render-omp-routes.sh <version> <agents-dir> <defaults.yml> <name|description|preset.yml>...' >&2
+  exit 2
+}
+
+version=$1
+agents_dir=$2
+defaults=$3
+shift 3
+
+# Provider is encoded as a colorblind-safe blue/orange pair, and agent-backed
+# roles carry a shape marker so no information rides on color alone.
+if [[ ${OMP_ROUTES_COLOR:-1} == 1 ]]; then
+  bold=$'\e[1m' dim=$'\e[2m' reset=$'\e[0m'
+  openai=$'\e[38;5;33m' anthropic=$'\e[38;5;208m' other=$'\e[38;5;133m'
+else
+  bold='' dim='' reset='' openai='' anthropic='' other=''
+fi
+
+mapfile -t agents < <(
+  find "$agents_dir" -maxdepth 1 -name '*.md' -printf '%f\n' | sed 's/\.md$//' | sort
+)
+
+is_agent() {
+  local candidate
+  for candidate in "${agents[@]}"; do
+    [[ $candidate == "$1" ]] && return 0
+  done
+  return 1
+}
+
+short_model() {
+  local model=$1
+  model=${model#openai-codex/}
+  printf '%s' "${model#anthropic/}"
+}
+
+model_color() {
+  case $1 in
+    openai-codex/*) printf '%s' "$openai" ;;
+    anthropic/*) printf '%s' "$anthropic" ;;
+    *) printf '%s' "$other" ;;
+  esac
+}
+
+paint_model() {
+  printf '%s%s%s' "$(model_color "$1")" "$(short_model "$1")" "$reset"
+}
+
+pad_model() {
+  local model=$1 width=$2
+  printf '%s%-*s%s' "$(model_color "$model")" "$width" "$(short_model "$model")" "$reset"
+}
+
+merge_configs() {
+  local json='{}' file
+  for file in "$@"; do
+    json=$(printf '%s\n%s\n' "$json" "$(yq eval -o=json -I=0 '.' "$file")" | jq -cs '.[0] * .[1]')
+  done
+  printf '%s' "$json"
+}
+
+role_order=(default task plan slow designer reviewer librarian sonic advisor smol tiny commit)
+
+render_profile() {
+  local name=$1 description=$2 merged=$3
+  local thinking advisor_enabled fallback
+  thinking=$(jq -r '.defaultThinkingLevel // "medium"' <<<"$merged")
+  advisor_enabled=$(jq -r '.advisor.enabled // false' <<<"$merged")
+  fallback=$(jq -r '(.retry.enabled // false) and (.retry.modelFallback // false)' <<<"$merged")
+
+  local advisor_note='advisor off' fallback_note='fallback disabled'
+  [[ $advisor_enabled == true ]] && advisor_note='advisor on'
+  [[ $fallback == true ]] && fallback_note='fallback enabled'
+
+  printf '%s%s%s  %s\n' "$bold" "$name" "$reset" "$description"
+  printf '  %sthinking %s · %s · %s%s\n' "$dim" "$thinking" "$fallback_note" "$advisor_note" "$reset"
+
+  local -a roles=()
+  local role
+  for role in "${role_order[@]}"; do
+    if jq -e --arg role "$role" '.modelRoles[$role] != null' <<<"$merged" >/dev/null; then
+      roles+=("$role")
+    fi
+  done
+  while IFS= read -r role; do
+    [[ " ${role_order[*]} " == *" $role "* ]] || roles+=("$role")
+  done < <(jq -r '.modelRoles | keys[]' <<<"$merged" | sort)
+
+  local primary override marker line step
+  local -a chain
+  for role in "${roles[@]}"; do
+    primary=$(jq -r --arg role "$role" '.modelRoles[$role]' <<<"$merged")
+    marker=' '
+    if is_agent "$role"; then
+      marker='●'
+    fi
+    line=$(printf '  %s %-10s %s' "$marker" "$role" "$(pad_model "$primary" 24)")
+    if [[ $fallback == true ]]; then
+      mapfile -t chain < <(
+        jq -r --arg role "$role" '.retry.fallbackChains[$role] // [] | .[]' <<<"$merged"
+      )
+      for step in "${chain[@]}"; do
+        line+=$(printf ' %s→%s %s' "$dim" "$reset" "$(paint_model "$step")")
+      done
+    fi
+    override=$(jq -r --arg role "$role" '.task.agentModelOverrides[$role] // ""' <<<"$merged")
+    if [[ -n $override && $override != "$primary" ]]; then
+      line+=$(printf ' %s(task override: %s)%s' "$dim" "$(short_model "$override")" "$reset")
+    fi
+    printf '%s\n' "$line"
+  done
+  printf '\n'
+}
+
+printf '%sOMP managed routing%s — oh-my-pi %s\n' "$bold" "$reset" "$version"
+printf '%sbundled agents: %s — ● marks a role backed by a bundled agent%s\n\n' \
+  "$dim" "${agents[*]}" "$reset"
+
+for spec in "$@"; do
+  IFS='|' read -r name description preset <<<"$spec"
+  render_profile "$name" "$description" "$(merge_configs "$defaults" "$preset")"
+done
+
+printf '%s' "$dim"
+printf 'scout is deliberately unpinned: it rides the smol route via its upstream frontmatter.\n'
+printf 'omp runs your own mutable config, unmanaged; ompu is the untrusted launcher\n'
+printf '(defaults routing, isolated state, restricted tools).\n'
+printf 'source: omp/defaults.yml + omp/presets/*.yml — edit in the dotfiles repo, then zconf.\n'
+printf '%s' "$reset"


### PR DESCRIPTION
Re-lands the `omph` commit that missed #66: the PR was merged while the omph
commit was still being pushed, so the squash (8c0205c) contains everything
except it, and the branch deletion afterwards orphaned it. This is that
commit cherry-picked onto current main (post-#67), verified against the seed:

- `omph` renders the managed routing as a terminal page — per preset
  launcher, every role's primary model, fallback chain, and any diverging
  task-agent override, with agent-backed roles marked (●). Rendered at
  package build time from the same defaults/preset files the launchers load,
  so it cannot drift; regenerated by every apply.
- Colorblind-safe blue (OpenAI) / orange (Anthropic) provider coding; plain
  text when piped or under `NO_COLOR`.
- The managed binary set becomes `omp,ompb,ompf,ompg,omph,ompu`; the package
  check asserts the set plus the page's header, sections, and key routes.
- #67 integration checked: `plain-seed.yml` pins only surviving roles (no
  explore/Tester/*-deep) and #67 already added it to the
  `omp-agent-references` check, so nothing further was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)