### PR TITLE
feat(omp): launcher palette, `code` picker with usage panel, Spark draining

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ receipts. See [Bootstrap and migrations](docs/bootstrap.md).
 
 ### macOS Apps
 - **Nix app bundles** - ChatGPT, Godot, Lichess, Obsidian, OrbStack, Postman,
-  Prism Launcher, REAPER, Signal, Spotify, VLC, VS Code, and WhatsApp
+  Prism Launcher, REAPER, Signal, Spotify, VLC, and WhatsApp
 - **Homebrew casks** - Arduino IDE, Bitwarden, Claude Desktop, Codex Desktop, Discord, Display
   Pilot, Parsec, PlugData, Sonos, Steam, and Zen Browser, managed through
   nix-darwin
@@ -88,14 +88,21 @@ atyrode doctor system # Audit system-owned operational prerequisites
 
 ### Agent Tools
 ```bash
+code          # Umbrella picker: list the launchers, pick one, forward your args
 omp           # Mutable user-owned OMP; unmanaged except the blocked update
-ompb          # Budget profile
-ompg          # OpenAI-only high-capability profile
+ompb          # Cost-conscious routine work (OpenAI-led; nano background)
+omps          # Everyday value (Anthropic-led; Sonnet leads, Haiku background)
+ompg          # Difficult work, GPT-led (Sol drives, Claude is the net)
+ompc          # Difficult work, Claude-led (Fable drives, GPT is the net)
 ompf          # Fable-first profile with fallback disabled
+ompx          # Huge-context (1M) work; GPT-5.4 is the 1M cross-net
 omph          # Show the managed routing: roles, models, fallbacks per profile
 ompu          # Restricted launcher for deliberately untrusted repositories
 herdr         # Persistent terminal workspace manager
 ```
+
+See [`omp/PROFILES.md`](omp/PROFILES.md) for the model catalog and the
+reasoning behind each profile.
 
 OMP, Herdr, their integration, shared skills, and mise are installed by `zconf`
 with the rest of the Home Manager profile. See

--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -122,14 +122,14 @@ in
         test "$(yq eval '.tools.approvalMode' ${yoloConfig})" = "null"
         test "$(yq eval '.retry.modelFallback' ${fablePreset})" = "false"
 
-        for command in omp ompb ompf ompg ompu; do
+        for command in omp ompb ompc ompf ompg omps ompu ompx; do
           command_version="$(${pkgs.omp-configured}/bin/"$command" --version)"
           test "''${command_version##*/}" = "${lib.getVersion pkgs.omp}"
         done
         test ! -e ${pkgs.omp-configured}/bin/pi
         test "$(
           find ${pkgs.omp-configured}/bin -mindepth 1 -maxdepth 1 -printf '%f\n' | sort | paste -sd, -
-        )" = "omp,ompb,ompf,ompg,omph,ompu"
+        )" = "code,omp,ompb,ompc,ompf,ompg,omph,omps,ompu,ompx"
         test "$(${pkgs.herdr-configured}/bin/herdr --version)" = "herdr 0.7.3"
 
         ${pkgs.omp-configured}/bin/omph > "$TMPDIR/omph.txt"
@@ -137,11 +137,28 @@ in
         grep -q "OMP managed routing — oh-my-pi ${lib.getVersion pkgs.omp}" "$TMPDIR/omph.txt"
         grep -q 'bundled agents: designer librarian reviewer scout sonic task' "$TMPDIR/omph.txt"
         grep -q '^ompb  Cost-conscious routine work$' "$TMPDIR/omph.txt"
-        grep -q '^ompg  OpenAI-only difficult work$' "$TMPDIR/omph.txt"
-        grep -q '^ompf  Fable-first work with predictable routing$' "$TMPDIR/omph.txt"
+        grep -q '^omps  Everyday value, Sonnet-led$' "$TMPDIR/omph.txt"
+        grep -q '^ompg  Difficult work, GPT-led$' "$TMPDIR/omph.txt"
+        grep -q '^ompc  Difficult work, Claude-led$' "$TMPDIR/omph.txt"
+        grep -q '^ompf  Fable-first, deterministic routing$' "$TMPDIR/omph.txt"
+        grep -q '^ompx  Huge-context (1M) work$' "$TMPDIR/omph.txt"
         grep -q 'gpt-5.6-sol:high' "$TMPDIR/omph.txt"
         grep -q 'claude-fable-5:high' "$TMPDIR/omph.txt"
+        grep -q 'gpt-5.4-nano:low' "$TMPDIR/omph.txt"
+        grep -q 'gpt-5.3-codex-spark:xhigh' "$TMPDIR/omph.txt"
+        grep -q 'claude-haiku-4-5:low' "$TMPDIR/omph.txt"
         grep -q 'scout is deliberately unpinned' "$TMPDIR/omph.txt"
+
+        # `code` umbrella picker: lists the palette non-interactively and
+        # resolves selectors without opening the interactive prompt.
+        ${pkgs.omp-configured}/bin/code --list > "$TMPDIR/code.txt"
+        grep -q '1) omp' "$TMPDIR/code.txt"
+        grep -q 'omps' "$TMPDIR/code.txt"
+        grep -q 'ompc' "$TMPDIR/code.txt"
+        grep -q 'ompx' "$TMPDIR/code.txt"
+        grep -q 'ompu' "$TMPDIR/code.txt"
+        ${pkgs.omp-configured}/bin/code --help > "$TMPDIR/code-help.txt"
+        grep -q 'pick an OMP launcher' "$TMPDIR/code-help.txt"
 
         for invocation in 'update' '--handoff update' 'update --handoff'; do
           read -r -a args <<< "$invocation"
@@ -626,7 +643,7 @@ in
             # Model-preset launchers are routing overlays only: all of them
             # share the default profile and the normal persisted state root,
             # so switching launchers never requires re-authentication.
-            for launcher in ompb ompf ompg; do
+            for launcher in ompb omps ompg ompc ompf ompx; do
               ${configuredStub}/bin/"$launcher" config managed --json \
                 > "$TMPDIR/launcher-state.json"
               jq -e '.profile == "default"' "$TMPDIR/launcher-state.json" >/dev/null
@@ -806,13 +823,16 @@ in
             # the managed defaults file is asserted directly with yq above.
             declare -A expected_default_models=(
               [ompb]='openai-codex/gpt-5.6-terra:low'
-              [ompf]='anthropic/claude-fable-5:high'
+              [omps]='anthropic/claude-sonnet-5:medium'
               [ompg]='openai-codex/gpt-5.6-sol:high'
+              [ompc]='anthropic/claude-fable-5:high'
+              [ompf]='anthropic/claude-fable-5:high'
+              [ompx]='anthropic/claude-opus-4-8:medium'
             )
             policy_home="$TMPDIR/policy-home"
             policy_project="$TMPDIR/policy-project"
             mkdir -p "$policy_home" "$policy_project"
-            for command in ompb ompf ompg; do
+            for command in ompb omps ompg ompc ompf ompx; do
               HOME="$policy_home" XDG_CONFIG_HOME="$policy_home/.config" \
                 ${configuredStub}/bin/"$command" --cwd "$policy_project" \
                   config managed --json > "$TMPDIR/$command-policy.json"
@@ -827,7 +847,7 @@ in
               and (.ownership.presets | index("providers.anthropic.serverSideFallback")) != null
             ' "$TMPDIR/ompf-policy.json" >/dev/null
 
-            for command in omp ompb ompf ompg; do
+            for command in omp ompb omps ompg ompc ompf ompx; do
               set +e
               ${configuredStub}/bin/"$command" update \
                 > "$TMPDIR/update.out" 2> "$TMPDIR/update.err"

--- a/docs/agent-security.md
+++ b/docs/agent-security.md
@@ -6,8 +6,8 @@ repository trustworthy, and it is not an operating-system sandbox.
 
 ## Normal sessions
 
-Managed preset launchers (`ompb`, `ompf`, `ompg`) use the
-trusted-machine unattended approval policy: workspace edits, shell/eval,
+Managed preset launchers (`ompb`, `omps`, `ompg`, `ompc`, `ompf`, `ompx`) use
+the trusted-machine unattended approval policy: workspace edits, shell/eval,
 browser, task spawning, and GitHub operations do not prompt. Secret filtering
 remains enabled, and task isolation uses OMP's automatic backend selection and
 patch merging. A managed extension fails closed when a `task` call that can

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -14,8 +14,9 @@ Nix owns:
 - the curated plain-omp seed and its drift-aware activation step;
 - the pinned bundled agents, global generic skills, and managed-settings guard
   extension;
-- the `omp`, `ompb`, `ompf`, `ompg`, and restricted `ompu` launchers, plus the
-  `omph` routing view; and
+- the `omp`, `ompb`, `omps`, `ompg`, `ompc`, `ompf`, `ompx`, and restricted
+  `ompu` launchers, plus the `omph` routing view and the `code` launcher
+  picker; and
 - Claude Code's user-scope operator policy: the deployed `~/.claude/CLAUDE.md`
   instructions and `~/.claude/settings.json` permission rules; and
 - mise itself, with no globally declared mise tools.
@@ -28,8 +29,9 @@ This subsystem deliberately owns neither a `pi` executable nor a `.pi`
 mutable-state namespace. The bounded Pi experiment in #29 may therefore install
 alongside OMP without an executable collision, shared authentication/session
 state, or any parity requirement. The package check asserts the exact managed
-OMP binary set — five launchers plus the `omph` routing view — and verifies
-that an OMP clean-home startup does not create `.pi` state. Security boundaries and the untrusted-project launcher are
+OMP binary set — eight launchers plus the `omph` routing view and the `code`
+picker — and verifies that an OMP clean-home startup does not create `.pi`
+state. Security boundaries and the untrusted-project launcher are
 documented in [Agent security](agent-security.md).
 
 Agents, rules, the settings guard, and the Herdr extension are assembled into
@@ -46,13 +48,31 @@ rewriting the Bun executable with `patchelf`.
 
 ## OMP launchers
 
+The launchers form a palette: two everyday profiles per subscription pool
+(cheap and hard), two specialists, and a base layer. `code` is an umbrella
+picker over all of them (see below). The design rationale — the model catalog,
+the fallback principles, and the per-profile reasoning — lives in
+[`omp/PROFILES.md`](../omp/PROFILES.md).
+
 | Command | Intended use | Primary route |
 | --- | --- | --- |
 | `omp` | Mutable daily driver; user-owned configuration | Whatever the operator's own OMP config selects; unmanaged apart from the blocked `update` |
-| `ompb` | Cost-conscious routine work | GPT-5.6 Terra/Luna at lower thinking |
-| `ompg` | OpenAI-only difficult work | GPT-5.6 Sol with Terra/Luna fallbacks |
+| `ompb` | Cost-conscious routine work (OpenAI-led) | GPT-5.6 Terra/Luna at low thinking; `task`+background lead on GPT-5.3-codex-spark (free bucket) → nano |
+| `omps` | Everyday value (Anthropic-led) | Sonnet 5 leads; Opus for plan/slow; background on GPT-5.3-codex-spark (free bucket) → Haiku |
+| `ompg` | Difficult work, GPT-led | GPT-5.6 Sol drives; a GPT sibling absorbs a blip, then Claude is the net |
+| `ompc` | Difficult work, Claude-led | Fable drives; Opus absorbs a blip, then GPT is the net (ompg's mirror) |
 | `ompf` | Fable-first work with predictable routing | Fable for primary/deliberative roles, with automatic fallback disabled |
+| `ompx` | Huge-context (1M) work | Fable/Opus/Sonnet lead; GPT-5.4 is the 1M cross-net; every substantive hop holds 1M |
 | `ompu` | Deliberately untrusted repositories | Dedicated state, sanitized credentials, restricted integrations, and isolated writing tasks |
+
+Each profile commits to one subscription pool for its lead and substantive
+roles, so switching launchers also switches which meter burns (Codex credits vs
+the Claude plan); the fallback net is the other pool. The exception is the
+fast-execution and background roles, which lead on `gpt-5.3-codex-spark` — its
+5h/7d Codex quota is a separate, normally-idle bucket, so draining it costs
+nothing on the main meters, and each role falls back to the per-pool cheap rung
+(nano or Haiku) the moment that bucket is exhausted. See
+[`omp/PROFILES.md`](../omp/PROFILES.md) for the full rationale.
 
 Plain `omp` executes upstream OMP directly: no extension, defaults, preset, or
 policy overlay is injected, so its models, approvals, and interface belong to
@@ -62,24 +82,28 @@ starting point is not empty, though: activation seeds the curated defaults
 from `omp/plain-seed.yml` into the writable configuration with local edits
 always winning; see [Seeded plain-omp defaults](#seeded-plain-omp-defaults).
 
-The managed defaults use Sol for interactive daily work, keep cheap, fast
-roles on Luna or low-thinking Terra, and reserve Fable/Opus for planning,
-design, architecture, and review where their higher cost is most useful. The
-presets are policy, not provider pricing data; revisit the routes when model
-quality or pricing changes.
+The managed defaults use Sol for interactive daily work, keep cheap, fast roles
+on Luna, drop the text-trivial `commit`/`tiny` roles to GPT-5.4-nano, and
+reserve Fable/Opus for planning and the deliberative fallback tier. Fallback
+chains follow one rule: try a same-provider sibling first (it rules out a single
+model at capacity for free), then make the last, load-bearing hop cross to the
+other provider; trivial background roles carry no chain at all. The presets are
+policy, not provider pricing data; revisit the routes when model quality or
+pricing changes.
 
 The balanced routing rationale is:
 
 | Role or role group | Capability and intended use | Thinking | Cost posture and fallback rationale |
 | --- | --- | --- | --- |
-| `default` | Interactive daily work on Sol | Medium | Sol is the user-selected default; Sonnet then Terra preserve cross-provider fallback |
-| `task` | General implementation on Terra | Medium | Mid-cost worker route; Sonnet then Sol covers provider or capability failures |
-| `librarian` | Repository and documentation research on Terra | Medium | Sonnet adds cross-provider depth; Luna is the economical final fallback |
-| `advisor`, `smol`, `sonic`, `tiny`, `commit` | Fast review, lookup, naming, and commit-message work on Luna | Minimal–low | Cheapest recurring work; Terra is the first quality step-up |
-| `designer` | Product and interface design on Sonnet | Medium | Pays for stronger visual judgment; Sol and Fable provide cross-provider fallbacks |
-| `reviewer` | High-scrutiny review on Sonnet | High | Higher-cost quality gate; Opus then Sol preserve depth if the primary is unavailable |
-| `plan` | Architecture and planning on Fable | High | Premium reasoning is intentional for decisions with broad downstream impact; Opus or Sol are the escape routes |
-| `slow` | Hard debugging and deliberate reasoning on Sol | Xhigh | Expensive OpenAI reasoning is reserved for difficult failures; Opus and high-thinking Terra provide diversity |
+| `default` | Interactive daily work on Sol | Medium | Sol is the user-selected default; a Terra sibling absorbs a Sol blip, then Sonnet is the cross-provider net |
+| `task` | General implementation on Terra | Medium | Mid-cost worker; a Luna sibling first, then Sonnet crosses providers |
+| `librarian` | Repository and documentation research on Terra | Medium | A Luna sibling keeps the read-heavy role cheap, then Sonnet crosses for depth |
+| `advisor`, `smol`, `sonic` | Fast review, lookup, and naming on Luna | Minimal–low | Cheapest recurring work; no fallback chain — a blip is harmless and crossing them is wasteful |
+| `tiny`, `commit` | Labels and commit messages on GPT-5.4-nano | Low | The cheapest rung for text-trivial, always-on work; no fallback chain |
+| `designer` | Product and interface design on Sonnet | Medium | Crosses straight to Terra, Sonnet's price-twin (Sonnet has no lateral Anthropic sibling) |
+| `reviewer` | High-scrutiny review on Sonnet | High | Higher-cost quality gate; escalates to Opus, then Sol, if the primary is unavailable |
+| `plan` | Architecture and planning on Fable | High | Premium reasoning is intentional for decisions with broad downstream impact; Opus then Sol are the escape routes |
+| `slow` | Hard debugging and deliberate reasoning on Sol | Xhigh | Expensive OpenAI reasoning is reserved for difficult failures; a Terra sibling, then Opus crosses providers |
 
 The bundled `scout` agent (upstream's rename of `explore`) is deliberately not
 pinned: its frontmatter declares the `smol` model role, so repository
@@ -93,9 +117,25 @@ package build time from the same defaults and preset files, so it always
 matches the deployed configuration. Provider is encoded as a colorblind-safe
 blue/orange pair; piped or `NO_COLOR` output falls back to plain text.
 
+`code` is an umbrella picker over the whole palette. With no arguments it lists
+the launchers with one-line descriptions and prompts for a choice; `?N` shows a
+longer description for entry `N`. The interactive picker also renders a compact
+`omp usage` panel beside the palette (best-effort and bounded, so it never
+blocks; `code --no-usage` skips it), marking each provider's quota windows
+`free` when idle and `tight` at ≥80% — a glance at which meter has room before
+you pick. A selector can also be passed directly by
+name, menu number, or single suffix letter (`code ompg`, `code 4`, `code g`),
+with any remaining arguments forwarded to the chosen launcher. If the first
+argument is not a known profile, the picker opens and then forwards every
+argument to the choice, so `code --resume` picks a profile first, then resumes.
+`code --list` and `code --help` are non-interactive. It is a thin wrapper: the
+chosen launcher receives the arguments unchanged and applies its own managed
+overlays.
+
 `omp/defaults.yml` is the authoritative role map and fallback-chain definition;
-the preset files intentionally change parts of this table for budget,
-OpenAI-only, and Fable-first sessions.
+the preset files intentionally change parts of this table for the budget
+(`ompb`), Sonnet-value (`omps`), GPT-led (`ompg`), Claude-led (`ompc`),
+Fable-first (`ompf`), and huge-context (`ompx`) sessions.
 
 Managed preset launchers load configuration in this order:
 

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,6 @@
         "steam-unwrapped"
         "steamcmd"
         "vital"
-        "vscode"
         "whatsapp-for-mac"
       ];
       homebrewCasks = import ./darwin/casks.nix;

--- a/home/profiles/desktop.nix
+++ b/home/profiles/desktop.nix
@@ -23,7 +23,6 @@ in
       signal-desktop
       spotify
       vlc-bin
-      vscode
       whatsapp-for-mac
     ])
     ++ [ lichess ]

--- a/modules/home/agent-tools.nix
+++ b/modules/home/agent-tools.nix
@@ -14,6 +14,9 @@ let
     budget = ../../omp/presets/budget.yml;
     fable = ../../omp/presets/fable-primary.yml;
     gpt = ../../omp/presets/gpt56.yml;
+    sonnet = ../../omp/presets/sonnet-value.yml;
+    claude = ../../omp/presets/claude-hard.yml;
+    context = ../../omp/presets/context-1m.yml;
   };
 
   herdrCompletions = pkgs.runCommand "herdr-completions-${lib.getVersion cfg.herdrPackage}" { } ''
@@ -65,6 +68,9 @@ in
       "omp/presets/budget.yml".source = presets.budget;
       "omp/presets/fable-primary.yml".source = presets.fable;
       "omp/presets/gpt56.yml".source = presets.gpt;
+      "omp/presets/sonnet-value.yml".source = presets.sonnet;
+      "omp/presets/claude-hard.yml".source = presets.claude;
+      "omp/presets/context-1m.yml".source = presets.context;
     };
 
     home.file = {

--- a/omp/PROFILES.md
+++ b/omp/PROFILES.md
@@ -1,0 +1,244 @@
+# OMP profile design
+
+This is the *why* behind the managed OMP launchers. The *what* — the actual
+role → model maps and fallback chains — lives in [`defaults.yml`](defaults.yml)
+and [`presets/`](presets/); the operational reference (launcher table, config
+load order, security posture) is [`docs/agent-tools.md`](../docs/agent-tools.md).
+Read this file before reshaping the routing, and update it when you do.
+
+Everything here was derived from `omp models` on 2026-07-11 and prototyped in an
+interactive proposal artifact ("OMP routing proposal"). Prices are list price
+per 1M tokens (input/output); with subscription auth (Codex credits / Claude
+plan) they read as **relative burn rates** rather than direct dollars.
+
+## The model catalog
+
+Only the models actually used in routing are listed. `omp models` shows the full
+registry, including previous GPT generations that are cheaper per token but
+deliver less per dollar than the 5.6 tiers, so nothing routes to them today.
+
+### OpenAI (provider `openai-codex`)
+
+| Model | $ in/out | Context | Thinking | Role in routing |
+| --- | --- | --- | --- | --- |
+| `gpt-5.6-sol` | $5 / $30 | 372K | low→max | Flagship. Leads `ompg` and the base default. Out-prices Opus 4.8 per output token. |
+| `gpt-5.6-terra` | $2.50 / $15 | 372K | low→max | Balanced workhorse. Leads `ompb` and the task/librarian roles. Sonnet's price-twin. |
+| `gpt-5.6-luna` | $1 / $6 | 372K | low→max | Fast, high-volume. Sibling hop and cheap worker across the OpenAI-led maps. |
+| `gpt-5.4` | $2.50 / $15 | **1M** | low→xhigh | The only OpenAI 1M card. `ompx`'s cross-net and librarian lead. |
+| `gpt-5.4-nano` | **$0.20 / $1.25** | 272K | low→xhigh | Cheapest model on hand (~5× under Luna). Background trivia (`commit`/`tiny`, all of `ompb`'s background). No `minimal` level — floor is `low`. |
+
+### Anthropic (provider `anthropic`)
+
+| Model | $ in/out | Context | Thinking | Role in routing |
+| --- | --- | --- | --- | --- |
+| `claude-fable-5` | $10 / $50 | 1M | low→max | Most capable. Drives `ompf`/`ompc`, plans in `ompx`, holds the base `plan` role. Thinking is always on (levels are effort). |
+| `claude-opus-4-8` | $5 / $25 | 1M | low→max | Top Opus tier. Leads `omps`'s plan/slow and `ompx`'s live thread; the deliberative fallback across the maps. |
+| `claude-sonnet-5` | $2 / $10 † | 1M | low→max | The value pick — near-Opus quality at a fraction of the cost. Leads `omps` and the Anthropic-led worker roles. |
+| `claude-haiku-4-5` | $1 / $5 | 200K | minimal→xhigh | Fastest/cheapest Anthropic tier. Background hum of the Anthropic-led maps; cross-net for `ompb`'s task. |
+
+† Sonnet 5 is at introductory pricing through **2026-08-31**, then $3 / $15 —
+dearer than Terra. See [Revisit triggers](#revisit-triggers).
+
+Not routed: `gpt-5.4-mini` (squeezed between nano and Luna with no niche),
+`gpt-5.1-codex-mini` (cheap but narrow thinking), the rest of the GPT-5.x
+back-catalog, and `claude-mythos-5` (gated private program, not usable).
+
+## Principles
+
+1. **Every fallback chain ends by crossing providers.** A same-provider sibling
+   first cheaply rules out a single model being at capacity; the last,
+   load-bearing hop must reach the *other* vendor, or the chain dies with its
+   provider. `Sol → Terra → Luna` is three OpenAI models — one outage takes all
+   three.
+2. **Sibling hops must be price-lateral.** `Sol → Terra` costs nothing extra to
+   try. Sonnet has no lateral Anthropic sibling (Opus is 2.5× up, Haiku a class
+   down), so Sonnet-led chains cross straight to Terra, its price-twin. No chain
+   silently upgrades you. (High-stakes `reviewer` is the deliberate exception:
+   escalating to Opus on failure is a feature, not a surprise.)
+3. **One subscription pool per profile.** All-OpenAI columns burn Codex credits;
+   all-Anthropic columns burn the Claude plan — background roles included. A
+   profile is therefore also a quota lever: when one meter runs dry, switch
+   columns and *everything* moves. The fallback net is the other pool.
+4. **Fast-execution roles drain the free Spark bucket first.** `gpt-5.3-codex-spark`
+   has a separate, normally-idle 5h/7d Codex quota (see [Separate rate
+   buckets](#separate-rate-buckets--an-underused-lever)), so the execution and
+   background roles — `sonic`/`advisor`/`tiny`/`commit`, plus `task` in the
+   OpenAI-led profiles — lead on it. Because that bucket is free and the goal is
+   to empty it, the roles that do real work (`task`/`sonic`/`advisor`) run at
+   **`:xhigh`** — best output *and* faster drain — while the boilerplate
+   one-liners (`tiny`/`commit`) stay at `:low`, where xhigh reasoning would only
+   add latency. When the bucket is exhausted each role falls back to the cheap
+   rung: `gpt-5.4-nano` ($0.20/$1.25) under OpenAI-led profiles, `claude-haiku-4-5`
+   ($1/$5) under Anthropic-led ones. Spark stays off `smol`/scout (exploration
+   can exceed its 128K window), the thinking roles, and `ompf`.
+5. **Trivial roles carry at most one cheap fallback.** Background is never
+   crossed to a premium model — it gets exactly one hop, from Spark down to the
+   cheap rung, so draining the Spark allowance is transparent. The real chains
+   are reserved for the live thread, the workers, and the deliberative roles.
+6. **Thinking scales with stakes.** xhigh/high for `plan`, `slow`, `reviewer`,
+   `designer`; medium for the interactive default and workers; low/minimal for
+   background. `ompb` caps at high even for its deliberative roles.
+
+## Separate rate buckets — an underused lever
+
+With subscription auth the real constraint is not dollars but **quota windows**,
+and the providers meter more than one bucket per account. `omp usage` shows them
+(and the `code` picker renders a compact panel of them beside the palette):
+
+- **OpenAI Codex has two independent buckets.** The main 5h/7d window is shared
+  by `sol`/`terra`/`luna`/`gpt-5.4`/`nano`. But `gpt-5.3-codex-spark` draws from
+  a **separate** 5h/7d "Spark" bucket that is usually sitting at 0%. That idle
+  Spark allowance is effectively **free extra Codex capacity every 5h/7d** — in
+  an ideal world we drain it too, rather than let it reset unused. Routing some
+  work to `openai-codex/gpt-5.3-codex-spark` spends the Spark bucket instead of
+  the shared main bucket, and (as a fallback) delays the cross to Anthropic.
+  - *Wired in as of this revision.* The fast-execution roles lead on
+    `gpt-5.3-codex-spark` — at `:xhigh` for the real-work roles
+    (`task`/`sonic`/`advisor`) to drain harder and get better output, `:low` for
+    the `tiny`/`commit` one-liners — and fall back the instant its bucket 429s,
+    so the drain is transparent:
+    - OpenAI-led (`ompb`, `ompg`): `task` **and** `sonic`/`advisor`/`tiny`/`commit`
+      lead on Spark. `task` falls back to its old terra/luna worker chain (then
+      crosses); background falls back to `nano`.
+    - Anthropic-led (`omps`, `ompc`, `ompx`): the background roles lead on Spark
+      and fall back to `haiku`. `task` stays pool-pure on Claude — draining the
+      free Codex bucket for trivia is worth a small pool impurity, but the
+      substantial worker is not.
+  - *Deliberately kept off Spark:* `smol`/scout (exploration can exceed the 128K
+    window — truncation risk), every thinking role (`plan`/`slow`/`reviewer`/
+    `designer`/`default` — Spark is fast, not a reasoner), and all of `ompf`
+    (its no-fallback contract means an exhausted Spark bucket would hard-fail).
+  - *Caveats to watch:* Spark is $1.75/$14 list, so this only "wins" under
+    subscription auth where quota, not dollars, is scarce; and a `task` whose
+    context exceeds 128K relies on Spark erroring (not silently truncating) for
+    the fallback to engage.
+- **Anthropic's Fable is the mirror image — a separate but *scarce* bucket.**
+  Fable draws from its own 7-day sub-limit that is frequently the binding
+  Anthropic constraint (often 80%+ while the general Claude 5h/7d bucket sits
+  much lower). So Fable-heavy profiles (`ompf`, and `ompc`'s default/plan/slow)
+  burn that scarce bucket fastest. When the picker panel flags Fable **tight**,
+  lean Sonnet/Opus (general bucket) or an OpenAI-led profile.
+
+The picker panel is exactly there to make this a glance-and-pick decision: see
+which bucket is tight before you choose a harness.
+
+## The palette
+
+Two everyday profiles per pool (cheap and hard), two specialists, and a base
+layer. `code` (see [below](#the-code-picker)) is an umbrella picker over all of
+them.
+
+| | OpenAI-led (Codex meter) | Anthropic-led (Claude meter) |
+| --- | --- | --- |
+| **cheap** | `ompb` — routine work, nano background, features off | `omps` — everyday value, Sonnet-led, features on |
+| **hard** | `ompg` — Sol drives, Claude is the net | `ompc` — Fable drives, GPT is the net |
+| **specialist** | — | `ompf` deterministic Fable · `ompx` huge-context (1M) |
+
+Base layer: [`defaults.yml`](defaults.yml) underlies every launcher and is the
+entire model map for `ompu` (untrusted repos), whose real differences are
+posture (approvals, secrets, isolation), not models.
+
+## Per-profile rationale
+
+Routing detail is in the YAML; each file's header comment states its thesis.
+Summary:
+
+- **`ompb`** ([budget.yml](presets/budget.yml)) — minimum burn. Terra/Luna lead
+  the interactive and deliberative roles at low thinking. `task` and the
+  background roles lead on Spark to drain the free Codex bucket, falling back to
+  their old rungs (`task`→terra→luna→Haiku; background→nano). `default` keeps a
+  Luna→Sonnet net; the deliberative roles keep none. Advisor, branch summaries,
+  and autolearn off.
+- **`omps`** ([sonnet-value.yml](presets/sonnet-value.yml)) — the profile `ompb`
+  can't be: cheap *and* premium-adjacent. Sonnet leads everything but plan/slow,
+  where low-volume Opus is worth the leverage. Chains cross to Terra/Luna
+  (Sonnet's price-twins). All-Anthropic pool for the substantive roles; features
+  stay on. Background leads on Spark (free Codex bucket) → Haiku, so trivia
+  doesn't spend the Claude plan. Doubles as the "Codex credits are spent"
+  everyday driver.
+- **`ompg`** ([gpt56.yml](presets/gpt56.yml)) — difficult work, GPT-led. Every
+  substantive role runs GPT → GPT → Claude: a sibling absorbs a single-model
+  overload for free, then the last hop crosses to Fable/Opus so a full OpenAI
+  outage still lands on a live vendor. `task` and the background roles lead on
+  Spark (fast execution, draining the free Codex bucket), falling back to the
+  terra/luna chain and nano respectively.
+- **`ompc`** ([claude-hard.yml](presets/claude-hard.yml)) — `ompg`'s mirror,
+  opposite pool. Fable drives, Opus is the sibling (and leads review, its
+  strength), Sonnet/Haiku carry workers, every chain reaches back to Sol/Terra.
+  Load it when OpenAI is dark or the Codex meter is empty and the work is still
+  hard. Unlike `ompf`, nothing strands on a single model. Background leads on
+  Spark (free Codex bucket) → Haiku.
+- **`ompf`** ([fable-primary.yml](presets/fable-primary.yml)) — Fable-first,
+  deterministic. Retry and server-side fallback **off**: the contract is "give
+  me Fable, predictably, and never silently swap." Resilience is `ompc`'s job
+  now, so `ompf` stays pure. Background on cheap OpenAI rungs so Fable isn't
+  burned on commit messages (the mixed pool is the accepted price of
+  determinism).
+- **`ompx`** ([context-1m.yml](presets/context-1m.yml)) — work beyond the 372K
+  ceiling of the 5.6 family. Anthropic owns 1M, so Fable/Opus/Sonnet lead;
+  `gpt-5.4` is the only OpenAI 1M card, used as the universal cross-net and the
+  librarian lead (putting the read-everything role on the Codex meter splits the
+  burn). **Invariant: a fallback never shrinks the window mid-job** on a
+  substantive role. Background trivia never sees the big context, so it leads on
+  Spark (free Codex bucket) → Haiku.
+
+## The `code` picker
+
+`code` lists the palette, resolves a selector (menu number, launcher name,
+alias like `plain`, or a single suffix letter — `code ompg`, `code 4`,
+`code g`), and execs the matching launcher, forwarding every remaining argument.
+If the first argument is not a known profile, the picker opens and then forwards
+all arguments to the choice, so `code --resume` picks first, then resumes.
+`code --list` / `code --help` are non-interactive. It is a thin wrapper: the
+chosen launcher applies its own managed overlays unchanged.
+
+The interactive picker also renders a compact `omp usage` panel beside the
+palette (best-effort, ~2s from cache; bounded so it never blocks the picker —
+`code --no-usage` skips it). Each provider's quota windows show a bar and
+percent, with `free` on an idle bucket and `tight` at ≥80%, so you can see which
+meter has room before you pick. See [Separate rate buckets](#separate-rate-buckets--an-underused-lever).
+
+It is defined in [`pkgs/omp-configured/default.nix`](../pkgs/omp-configured/default.nix)
+from a single `paletteProfiles` list that also feeds the `omph` route view, so
+the picker, the routing page, and the launchers never drift.
+
+## Changing the routing
+
+1. Edit [`defaults.yml`](defaults.yml) (base map) or the relevant
+   [`presets/`](presets/) file. Model selectors are `provider/model:thinking`,
+   e.g. `openai-codex/gpt-5.6-terra:medium`.
+2. Verify the selector and thinking level exist: `omp models --json`. A bad ID
+   or level is a *runtime* error, not a build failure — the YAML is not
+   validated against the registry at build time.
+3. Run `zconf` (`atyrode apply`), then `omph` to see the rendered routing.
+4. If you add or rename a launcher, update `paletteProfiles` in
+   `pkgs/omp-configured/default.nix`, the preset set in
+   `modules/home/agent-tools.nix`, and the assertions in
+   `checks/agent-tools.nix` (the bin inventory and `omph` descriptions are
+   pinned).
+
+## Revisit triggers
+
+- **The nano bet.** `commit`/`tiny` and all of `ompb`'s background run on
+  `gpt-5.4-nano` — the ~5× saving is the biggest here, and the only quality
+  gamble. If commit messages or labels degrade, the revert is one line back to
+  Luna per role. Worth a week's trial before judging.
+- **Sonnet's price cliff.** `omps` is built on introductory pricing ($2/$10). On
+  **2026-08-31** it steps to $3/$15 — dearer than Terra. The profile stays
+  coherent (pool separation still justifies it), but the "cheapest
+  premium-adjacent" pitch expires; recheck against Terra then.
+- **`ompx` librarian pool-split.** `gpt-5.4` leads `ompx`'s librarian to spread
+  the read-everything burn onto the Codex meter and give the 1M card a real job.
+  If a previous-gen model leading a role feels wrong, the alternative is
+  all-Anthropic (Sonnet lead, `gpt-5.4` as net only).
+- **How hard to push Spark.** Spark now leads the fast-execution roles (see
+  [Separate rate buckets](#separate-rate-buckets--an-underused-lever)). Two dials
+  remain: whether `task` should also lead on Spark in the Anthropic-led profiles
+  (more drain, but the substantial worker leaves the Claude pool), and whether
+  the background `:low` output holds up in practice. If a role degrades, revert
+  it to its cheap rung — one line per role. Watch the Spark 5h/7d bars in the
+  `code` panel: if they never approach full, push more roles onto Spark; if they
+  saturate early and fall back constantly, ease off.
+- **Model registry churn.** New tiers or price changes can invalidate a lead or
+  a price-twin pairing. The presets are policy, not pricing data — re-derive from
+  `omp models` when the catalog moves.

--- a/omp/defaults.yml
+++ b/omp/defaults.yml
@@ -15,46 +15,37 @@ modelRoles:
   reviewer: anthropic/claude-sonnet-5:high
   plan: anthropic/claude-fable-5:high
   slow: openai-codex/gpt-5.6-sol:xhigh
-  tiny: openai-codex/gpt-5.6-luna:minimal
-  commit: openai-codex/gpt-5.6-luna:low
+  tiny: openai-codex/gpt-5.4-nano:low
+  commit: openai-codex/gpt-5.4-nano:low
 
 retry:
   enabled: true
   modelFallback: true
   fallbackRevertPolicy: cooldown-expiry
+  # Sibling first (rules out one model at capacity for free), cross last (the
+  # load-bearing step reaches the other provider). Trivial roles carry no chain:
+  # a blip on commit/tiny/sonic is harmless and crossing them is wasteful.
   fallbackChains:
     default:
-      - anthropic/claude-sonnet-5:medium
       - openai-codex/gpt-5.6-terra:medium
-    advisor:
-      - openai-codex/gpt-5.6-terra:low
       - anthropic/claude-sonnet-5:medium
-    smol:
-      - openai-codex/gpt-5.6-terra:low
     task:
+      - openai-codex/gpt-5.6-luna:medium
       - anthropic/claude-sonnet-5:medium
-      - openai-codex/gpt-5.6-sol:medium
-    sonic:
-      - openai-codex/gpt-5.6-terra:low
-    librarian:
-      - anthropic/claude-sonnet-5:medium
-      - openai-codex/gpt-5.6-luna:high
-    designer:
-      - openai-codex/gpt-5.6-sol:high
-      - anthropic/claude-fable-5:medium
-    reviewer:
-      - anthropic/claude-opus-4-8:high
-      - openai-codex/gpt-5.6-sol:high
     plan:
       - anthropic/claude-opus-4-8:high
       - openai-codex/gpt-5.6-sol:high
     slow:
-      - anthropic/claude-opus-4-8:high
       - openai-codex/gpt-5.6-terra:xhigh
-    tiny:
-      - openai-codex/gpt-5.6-terra:low
-    commit:
-      - openai-codex/gpt-5.6-terra:low
+      - anthropic/claude-opus-4-8:xhigh
+    designer:
+      - openai-codex/gpt-5.6-terra:medium
+    reviewer:
+      - anthropic/claude-opus-4-8:high
+      - openai-codex/gpt-5.6-sol:high
+    librarian:
+      - openai-codex/gpt-5.6-luna:medium
+      - anthropic/claude-sonnet-5:medium
 
 personality: pragmatic
 

--- a/omp/presets/budget.yml
+++ b/omp/presets/budget.yml
@@ -1,34 +1,49 @@
+# Fast-execution roles lead on gpt-5.3-codex-spark, which draws from its own
+# idle 5h/7d Codex quota (see omp/PROFILES.md "Separate rate buckets"). The
+# bucket is free and the goal is to drain it, so the roles that do real work
+# (task/sonic/advisor) run at :xhigh — best output and faster drain — while the
+# boilerplate one-liners (tiny/commit) stay at :low (xhigh buys them nothing but
+# latency). Each role falls back to the normal cheap rung the moment Spark's
+# bucket is exhausted, so the drain is transparent. Thinking roles
+# (plan/slow/designer/reviewer) and smol/scout stay off Spark.
 modelRoles:
   default: openai-codex/gpt-5.6-terra:low
-  advisor: openai-codex/gpt-5.6-luna:minimal
-  smol: openai-codex/gpt-5.6-luna:minimal
-  task: openai-codex/gpt-5.6-terra:low
-  sonic: openai-codex/gpt-5.6-luna:minimal
-  librarian: openai-codex/gpt-5.6-terra:low
+  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  smol: openai-codex/gpt-5.4-nano:low
+  task: openai-codex/gpt-5.3-codex-spark:xhigh
+  sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+  librarian: openai-codex/gpt-5.6-luna:medium
   designer: openai-codex/gpt-5.6-terra:medium
   reviewer: openai-codex/gpt-5.6-terra:medium
   plan: openai-codex/gpt-5.6-terra:high
   slow: openai-codex/gpt-5.6-terra:high
-  tiny: openai-codex/gpt-5.6-luna:minimal
-  commit: openai-codex/gpt-5.6-luna:minimal
+  tiny: openai-codex/gpt-5.3-codex-spark:low
+  commit: openai-codex/gpt-5.3-codex-spark:low
 
 retry:
   enabled: true
   modelFallback: true
   fallbackRevertPolicy: cooldown-expiry
+  # task drains Spark first, then the old terra/luna worker chain, then crosses
+  # to Haiku. Background drains Spark, then nano. The deliberative roles keep no
+  # net (defaults.yml defines chains for them, so they are cleared with []).
   fallbackChains:
-    default: [openai-codex/gpt-5.6-luna:medium]
-    advisor: [openai-codex/gpt-5.6-terra:low]
-    smol: [openai-codex/gpt-5.6-terra:low]
-    task: [openai-codex/gpt-5.6-luna:medium]
-    sonic: [openai-codex/gpt-5.6-terra:low]
-    librarian: [openai-codex/gpt-5.6-luna:medium]
-    designer: [openai-codex/gpt-5.6-luna:high]
-    reviewer: [openai-codex/gpt-5.6-luna:high]
-    plan: [openai-codex/gpt-5.6-luna:high]
-    slow: [openai-codex/gpt-5.6-luna:xhigh]
-    tiny: [openai-codex/gpt-5.6-terra:low]
-    commit: [openai-codex/gpt-5.6-terra:low]
+    default:
+      - openai-codex/gpt-5.6-luna:medium
+      - anthropic/claude-sonnet-5:medium
+    task:
+      - openai-codex/gpt-5.6-terra:low
+      - openai-codex/gpt-5.6-luna:medium
+      - anthropic/claude-haiku-4-5:medium
+    sonic: [openai-codex/gpt-5.4-nano:low]
+    advisor: [openai-codex/gpt-5.4-nano:low]
+    tiny: [openai-codex/gpt-5.4-nano:low]
+    commit: [openai-codex/gpt-5.4-nano:low]
+    plan: []
+    slow: []
+    designer: []
+    reviewer: []
+    librarian: []
 
 advisor:
   enabled: false
@@ -43,9 +58,9 @@ autolearn:
 task:
   agentModelOverrides:
     designer: openai-codex/gpt-5.6-terra:medium
-    librarian: openai-codex/gpt-5.6-terra:low
+    librarian: openai-codex/gpt-5.6-luna:medium
     reviewer: openai-codex/gpt-5.6-terra:medium
-    sonic: openai-codex/gpt-5.6-luna:minimal
-    task: openai-codex/gpt-5.6-terra:low
+    sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+    task: openai-codex/gpt-5.3-codex-spark:xhigh
 
 defaultThinkingLevel: low

--- a/omp/presets/claude-hard.yml
+++ b/omp/presets/claude-hard.yml
@@ -1,0 +1,54 @@
+# ompc — difficult work, Claude-led. ompg's mirror at the same stakes, opposite
+# pool: Fable drives the deliberative roles, Opus is the sibling (and leads
+# review, its strength), Sonnet/Haiku carry the workers, and every substantive
+# chain reaches back to OpenAI. Load this when OpenAI is dark or the Codex meter
+# is empty and the work is still hard. Unlike ompf, nothing here strands on a
+# single model.
+#
+# Background leads on gpt-5.3-codex-spark to drain its separate idle Codex bucket
+# (see omp/PROFILES.md). The bucket is free, so sonic/advisor run at :xhigh
+# (best output, faster drain) while tiny/commit stay :low; each falls back to
+# Haiku when exhausted. The substantive roles stay pool-pure on Claude.
+modelRoles:
+  default: anthropic/claude-fable-5:high
+  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  smol: anthropic/claude-haiku-4-5:low
+  task: anthropic/claude-sonnet-5:medium
+  sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+  librarian: anthropic/claude-sonnet-5:medium
+  designer: anthropic/claude-fable-5:high
+  reviewer: anthropic/claude-opus-4-8:high
+  plan: anthropic/claude-fable-5:high
+  slow: anthropic/claude-fable-5:xhigh
+  tiny: openai-codex/gpt-5.3-codex-spark:low
+  commit: openai-codex/gpt-5.3-codex-spark:low
+
+retry:
+  enabled: true
+  modelFallback: true
+  fallbackRevertPolicy: cooldown-expiry
+  # Claude sibling first, then cross to OpenAI. Sol out-prices Opus per output
+  # token, so the crossing is the expensive step; it only fires when Anthropic
+  # is actually down provider-wide. Background drains Spark, then Haiku.
+  fallbackChains:
+    default: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high]
+    task: [anthropic/claude-haiku-4-5:medium, openai-codex/gpt-5.6-terra:medium]
+    plan: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high]
+    slow: [anthropic/claude-opus-4-8:xhigh, openai-codex/gpt-5.6-sol:xhigh]
+    designer: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high]
+    reviewer: [anthropic/claude-sonnet-5:high, openai-codex/gpt-5.6-sol:high]
+    librarian: [anthropic/claude-haiku-4-5:medium, openai-codex/gpt-5.6-terra:medium]
+    sonic: [anthropic/claude-haiku-4-5:low]
+    advisor: [anthropic/claude-haiku-4-5:low]
+    tiny: [anthropic/claude-haiku-4-5:low]
+    commit: [anthropic/claude-haiku-4-5:low]
+
+task:
+  agentModelOverrides:
+    designer: anthropic/claude-fable-5:high
+    librarian: anthropic/claude-sonnet-5:medium
+    reviewer: anthropic/claude-opus-4-8:high
+    sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+    task: anthropic/claude-sonnet-5:medium
+
+defaultThinkingLevel: medium

--- a/omp/presets/context-1m.yml
+++ b/omp/presets/context-1m.yml
@@ -1,0 +1,54 @@
+# ompx — huge-context work: monorepo audits, log forensics, marathon sessions
+# that outgrow the 372K ceiling of the 5.6 family. Anthropic owns 1M across its
+# line, so Fable/Opus/Sonnet lead; gpt-5.4 is the only OpenAI 1M card, used as
+# the universal cross-net and the librarian lead (putting the read-everything
+# role on the Codex meter splits the burn across pools).
+#
+# Invariant: a fallback never shrinks the window mid-job on a substantive role.
+# Background trivia never sees the big context, so it leads on gpt-5.3-codex-spark
+# (128K) to drain the separate idle Codex bucket (see omp/PROFILES.md). The
+# bucket is free, so sonic/advisor run at :xhigh (best output, faster drain)
+# while tiny/commit stay :low; each falls back to Haiku when exhausted.
+modelRoles:
+  default: anthropic/claude-opus-4-8:medium
+  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  smol: anthropic/claude-haiku-4-5:low
+  task: anthropic/claude-sonnet-5:medium
+  sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+  librarian: openai-codex/gpt-5.4:medium
+  designer: anthropic/claude-opus-4-8:high
+  reviewer: anthropic/claude-opus-4-8:high
+  plan: anthropic/claude-fable-5:high
+  slow: anthropic/claude-fable-5:xhigh
+  tiny: openai-codex/gpt-5.3-codex-spark:low
+  commit: openai-codex/gpt-5.3-codex-spark:low
+
+retry:
+  enabled: true
+  modelFallback: true
+  fallbackRevertPolicy: cooldown-expiry
+  # Every substantive hop is a 1M model: Fable/Opus/Sonnet (Anthropic) or
+  # gpt-5.4 (the sole OpenAI 1M). The window never contracts on a fallback.
+  # Background is exempt (it never sees the big context): Spark, then Haiku.
+  fallbackChains:
+    default: [anthropic/claude-sonnet-5:medium, openai-codex/gpt-5.4:medium]
+    task: [openai-codex/gpt-5.4:medium]
+    plan: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.4:high]
+    slow: [anthropic/claude-opus-4-8:xhigh, openai-codex/gpt-5.4:xhigh]
+    designer: [openai-codex/gpt-5.4:high]
+    reviewer: [openai-codex/gpt-5.4:high]
+    librarian: [anthropic/claude-sonnet-5:medium]
+    sonic: [anthropic/claude-haiku-4-5:low]
+    advisor: [anthropic/claude-haiku-4-5:low]
+    tiny: [anthropic/claude-haiku-4-5:low]
+    commit: [anthropic/claude-haiku-4-5:low]
+
+task:
+  agentModelOverrides:
+    designer: anthropic/claude-opus-4-8:high
+    librarian: openai-codex/gpt-5.4:medium
+    reviewer: anthropic/claude-opus-4-8:high
+    sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+    task: anthropic/claude-sonnet-5:medium
+
+defaultThinkingLevel: medium

--- a/omp/presets/gpt56.yml
+++ b/omp/presets/gpt56.yml
@@ -1,39 +1,52 @@
+# Sol drives the thinking roles; the fast-execution roles (task + background)
+# lead on gpt-5.3-codex-spark to drain its separate idle 5h/7d Codex bucket (see
+# omp/PROFILES.md "Separate rate buckets"). The bucket is free, so the roles
+# that do real work (task/sonic/advisor) run at :xhigh — best output and faster
+# drain — while boilerplate (tiny/commit) stays :low. Each falls back the
+# instant its bucket is exhausted — task to the terra/luna chain, background to
+# nano. The substantive chains still end on Anthropic. smol/scout stay off Spark
+# (exploration context can exceed 128K).
 modelRoles:
   default: openai-codex/gpt-5.6-sol:high
-  advisor: openai-codex/gpt-5.6-terra:low
+  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
   smol: openai-codex/gpt-5.6-luna:low
-  task: openai-codex/gpt-5.6-terra:medium
-  sonic: openai-codex/gpt-5.6-luna:minimal
+  task: openai-codex/gpt-5.3-codex-spark:xhigh
+  sonic: openai-codex/gpt-5.3-codex-spark:xhigh
   librarian: openai-codex/gpt-5.6-terra:medium
   designer: openai-codex/gpt-5.6-sol:high
   reviewer: openai-codex/gpt-5.6-sol:high
   plan: openai-codex/gpt-5.6-sol:high
   slow: openai-codex/gpt-5.6-sol:xhigh
-  tiny: openai-codex/gpt-5.6-luna:minimal
-  commit: openai-codex/gpt-5.6-luna:low
+  tiny: openai-codex/gpt-5.3-codex-spark:low
+  commit: openai-codex/gpt-5.3-codex-spark:low
 
 retry:
   enabled: true
   modelFallback: true
   fallbackRevertPolicy: cooldown-expiry
+  # Substantive roles run GPT -> GPT -> Claude (sibling absorbs a blip, last hop
+  # crosses). task leads on Spark, then the old terra/luna worker chain, then
+  # crosses to Sonnet. Background drains Spark, then nano.
   fallbackChains:
-    default: [openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-luna:high]
-    advisor: [openai-codex/gpt-5.6-luna:medium]
-    smol: [openai-codex/gpt-5.6-terra:low]
-    task: [openai-codex/gpt-5.6-luna:medium, openai-codex/gpt-5.6-sol:medium]
-    sonic: [openai-codex/gpt-5.6-terra:low]
-    librarian: [openai-codex/gpt-5.6-luna:high]
-    designer: [openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-luna:high]
-    reviewer: [openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-luna:high]
-    plan: [openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-luna:high]
-    slow: [openai-codex/gpt-5.6-terra:xhigh, openai-codex/gpt-5.6-luna:xhigh]
-    tiny: [openai-codex/gpt-5.6-terra:low]
-    commit: [openai-codex/gpt-5.6-terra:low]
+    default: [openai-codex/gpt-5.6-terra:high, anthropic/claude-fable-5:high]
+    task:
+      - openai-codex/gpt-5.6-terra:medium
+      - openai-codex/gpt-5.6-luna:medium
+      - anthropic/claude-sonnet-5:medium
+    plan: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high]
+    slow: [openai-codex/gpt-5.6-terra:xhigh, anthropic/claude-opus-4-8:xhigh]
+    designer: [openai-codex/gpt-5.6-terra:high, anthropic/claude-fable-5:high]
+    reviewer: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high]
+    librarian: [openai-codex/gpt-5.6-luna:medium, anthropic/claude-sonnet-5:medium]
+    sonic: [openai-codex/gpt-5.4-nano:low]
+    advisor: [openai-codex/gpt-5.4-nano:low]
+    tiny: [openai-codex/gpt-5.4-nano:low]
+    commit: [openai-codex/gpt-5.4-nano:low]
 
 task:
   agentModelOverrides:
     designer: openai-codex/gpt-5.6-sol:high
     librarian: openai-codex/gpt-5.6-terra:medium
     reviewer: openai-codex/gpt-5.6-sol:high
-    sonic: openai-codex/gpt-5.6-luna:minimal
-    task: openai-codex/gpt-5.6-terra:medium
+    sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+    task: openai-codex/gpt-5.3-codex-spark:xhigh

--- a/omp/presets/sonnet-value.yml
+++ b/omp/presets/sonnet-value.yml
@@ -1,0 +1,55 @@
+# omps — everyday value, Anthropic-led. Sonnet 5 (intro pricing) is the best
+# capability-per-dollar model on hand, so it leads everything but plan/slow,
+# where low-volume Opus earns its leverage. All-Anthropic lead pool: this is
+# also the "Codex credits are spent" everyday driver. Unlike ompb, features
+# stay on — only the models are modest.
+#
+# Background leads on gpt-5.3-codex-spark to drain its separate idle Codex bucket
+# (see omp/PROFILES.md) rather than spend the Claude plan on trivia. The bucket
+# is free, so sonic/advisor run at :xhigh (best output, faster drain) while the
+# tiny/commit one-liners stay :low; each falls back to Haiku when Spark is
+# exhausted. The substantive roles stay pool-pure on Claude.
+modelRoles:
+  default: anthropic/claude-sonnet-5:medium
+  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  smol: anthropic/claude-haiku-4-5:low
+  task: anthropic/claude-sonnet-5:medium
+  sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+  librarian: anthropic/claude-sonnet-5:low
+  designer: anthropic/claude-sonnet-5:high
+  reviewer: anthropic/claude-sonnet-5:high
+  plan: anthropic/claude-opus-4-8:high
+  slow: anthropic/claude-opus-4-8:xhigh
+  tiny: openai-codex/gpt-5.3-codex-spark:low
+  commit: openai-codex/gpt-5.3-codex-spark:low
+
+retry:
+  enabled: true
+  modelFallback: true
+  fallbackRevertPolicy: cooldown-expiry
+  # Sonnet has no price-lateral Anthropic sibling (Opus is 2.5x up, Haiku a
+  # class down), so its chains cross straight to Terra/Luna, its OpenAI price
+  # twins. plan/slow lead on Opus and take a Sonnet sibling before crossing.
+  # Background drains Spark, then falls back to Haiku.
+  fallbackChains:
+    default: [openai-codex/gpt-5.6-terra:medium]
+    task: [openai-codex/gpt-5.6-terra:medium]
+    plan: [anthropic/claude-sonnet-5:high, openai-codex/gpt-5.6-terra:high]
+    slow: [anthropic/claude-sonnet-5:xhigh, openai-codex/gpt-5.6-terra:xhigh]
+    designer: [openai-codex/gpt-5.6-terra:high]
+    reviewer: [openai-codex/gpt-5.6-terra:high]
+    librarian: [openai-codex/gpt-5.6-luna:medium]
+    sonic: [anthropic/claude-haiku-4-5:low]
+    advisor: [anthropic/claude-haiku-4-5:low]
+    tiny: [anthropic/claude-haiku-4-5:low]
+    commit: [anthropic/claude-haiku-4-5:low]
+
+task:
+  agentModelOverrides:
+    designer: anthropic/claude-sonnet-5:high
+    librarian: anthropic/claude-sonnet-5:low
+    reviewer: anthropic/claude-sonnet-5:high
+    sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+    task: anthropic/claude-sonnet-5:medium
+
+defaultThinkingLevel: medium

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -52,6 +52,9 @@ let
     budget = ../../omp/presets/budget.yml;
     fable = ../../omp/presets/fable-primary.yml;
     gpt = ../../omp/presets/gpt56.yml;
+    sonnet = ../../omp/presets/sonnet-value.yml;
+    claude = ../../omp/presets/claude-hard.yml;
+    context = ../../omp/presets/context-1m.yml;
   };
 
   managedDefaultPaths = [
@@ -977,13 +980,82 @@ let
     '';
   };
   ompBudget = mkOmpCommand "ompb" [ presets.budget ];
+  ompSonnet = mkOmpCommand "omps" [ presets.sonnet ];
   ompFable = mkOmpCommand "ompf" [ presets.fable ];
   ompGpt = mkOmpCommand "ompg" [ presets.gpt ];
-  routeSpecs = [
-    "ompb|Cost-conscious routine work|${presets.budget}"
-    "ompg|OpenAI-only difficult work|${presets.gpt}"
-    "ompf|Fable-first work with predictable routing|${presets.fable}"
+  ompClaude = mkOmpCommand "ompc" [ presets.claude ];
+  ompContext = mkOmpCommand "ompx" [ presets.context ];
+
+  # Single source of truth for the launcher palette. The `code` picker lists
+  # every entry; `omph` renders the role -> model routing for the preset-backed
+  # ones (those carrying a `preset`). `omp` and `ompu` are special builders, so
+  # they appear in the picker but not in the routing view.
+  paletteProfiles = [
+    {
+      cmd = "omp";
+      exe = lib.getExe ompDefault;
+      lead = "yours";
+      blurb = "Your mutable daily driver (unmanaged)";
+      detail = "Runs upstream OMP with whatever your writable ~/.omp config selects. No managed defaults, preset, or policy overlay beyond the blocked update.";
+    }
+    {
+      cmd = "ompb";
+      exe = lib.getExe ompBudget;
+      lead = "openai";
+      blurb = "Cost-conscious routine work";
+      detail = "Terra/Luna lead at low thinking; every background role rides gpt-5.4-nano (~5x under Luna). Only the live thread and task worker get a net. Advisor, branch summaries, and autolearn off.";
+      preset = presets.budget;
+    }
+    {
+      cmd = "omps";
+      exe = lib.getExe ompSonnet;
+      lead = "claude";
+      blurb = "Everyday value, Sonnet-led";
+      detail = "Sonnet 5 (intro pricing) leads all but plan/slow, where Opus earns its leverage. Haiku carries background. Chains cross to Terra, Sonnet's price-twin. All-Anthropic pool; features on.";
+      preset = presets.sonnet;
+    }
+    {
+      cmd = "ompg";
+      exe = lib.getExe ompGpt;
+      lead = "openai";
+      blurb = "Difficult work, GPT-led";
+      detail = "Sol leads the deliberative roles; a GPT sibling absorbs a capacity blip, then every substantive chain crosses to Fable/Opus. commit/tiny on nano. All-OpenAI lead pool.";
+      preset = presets.gpt;
+    }
+    {
+      cmd = "ompc";
+      exe = lib.getExe ompClaude;
+      lead = "claude";
+      blurb = "Difficult work, Claude-led";
+      detail = "ompg's mirror. Fable drives, Opus is the sibling (and leads review), Sonnet/Haiku carry workers, every chain reaches back to Sol/Terra. Load this when OpenAI is dark or Codex credits are spent.";
+      preset = presets.claude;
+    }
+    {
+      cmd = "ompf";
+      exe = lib.getExe ompFable;
+      lead = "claude";
+      blurb = "Fable-first, deterministic routing";
+      detail = "Fable for the primary and deliberative roles with retry and server-side fallback OFF. The contract is: give me Fable, predictably, never silently swap. Background on cheap OpenAI rungs.";
+      preset = presets.fable;
+    }
+    {
+      cmd = "ompx";
+      exe = lib.getExe ompContext;
+      lead = "claude";
+      blurb = "Huge-context (1M) work";
+      detail = "For work beyond 372K. Fable/Opus/Sonnet lead (Anthropic owns 1M); gpt-5.4 is the only OpenAI 1M card, used as the cross-net and librarian lead. Haiku (200K) only touches background trivia.";
+      preset = presets.context;
+    }
+    {
+      cmd = "ompu";
+      exe = lib.getExe ompUntrusted;
+      lead = "untrusted";
+      blurb = "Untrusted repositories (isolated)";
+      detail = "Dedicated sanitized state, stripped credentials, restricted tools and approvals for deliberately untrusted repositories. Inherits the managed defaults routing.";
+    }
   ];
+  presetProfiles = builtins.filter (p: p ? preset) paletteProfiles;
+  routeSpecs = map (p: "${p.cmd}|${p.blurb}|${p.preset}") presetProfiles;
   routesHelp =
     runCommand "omp-routes-help-${lib.getVersion omp}"
       {
@@ -1209,6 +1281,272 @@ let
       run_isolated "$raw_omp" "''${managed_args[@]}" "''${forwarded_args[@]}"
     '';
   };
+
+  # `code` — the umbrella picker. Lists the launcher palette, resolves a
+  # selector (number, name, alias, or single suffix letter) and execs the
+  # matching launcher, forwarding every remaining argument. If the first
+  # argument is not a known profile it opens the picker and then forwards all
+  # arguments to the choice, so `code --resume` picks first, then resumes.
+  codeLauncher = writeShellApplication {
+    name = "code";
+    runtimeInputs = [
+      jq
+      coreutils
+    ];
+    text = ''
+      omp_bin=${lib.escapeShellArg (lib.getExe omp)}
+      names=( ${lib.escapeShellArgs (map (p: p.cmd) paletteProfiles)} )
+      leads=( ${lib.escapeShellArgs (map (p: p.lead) paletteProfiles)} )
+      blurbs=( ${lib.escapeShellArgs (map (p: p.blurb) paletteProfiles)} )
+      details=( ${lib.escapeShellArgs (map (p: p.detail) paletteProfiles)} )
+      exes=( ${lib.escapeShellArgs (map (p: p.exe) paletteProfiles)} )
+      count=''${#names[@]}
+      show_usage_panel=1
+
+      lead_tag() {
+        case "$1" in
+          openai) printf '[openai]' ;;
+          claude) printf '[claude]' ;;
+          yours) printf '[yours]' ;;
+          untrusted) printf '[untrusted]' ;;
+          *) printf '[%s]' "$1" ;;
+        esac
+      }
+
+      # Fill the `palette` array with one plain-ASCII line per launcher.
+      palette=()
+      build_palette() {
+        palette=( "OMP launchers" "" )
+        local i
+        for (( i = 0; i < count; i++ )); do
+          palette+=( "$(printf '  %d) %-5s %-11s %s' \
+            "$(( i + 1 ))" "''${names[$i]}" "$(lead_tag "''${leads[$i]}")" "''${blurbs[$i]}")" )
+        done
+      }
+
+      short_window() {
+        case "$1" in
+          "5 hours" | "Claude 5 Hour") printf '5h' ;;
+          "7 days" | "Claude 7 Day") printf '7d' ;;
+          "5 hours (Spark)") printf '5h spark' ;;
+          "7 days (Spark)") printf '7d spark' ;;
+          "Claude 7 Day (Fable)") printf '7d fable' ;;
+          *) printf '%s' "$1" ;;
+        esac
+      }
+
+      bar() {
+        local pct="$1"
+        local fill=$(( (pct * 10 + 50) / 100 ))
+        local k out=""
+        (( fill > 10 )) && fill=10
+        (( fill < 0 )) && fill=0
+        for (( k = 0; k < 10; k++ )); do
+          if (( k < fill )); then out+='█'; else out+='░'; fi
+        done
+        printf '%s' "$out"
+      }
+
+      # Fill the `usagep` array with a compact per-provider quota panel from
+      # `omp usage --json`. Best-effort: on any failure (offline, timeout, not
+      # authed, --no-usage) it is left empty and the picker shows just the list.
+      usagep=()
+      build_usage() {
+        usagep=()
+        (( show_usage_panel == 1 )) || return 0
+        local json rows
+        json="$(timeout 8 "$omp_bin" usage --json 2>/dev/null)" || return 0
+        [[ -n "$json" ]] || return 0
+        rows="$(printf '%s' "$json" | jq -r '
+            ( "HDR\t" + ((now - (.generatedAt / 1000)) | floor | tostring) ),
+            ( .reports[] | .provider as $p | .limits[]
+              | "ROW\t" + $p + "\t" + .label + "\t"
+                + ((.amount.usedFraction * 100) | round | tostring) + "\t"
+                + (.scope.tier // "-") )
+          ' 2>/dev/null)" || return 0
+        [[ -n "$rows" ]] || return 0
+        local kind a b c d last_provider="" pname when note
+        while IFS=$'\t' read -r kind a b c d; do
+          case "$kind" in
+            HDR)
+              if (( a >= 60 )); then when="$(( a / 60 ))m ago"; else when="''${a}s ago"; fi
+              usagep+=( "usage · $when" "" )
+              ;;
+            ROW)
+              case "$a" in
+                openai-codex) pname="Codex" ;;
+                anthropic) pname="Claude" ;;
+                *) pname="$a" ;;
+              esac
+              if [[ "$a" != "$last_provider" ]]; then
+                usagep+=( "$pname" )
+                last_provider="$a"
+              fi
+              note=""
+              (( c >= 80 )) && note=" tight"
+              [[ "$d" == spark && "$c" -eq 0 ]] && note=" free"
+              usagep+=( "$(printf '  %-8s %s %3d%%%s' \
+                "$(short_window "$b")" "$(bar "$c")" "$c" "$note")" )
+              ;;
+          esac
+        done <<< "$rows"
+      }
+
+      term_cols() {
+        local rows cols
+        if read -r rows cols < <(stty size 2>/dev/null) && [[ -n "''${cols:-}" ]]; then
+          printf '%s' "$cols"
+        else
+          printf '%s' "''${COLUMNS:-80}"
+        fi
+      }
+
+      # Print the palette, with the usage panel beside it when the terminal is
+      # wide enough, otherwise stacked above it.
+      render_screen() {
+        build_palette
+        build_usage
+        if (( ''${#usagep[@]} == 0 )); then
+          printf '%s\n' "''${palette[@]}"
+          return 0
+        fi
+        local leftw=0 line
+        for line in "''${palette[@]}"; do (( ''${#line} > leftw )) && leftw=''${#line}; done
+        local cols
+        cols="$(term_cols)"
+        if (( cols < leftw + 24 )); then
+          printf '%s\n' "''${usagep[@]}" "" "''${palette[@]}"
+          return 0
+        fi
+        local n=''${#palette[@]}
+        (( ''${#usagep[@]} > n )) && n=''${#usagep[@]}
+        local i l r
+        for (( i = 0; i < n; i++ )); do
+          l="''${palette[$i]:-}"
+          r="''${usagep[$i]:-}"
+          printf '%-*s  %s\n' "$leftw" "$l" "$r"
+        done
+      }
+
+      show_detail() {
+        local i="$1"
+        printf '\n  %s  %s\n  %s\n\n' \
+          "''${names[$i]}" "$(lead_tag "''${leads[$i]}")" "''${details[$i]}"
+      }
+
+      # Print a 0-based index for a selector, or return non-zero when unmatched.
+      resolve() {
+        local sel="$1" i n
+        case "$sel" in
+          plain | bare) sel=omp ;;
+        esac
+        if [[ "$sel" =~ ^[0-9]+$ ]]; then
+          if (( sel >= 1 && sel <= count )); then
+            printf '%d' "$(( sel - 1 ))"
+            return 0
+          fi
+          return 1
+        fi
+        for (( i = 0; i < count; i++ )); do
+          if [[ "$sel" == "''${names[$i]}" ]]; then
+            printf '%d' "$i"
+            return 0
+          fi
+        done
+        if [[ "$sel" =~ ^[a-z]$ ]]; then
+          for (( i = 0; i < count; i++ )); do
+            n="''${names[$i]}"
+            if [[ "$n" == omp? && "''${n: -1}" == "$sel" ]]; then
+              printf '%d' "$i"
+              return 0
+            fi
+          done
+        fi
+        return 1
+      }
+
+      usage() {
+        printf '%s\n' \
+          'code - pick an OMP launcher and run it' \
+          "" \
+          'usage:' \
+          '  code                    open the picker (with a live usage panel)' \
+          '  code <profile>          run that launcher (name, number, or letter)' \
+          '  code <profile> [args]   run it, forwarding all extra args' \
+          '  code -l, --list         print the palette and exit' \
+          '  code -U, --no-usage     open the picker without fetching usage' \
+          '  code -h, --help         this help' \
+          "" \
+          'Profiles: omp (bare) - ompb omps ompg ompc ompf ompx - ompu (untrusted).' \
+          'A first argument that is not a profile opens the picker, then forwards all' \
+          'args to your choice, so code --resume picks, then resumes.' \
+          'The picker shows a live omp-usage panel beside the options (best-effort);' \
+          'for the full role/model routing of each managed profile, run omph.'
+      }
+
+      case "''${1:-}" in
+        -U | --no-usage)
+          show_usage_panel=0
+          shift
+          ;;
+      esac
+
+      idx=""
+      if (( $# > 0 )); then
+        case "$1" in
+          -h | --help)
+            usage
+            exit 0
+            ;;
+          -l | --list)
+            build_palette
+            printf '%s\n' "''${palette[@]}"
+            exit 0
+            ;;
+        esac
+        if idx="$(resolve "$1")"; then
+          shift
+          exec "''${exes[$idx]}" "$@"
+        fi
+      fi
+
+      if [[ ! -t 0 || ! -t 1 ]]; then
+        build_palette
+        printf 'code: no profile given and no interactive terminal.\n\n' >&2
+        printf '%s\n' "''${palette[@]}" >&2
+        exit 2
+      fi
+
+      render_screen
+      while true; do
+        printf '\npick [1-%d - name - ?N for details - q]: ' "$count"
+        if ! read -r reply; then
+          printf '\n'
+          exit 0
+        fi
+        case "$reply" in
+          q | quit | "")
+            exit 0
+            ;;
+          \?*)
+            sel="''${reply#\?}"
+            sel="''${sel# }"
+            if di="$(resolve "$sel")"; then
+              show_detail "$di"
+            else
+              printf '  no such profile: %s\n\n' "$sel"
+            fi
+            ;;
+          *)
+            if idx="$(resolve "$reply")"; then
+              exec "''${exes[$idx]}" "$@"
+            fi
+            printf '  no such profile: %s\n\n' "$reply"
+            ;;
+        esac
+      done
+    '';
+  };
 in
 runCommand "omp-configured-${lib.getVersion omp}"
   {
@@ -1242,9 +1580,13 @@ runCommand "omp-configured-${lib.getVersion omp}"
     mkdir -p "$out/bin" "$out/share/zsh/site-functions"
     ln -s ${lib.getExe ompDefault} "$out/bin/omp"
     ln -s ${lib.getExe ompBudget} "$out/bin/ompb"
-    ln -s ${lib.getExe ompFable} "$out/bin/ompf"
+    ln -s ${lib.getExe ompSonnet} "$out/bin/omps"
     ln -s ${lib.getExe ompGpt} "$out/bin/ompg"
+    ln -s ${lib.getExe ompClaude} "$out/bin/ompc"
+    ln -s ${lib.getExe ompFable} "$out/bin/ompf"
+    ln -s ${lib.getExe ompContext} "$out/bin/ompx"
     ln -s ${lib.getExe ompHelp} "$out/bin/omph"
     ln -s ${lib.getExe ompUntrusted} "$out/bin/ompu"
+    ln -s ${lib.getExe codeLauncher} "$out/bin/code"
     ln -s ${omp}/share/zsh/site-functions/_omp "$out/share/zsh/site-functions/_omp"
   ''

--- a/pkgs/omp-configured/render-omp-routes.sh
+++ b/pkgs/omp-configured/render-omp-routes.sh
@@ -133,5 +133,6 @@ printf '%s' "$dim"
 printf 'scout is deliberately unpinned: it rides the smol route via its upstream frontmatter.\n'
 printf 'omp runs your own mutable config, unmanaged; ompu is the untrusted launcher\n'
 printf '(defaults routing, isolated state, restricted tools).\n'
+printf "pick a launcher interactively with 'code'; design rationale in omp/PROFILES.md.\n"
 printf 'source: omp/defaults.yml + omp/presets/*.yml — edit in the dotfiles repo, then zconf.\n'
 printf '%s' "$reset"


### PR DESCRIPTION
## What

Restructures the managed OMP launchers into a **palette** and builds tooling around it. Design was iterated in a proposal artifact and this lands it.

### Routing
- **Cleaned base** (`omp/defaults.yml`): one fallback rule — try a same-provider sibling first, cross to the other provider on the last hop. Trivial roles carry no premium chain; `commit`/`tiny` drop to `gpt-5.4-nano`.
- **Three new presets**: `omps` (Sonnet-led everyday value), `ompc` (Fable-led hard work — `ompg`'s mirror), `ompx` (huge-context; `gpt-5.4` is the only 1M cross-net). `ompg` now crosses to Claude; `ompf` and the base map are otherwise unchanged. Every model id and thinking level was validated against the live `omp models` registry.

### `code` launcher
- Umbrella picker over the whole palette — name/number/letter selectors, and arg forwarding so `code --resume` picks a profile then resumes. Built from a single `paletteProfiles` list that also feeds `omph`, so they can't drift.
- The interactive picker renders a live **`omp usage` panel** beside the options (best-effort, timeout-bounded, `--no-usage` to skip; `--list` stays panel-free), marking each provider's quota windows `free` when idle and `tight` at ≥80%.

### Spark bucket draining
`gpt-5.3-codex-spark` draws from a **separate, normally-idle** 5h/7d Codex quota. The fast-execution roles now lead on it with a transparent fallback: `task` + `sonic`/`advisor`/`tiny`/`commit` in the OpenAI-led profiles, background in the Anthropic-led ones (`task` stays Claude-pure). Real-work roles run at `:xhigh` (drain harder, better output); `tiny`/`commit` stay `:low`. Kept off `smol`/scout, the thinking roles, and `ompf`.

### Also
- **Removes VS Code** (unfree allowlist, darwin package, README) to free the `code` command name.
- New **`omp/PROFILES.md`** rationale doc; updates to `docs/agent-tools.md`, `docs/agent-security.md`, README, and the `checks/agent-tools.nix` assertions.

## Verified
`nix build .#omp-configured` green; `omp-stack`, `omp-wrapper`, `home-evaluation`, `package-ownership` checks pass; the `code` picker and usage panel exercised over a PTY.

## Watch after merge (not code issues — empirical, one-line reverts)
- **Spark fallback on exhaustion** couldn't be tested from here (can't drain a real bucket). If OMP doesn't fall back on a Spark-bucket 429, those roles fail loudly (immediately visible) rather than degrade.
- **`sonic` at `:xhigh`** may feel sluggish if it's on the interactive path; drop to `:high`/`:medium` if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
