### PR TITLE
feat(omp): revamp the code picker and complete the launcher matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ atyrode doctor system # Audit system-owned operational prerequisites
 code          # fzf picker: arrow-key select over the grouped launcher palette
 omp           # Mutable user-owned OMP; unmanaged except the blocked update
 ompz          # Fast, mixed — fastest tiers both providers, low thinking
-ompb          # Cost-conscious routine work (OpenAI-led; nano background)
+ompb          # Cost-conscious routine work (OpenAI-led; Spark/Luna background)
 omps          # Everyday value (Anthropic-led; Sonnet leads, Haiku background)
 ompg          # Difficult work, GPT-led (Sol drives, Claude is the net)
 ompc          # Difficult work, Claude-led (Fable drives, GPT is the net)

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ atyrode doctor system # Audit system-owned operational prerequisites
 
 ### Agent Tools
 ```bash
-code          # Umbrella picker: list the launchers, pick one, forward your args
+code          # fzf picker: arrow-key select over the grouped launcher palette
 omp           # Mutable user-owned OMP; unmanaged except the blocked update
+ompz          # Fast, mixed — fastest tiers both providers, low thinking
 ompb          # Cost-conscious routine work (OpenAI-led; nano background)
 omps          # Everyday value (Anthropic-led; Sonnet leads, Haiku background)
 ompg          # Difficult work, GPT-led (Sol drives, Claude is the net)

--- a/README.md
+++ b/README.md
@@ -90,13 +90,19 @@ atyrode doctor system # Audit system-owned operational prerequisites
 ```bash
 code          # fzf picker: arrow-key select over the grouped launcher palette
 omp           # Mutable user-owned OMP; unmanaged except the blocked update
-ompz          # Fast, mixed — fastest tiers both providers, low thinking
-ompb          # Cost-conscious routine work (OpenAI-led; Spark/Luna background)
-omps          # Everyday value (Anthropic-led; Sonnet leads, Haiku background)
-ompg          # Difficult work, GPT-led (Sol drives, Claude is the net)
-ompc          # Difficult work, Claude-led (Fable drives, GPT is the net)
+ompz          # Mixed · speed — fastest tiers both providers, low thinking
+ompn          # Mixed · regular — balanced daily driver, both pools
+ompm          # Mixed · smart — hardest work, best model per task
+ompl          # GPT · speed — fast Codex (Luna; task drains Spark)
+ompb          # GPT · regular — routine Codex work (Terra, off premium tiers)
+ompg          # GPT · smart — difficult work, GPT-led (Sol drives, Claude net)
+ompo          # GPT-only — never crosses to Anthropic (drain Codex)
+ompk          # Claude · speed — fast Claude (Haiku)
+omps          # Claude · regular — everyday value (Sonnet leads)
+ompc          # Claude · smart — difficult work, Claude-led (Fable drives)
+ompe          # Claude-only — never crosses to OpenAI (drain the Claude plan)
 ompf          # Fable-first profile with fallback disabled
-ompx          # Huge-context (1M) work; GPT-5.4 is the 1M cross-net
+ompx          # Huge-context (1M) work; Anthropic's 1M line, no cross-net
 omph          # Show the managed routing: roles, models, fallbacks per profile
 ompu          # Restricted launcher for deliberately untrusted repositories
 herdr         # Persistent terminal workspace manager

--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -122,20 +122,21 @@ in
         test "$(yq eval '.tools.approvalMode' ${yoloConfig})" = "null"
         test "$(yq eval '.retry.modelFallback' ${fablePreset})" = "false"
 
-        for command in omp ompb ompc ompf ompg omps ompu ompx; do
+        for command in omp ompb ompc ompf ompg omps ompu ompx ompz; do
           command_version="$(${pkgs.omp-configured}/bin/"$command" --version)"
           test "''${command_version##*/}" = "${lib.getVersion pkgs.omp}"
         done
         test ! -e ${pkgs.omp-configured}/bin/pi
         test "$(
           find ${pkgs.omp-configured}/bin -mindepth 1 -maxdepth 1 -printf '%f\n' | sort | paste -sd, -
-        )" = "code,omp,ompb,ompc,ompf,ompg,omph,omps,ompu,ompx"
+        )" = "code,omp,ompb,ompc,ompf,ompg,omph,omps,ompu,ompx,ompz"
         test "$(${pkgs.herdr-configured}/bin/herdr --version)" = "herdr 0.7.3"
 
         ${pkgs.omp-configured}/bin/omph > "$TMPDIR/omph.txt"
         ! grep -q $'\e' "$TMPDIR/omph.txt"
         grep -q "OMP managed routing — oh-my-pi ${lib.getVersion pkgs.omp}" "$TMPDIR/omph.txt"
         grep -q 'bundled agents: designer librarian reviewer scout sonic task' "$TMPDIR/omph.txt"
+        grep -q '^ompz  Fast, mixed, latency-first$' "$TMPDIR/omph.txt"
         grep -q '^ompb  Cost-conscious routine work$' "$TMPDIR/omph.txt"
         grep -q '^omps  Everyday value, Sonnet-led$' "$TMPDIR/omph.txt"
         grep -q '^ompg  Difficult work, GPT-led$' "$TMPDIR/omph.txt"
@@ -152,7 +153,9 @@ in
         # `code` umbrella picker: lists the palette non-interactively and
         # resolves selectors without opening the interactive prompt.
         ${pkgs.omp-configured}/bin/code --list > "$TMPDIR/code.txt"
-        grep -q '1) omp' "$TMPDIR/code.txt"
+        grep -q 'ompz' "$TMPDIR/code.txt"
+        grep -q '^  mixed$' "$TMPDIR/code.txt"
+        grep -q '^  specialists$' "$TMPDIR/code.txt"
         grep -q 'omps' "$TMPDIR/code.txt"
         grep -q 'ompc' "$TMPDIR/code.txt"
         grep -q 'ompx' "$TMPDIR/code.txt"
@@ -643,7 +646,7 @@ in
             # Model-preset launchers are routing overlays only: all of them
             # share the default profile and the normal persisted state root,
             # so switching launchers never requires re-authentication.
-            for launcher in ompb omps ompg ompc ompf ompx; do
+            for launcher in ompz ompb omps ompg ompc ompf ompx; do
               ${configuredStub}/bin/"$launcher" config managed --json \
                 > "$TMPDIR/launcher-state.json"
               jq -e '.profile == "default"' "$TMPDIR/launcher-state.json" >/dev/null
@@ -822,6 +825,7 @@ in
             # Plain omp is unmanaged and has no Nix-declared default model;
             # the managed defaults file is asserted directly with yq above.
             declare -A expected_default_models=(
+              [ompz]='openai-codex/gpt-5.6-luna:low'
               [ompb]='openai-codex/gpt-5.6-terra:low'
               [omps]='anthropic/claude-sonnet-5:medium'
               [ompg]='openai-codex/gpt-5.6-sol:high'
@@ -832,7 +836,7 @@ in
             policy_home="$TMPDIR/policy-home"
             policy_project="$TMPDIR/policy-project"
             mkdir -p "$policy_home" "$policy_project"
-            for command in ompb omps ompg ompc ompf ompx; do
+            for command in ompz ompb omps ompg ompc ompf ompx; do
               HOME="$policy_home" XDG_CONFIG_HOME="$policy_home/.config" \
                 ${configuredStub}/bin/"$command" --cwd "$policy_project" \
                   config managed --json > "$TMPDIR/$command-policy.json"
@@ -847,7 +851,7 @@ in
               and (.ownership.presets | index("providers.anthropic.serverSideFallback")) != null
             ' "$TMPDIR/ompf-policy.json" >/dev/null
 
-            for command in omp ompb omps ompg ompc ompf ompx; do
+            for command in omp ompb omps ompg ompc ompf ompx ompz; do
               set +e
               ${configuredStub}/bin/"$command" update \
                 > "$TMPDIR/update.out" 2> "$TMPDIR/update.err"

--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -155,7 +155,7 @@ in
         ${pkgs.omp-configured}/bin/code --list > "$TMPDIR/code.txt"
         grep -q 'ompz' "$TMPDIR/code.txt"
         grep -q '^  mixed$' "$TMPDIR/code.txt"
-        grep -q '^  specialists$' "$TMPDIR/code.txt"
+        grep -q '^  special$' "$TMPDIR/code.txt"
         grep -q 'omps' "$TMPDIR/code.txt"
         grep -q 'ompc' "$TMPDIR/code.txt"
         grep -q 'ompx' "$TMPDIR/code.txt"

--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -145,7 +145,7 @@ in
         grep -q '^ompx  Huge-context (1M) work$' "$TMPDIR/omph.txt"
         grep -q 'gpt-5.6-sol:high' "$TMPDIR/omph.txt"
         grep -q 'claude-fable-5:high' "$TMPDIR/omph.txt"
-        grep -q 'gpt-5.4-nano:low' "$TMPDIR/omph.txt"
+        grep -q 'gpt-5.6-luna:low' "$TMPDIR/omph.txt"
         grep -q 'gpt-5.3-codex-spark:xhigh' "$TMPDIR/omph.txt"
         grep -q 'claude-haiku-4-5:low' "$TMPDIR/omph.txt"
         grep -q 'scout is deliberately unpinned' "$TMPDIR/omph.txt"

--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -122,27 +122,35 @@ in
         test "$(yq eval '.tools.approvalMode' ${yoloConfig})" = "null"
         test "$(yq eval '.retry.modelFallback' ${fablePreset})" = "false"
 
-        for command in omp ompb ompc ompf ompg omps ompu ompx ompz; do
+        for command in omp ompb ompc ompe ompf ompg ompk ompl ompm ompn ompo omps ompu ompx ompz; do
           command_version="$(${pkgs.omp-configured}/bin/"$command" --version)"
           test "''${command_version##*/}" = "${lib.getVersion pkgs.omp}"
         done
         test ! -e ${pkgs.omp-configured}/bin/pi
         test "$(
           find ${pkgs.omp-configured}/bin -mindepth 1 -maxdepth 1 -printf '%f\n' | sort | paste -sd, -
-        )" = "code,omp,ompb,ompc,ompf,ompg,omph,omps,ompu,ompx,ompz"
+        )" = "code,omp,ompb,ompc,ompe,ompf,ompg,omph,ompk,ompl,ompm,ompn,ompo,omps,ompu,ompx,ompz"
         test "$(${pkgs.herdr-configured}/bin/herdr --version)" = "herdr 0.7.3"
 
         ${pkgs.omp-configured}/bin/omph > "$TMPDIR/omph.txt"
         ! grep -q $'\e' "$TMPDIR/omph.txt"
         grep -q "OMP managed routing — oh-my-pi ${lib.getVersion pkgs.omp}" "$TMPDIR/omph.txt"
         grep -q 'bundled agents: designer librarian reviewer scout sonic task' "$TMPDIR/omph.txt"
-        grep -q '^ompz  Fast, mixed, latency-first$' "$TMPDIR/omph.txt"
-        grep -q '^ompb  Cost-conscious routine work$' "$TMPDIR/omph.txt"
-        grep -q '^omps  Everyday value, Sonnet-led$' "$TMPDIR/omph.txt"
-        grep -q '^ompg  Difficult work, GPT-led$' "$TMPDIR/omph.txt"
-        grep -q '^ompc  Difficult work, Claude-led$' "$TMPDIR/omph.txt"
-        grep -q '^ompf  Fable-first, deterministic routing$' "$TMPDIR/omph.txt"
-        grep -q '^ompx  Huge-context (1M) work$' "$TMPDIR/omph.txt"
+        grep -q '^ompz  Luna + Haiku, low thinking$' "$TMPDIR/omph.txt"
+        grep -q '^ompb  Terra, off the premium tiers$' "$TMPDIR/omph.txt"
+        grep -q '^omps  Sonnet value, Opus for depth$' "$TMPDIR/omph.txt"
+        grep -q '^ompg  Sol drives, Claude is the net$' "$TMPDIR/omph.txt"
+        grep -q '^ompc  Fable drives, Opus reviews$' "$TMPDIR/omph.txt"
+        grep -q '^ompf  Fable, deterministic (no net)$' "$TMPDIR/omph.txt"
+        grep -q '^ompx  Beyond 372K — Anthropic 1M$' "$TMPDIR/omph.txt"
+        grep -q '^ompl  Luna; task drains Spark$' "$TMPDIR/omph.txt"
+        grep -q '^ompk  Haiku, fast and cheap$' "$TMPDIR/omph.txt"
+        grep -q '^ompn  Claude judges, GPT executes$' "$TMPDIR/omph.txt"
+        grep -q '^ompm  Best model per task$' "$TMPDIR/omph.txt"
+        grep -q '^ompo  Codex only, never crosses$' "$TMPDIR/omph.txt"
+        grep -q '^ompe  Claude only, never crosses$' "$TMPDIR/omph.txt"
+        # ompu inherits the managed defaults routing, so it is rendered like a preset
+        grep -q '^ompu  Sandboxed, restricted tools$' "$TMPDIR/omph.txt"
         grep -q 'gpt-5.6-sol:high' "$TMPDIR/omph.txt"
         grep -q 'claude-fable-5:high' "$TMPDIR/omph.txt"
         grep -q 'gpt-5.6-luna:low' "$TMPDIR/omph.txt"

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -58,13 +58,19 @@ reasoning — lives in [`omp/PROFILES.md`](../omp/PROFILES.md).
 | Command | Intended use | Primary route |
 | --- | --- | --- |
 | `omp` | Mutable daily driver; user-owned configuration | Whatever the operator's own OMP config selects; unmanaged apart from the blocked `update` |
-| `ompz` | Fast, mixed — latency over depth | Luna/Spark + Sonnet/Haiku at low thinking, light single-hop fallbacks; nothing reaches for Sol/Fable/Opus |
-| `ompb` | Cost-conscious routine work (OpenAI-led) | GPT-5.6 Terra/Luna at low thinking; `task`+background lead on GPT-5.3-codex-spark (free bucket) → Luna |
-| `omps` | Everyday value (Anthropic-led) | Sonnet 5 leads; Opus for plan/slow; background on GPT-5.3-codex-spark (free bucket) → Haiku |
-| `ompg` | Difficult work, GPT-led | GPT-5.6 Sol drives; a GPT sibling absorbs a blip, then Claude is the net |
-| `ompc` | Difficult work, Claude-led | Fable drives; Opus absorbs a blip, then GPT is the net (ompg's mirror) |
+| `ompz` | Mixed · speed — latency over depth | Luna/Spark + Sonnet/Haiku at low thinking, light single-hop crosses; nothing reaches for Sol/Fable/Opus |
+| `ompn` | Mixed · regular — balanced daily driver | Claude leads judgment, GPT leads execution, at medium thinking; full same-bucket-then-cross redundancy |
+| `ompm` | Mixed · smart — hardest work, best per task | Sol on GPT-strength roles, Fable/Opus on Claude-strength ones (design/plan/review); full redundancy |
+| `ompl` | GPT · speed — fast Codex | Luna at low thinking, `task` drains Spark, single fast hops to Haiku |
+| `ompb` | GPT · regular — routine Codex work | Terra at medium thinking, kept off premium tiers (Luna/Terra + Haiku/Sonnet, never Sol/Opus); background drains Spark |
+| `ompg` | GPT · smart — difficult work, GPT-led | Sol drives; a GPT sibling absorbs a blip, then Claude is the net |
+| `ompo` | GPT-only — never crosses to Anthropic | Sol → Terra → Luna internal redundancy; background drains Spark; keeps every token on Codex |
+| `ompk` | Claude · speed — fast Claude | Haiku at low thinking, background drains Spark, single fast hops to Luna |
+| `omps` | Claude · regular — everyday value | Sonnet 5 leads; Opus for plan/slow; background on Spark → Haiku |
+| `ompc` | Claude · smart — difficult work, Claude-led | Fable drives; Opus absorbs a blip, then GPT is the net (ompg's mirror) |
+| `ompe` | Claude-only — never crosses to OpenAI | Opus → Sonnet → Haiku internal redundancy, no Spark/Fable; keeps every token on the Claude plan |
 | `ompf` | Fable-first work with predictable routing | Fable for primary/deliberative roles, with automatic fallback disabled |
-| `ompx` | Huge-context (1M) work | Fable/Opus/Sonnet lead; GPT-5.4 is the 1M cross-net; every substantive hop holds 1M |
+| `ompx` | Huge-context (1M) work | Anthropic's 1M line (Fable/Opus/Sonnet) leads and is the only redundancy; no OpenAI 1M on a ChatGPT account, so no cross-net |
 | `ompu` | Deliberately untrusted repositories | Dedicated state, sanitized credentials, restricted integrations, and isolated writing tasks |
 
 Each profile commits to one subscription pool for its lead and substantive

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -14,9 +14,9 @@ Nix owns:
 - the curated plain-omp seed and its drift-aware activation step;
 - the pinned bundled agents, global generic skills, and managed-settings guard
   extension;
-- the `omp`, `ompb`, `omps`, `ompg`, `ompc`, `ompf`, `ompx`, and restricted
-  `ompu` launchers, plus the `omph` routing view and the `code` launcher
-  picker; and
+- the `omp`, `ompz`, `ompb`, `omps`, `ompg`, `ompc`, `ompf`, `ompx`, and
+  restricted `ompu` launchers, plus the `omph` routing view and the `code`
+  launcher picker; and
 - Claude Code's user-scope operator policy: the deployed `~/.claude/CLAUDE.md`
   instructions and `~/.claude/settings.json` permission rules; and
 - mise itself, with no globally declared mise tools.
@@ -29,7 +29,7 @@ This subsystem deliberately owns neither a `pi` executable nor a `.pi`
 mutable-state namespace. The bounded Pi experiment in #29 may therefore install
 alongside OMP without an executable collision, shared authentication/session
 state, or any parity requirement. The package check asserts the exact managed
-OMP binary set — eight launchers plus the `omph` routing view and the `code`
+OMP binary set — nine launchers plus the `omph` routing view and the `code`
 picker — and verifies that an OMP clean-home startup does not create `.pi`
 state. Security boundaries and the untrusted-project launcher are
 documented in [Agent security](agent-security.md).
@@ -48,15 +48,17 @@ rewriting the Bun executable with `patchelf`.
 
 ## OMP launchers
 
-The launchers form a palette: two everyday profiles per subscription pool
-(cheap and hard), two specialists, and a base layer. `code` is an umbrella
-picker over all of them (see below). The design rationale — the model catalog,
-the fallback principles, and the per-profile reasoning — lives in
-[`omp/PROFILES.md`](../omp/PROFILES.md).
+The launchers form a palette: a fast mixed profile, two everyday profiles per
+subscription pool (cheap and hard), specialists, and a base layer. The `code`
+picker (see below) groups them softly — mixed, then gpt-led, then claude-led,
+then specialists — sorted faster → smarter within each group. The design
+rationale — the model catalog, the fallback principles, and the per-profile
+reasoning — lives in [`omp/PROFILES.md`](../omp/PROFILES.md).
 
 | Command | Intended use | Primary route |
 | --- | --- | --- |
 | `omp` | Mutable daily driver; user-owned configuration | Whatever the operator's own OMP config selects; unmanaged apart from the blocked `update` |
+| `ompz` | Fast, mixed — latency over depth | Luna/nano/Spark + Sonnet/Haiku at low thinking, light single-hop fallbacks; nothing reaches for Sol/Fable/Opus |
 | `ompb` | Cost-conscious routine work (OpenAI-led) | GPT-5.6 Terra/Luna at low thinking; `task`+background lead on GPT-5.3-codex-spark (free bucket) → nano |
 | `omps` | Everyday value (Anthropic-led) | Sonnet 5 leads; Opus for plan/slow; background on GPT-5.3-codex-spark (free bucket) → Haiku |
 | `ompg` | Difficult work, GPT-led | GPT-5.6 Sol drives; a GPT sibling absorbs a blip, then Claude is the net |
@@ -117,20 +119,22 @@ package build time from the same defaults and preset files, so it always
 matches the deployed configuration. Provider is encoded as a colorblind-safe
 blue/orange pair; piped or `NO_COLOR` output falls back to plain text.
 
-`code` is an umbrella picker over the whole palette. With no arguments it lists
-the launchers with one-line descriptions and prompts for a choice; `?N` shows a
-longer description for entry `N`. The interactive picker also renders a compact
-`omp usage` panel beside the palette (best-effort and bounded, so it never
-blocks; `code --no-usage` skips it), marking each provider's quota windows
-`free` when idle and `tight` at ≥80% — a glance at which meter has room before
-you pick. A selector can also be passed directly by
-name, menu number, or single suffix letter (`code ompg`, `code 4`, `code g`),
-with any remaining arguments forwarded to the chosen launcher. If the first
-argument is not a known profile, the picker opens and then forwards every
-argument to the choice, so `code --resume` picks a profile first, then resumes.
-`code --list` and `code --help` are non-interactive. It is a thin wrapper: the
-chosen launcher receives the arguments unchanged and applies its own managed
-overlays.
+`code` is an umbrella picker over the whole palette. With no arguments it opens
+an `fzf` picker: arrow keys and Enter to select (type to filter), a truecolor
+list with Nerd Font provider glyphs and soft group labels (mixed / gpt-led /
+claude-led / specialists), the `omp usage` panel in a bottom footer (per-window
+`N% used` with green→red gradient bars, `free` on an idle bucket and `tight` at
+≥80%), and a preview pane showing the highlighted profile's detail and its live
+role → model routing — with model names coloured by provider (blue/orange) and
+brightness scaled by thinking level. It falls back to a typed menu when `fzf` is
+unavailable or `CODE_NO_FZF=1`, and `code --no-usage` skips the usage fetch. A
+selector can also be passed directly by name, menu number, or single suffix
+letter (`code ompg`, `code 4`, `code z`), with any remaining arguments forwarded
+to the chosen launcher. If the first argument is not a known profile, the picker
+opens and then forwards every argument to the choice, so `code --resume` picks a
+profile first, then resumes. `code --list` and `code --help` are
+non-interactive. It is a thin wrapper: the chosen launcher receives the
+arguments unchanged and applies its own managed overlays.
 
 `omp/defaults.yml` is the authoritative role map and fallback-chain definition;
 the preset files intentionally change parts of this table for the budget

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -58,8 +58,8 @@ reasoning — lives in [`omp/PROFILES.md`](../omp/PROFILES.md).
 | Command | Intended use | Primary route |
 | --- | --- | --- |
 | `omp` | Mutable daily driver; user-owned configuration | Whatever the operator's own OMP config selects; unmanaged apart from the blocked `update` |
-| `ompz` | Fast, mixed — latency over depth | Luna/nano/Spark + Sonnet/Haiku at low thinking, light single-hop fallbacks; nothing reaches for Sol/Fable/Opus |
-| `ompb` | Cost-conscious routine work (OpenAI-led) | GPT-5.6 Terra/Luna at low thinking; `task`+background lead on GPT-5.3-codex-spark (free bucket) → nano |
+| `ompz` | Fast, mixed — latency over depth | Luna/Spark + Sonnet/Haiku at low thinking, light single-hop fallbacks; nothing reaches for Sol/Fable/Opus |
+| `ompb` | Cost-conscious routine work (OpenAI-led) | GPT-5.6 Terra/Luna at low thinking; `task`+background lead on GPT-5.3-codex-spark (free bucket) → Luna |
 | `omps` | Everyday value (Anthropic-led) | Sonnet 5 leads; Opus for plan/slow; background on GPT-5.3-codex-spark (free bucket) → Haiku |
 | `ompg` | Difficult work, GPT-led | GPT-5.6 Sol drives; a GPT sibling absorbs a blip, then Claude is the net |
 | `ompc` | Difficult work, Claude-led | Fable drives; Opus absorbs a blip, then GPT is the net (ompg's mirror) |
@@ -73,7 +73,7 @@ the Claude plan); the fallback net is the other pool. The exception is the
 fast-execution and background roles, which lead on `gpt-5.3-codex-spark` — its
 5h/7d Codex quota is a separate, normally-idle bucket, so draining it costs
 nothing on the main meters, and each role falls back to the per-pool cheap rung
-(nano or Haiku) the moment that bucket is exhausted. See
+(Luna or Haiku) the moment that bucket is exhausted. See
 [`omp/PROFILES.md`](../omp/PROFILES.md) for the full rationale.
 
 Plain `omp` executes upstream OMP directly: no extension, defaults, preset, or
@@ -85,7 +85,7 @@ from `omp/plain-seed.yml` into the writable configuration with local edits
 always winning; see [Seeded plain-omp defaults](#seeded-plain-omp-defaults).
 
 The managed defaults use Sol for interactive daily work, keep cheap, fast roles
-on Luna, drop the text-trivial `commit`/`tiny` roles to GPT-5.4-nano, and
+on Luna, keep the text-trivial `commit`/`tiny` roles on GPT-5.6-luna, and
 reserve Fable/Opus for planning and the deliberative fallback tier. Fallback
 chains follow one rule: try a same-provider sibling first (it rules out a single
 model at capacity for free), then make the last, load-bearing hop cross to the
@@ -101,7 +101,7 @@ The balanced routing rationale is:
 | `task` | General implementation on Terra | Medium | Mid-cost worker; a Luna sibling first, then Sonnet crosses providers |
 | `librarian` | Repository and documentation research on Terra | Medium | A Luna sibling keeps the read-heavy role cheap, then Sonnet crosses for depth |
 | `advisor`, `smol`, `sonic` | Fast review, lookup, and naming on Luna | Minimal–low | Cheapest recurring work; no fallback chain — a blip is harmless and crossing them is wasteful |
-| `tiny`, `commit` | Labels and commit messages on GPT-5.4-nano | Low | The cheapest rung for text-trivial, always-on work; no fallback chain |
+| `tiny`, `commit` | Labels and commit messages on GPT-5.6-luna | Low | The cheapest supported Codex rung for text-trivial, always-on work; no fallback chain |
 | `designer` | Product and interface design on Sonnet | Medium | Crosses straight to Terra, Sonnet's price-twin (Sonnet has no lateral Anthropic sibling) |
 | `reviewer` | High-scrutiny review on Sonnet | High | Higher-cost quality gate; escalates to Opus, then Sol, if the primary is unavailable |
 | `plan` | Architecture and planning on Fable | High | Premium reasoning is intentional for decisions with broad downstream impact; Opus then Sol are the escape routes |

--- a/modules/home/agent-tools.nix
+++ b/modules/home/agent-tools.nix
@@ -17,6 +17,7 @@ let
     sonnet = ../../omp/presets/sonnet-value.yml;
     claude = ../../omp/presets/claude-hard.yml;
     context = ../../omp/presets/context-1m.yml;
+    fast = ../../omp/presets/fast-mixed.yml;
   };
 
   herdrCompletions = pkgs.runCommand "herdr-completions-${lib.getVersion cfg.herdrPackage}" { } ''
@@ -71,6 +72,7 @@ in
       "omp/presets/sonnet-value.yml".source = presets.sonnet;
       "omp/presets/claude-hard.yml".source = presets.claude;
       "omp/presets/context-1m.yml".source = presets.context;
+      "omp/presets/fast-mixed.yml".source = presets.fast;
     };
 
     home.file = {

--- a/modules/home/agent-tools.nix
+++ b/modules/home/agent-tools.nix
@@ -18,6 +18,12 @@ let
     claude = ../../omp/presets/claude-hard.yml;
     context = ../../omp/presets/context-1m.yml;
     fast = ../../omp/presets/fast-mixed.yml;
+    gptSpeed = ../../omp/presets/gpt-speed.yml;
+    claudeSpeed = ../../omp/presets/claude-speed.yml;
+    mixedRegular = ../../omp/presets/mixed-regular.yml;
+    mixedSmart = ../../omp/presets/mixed-smart.yml;
+    gptOnly = ../../omp/presets/gpt-only.yml;
+    claudeOnly = ../../omp/presets/claude-only.yml;
   };
 
   herdrCompletions = pkgs.runCommand "herdr-completions-${lib.getVersion cfg.herdrPackage}" { } ''
@@ -73,6 +79,12 @@ in
       "omp/presets/claude-hard.yml".source = presets.claude;
       "omp/presets/context-1m.yml".source = presets.context;
       "omp/presets/fast-mixed.yml".source = presets.fast;
+      "omp/presets/gpt-speed.yml".source = presets.gptSpeed;
+      "omp/presets/claude-speed.yml".source = presets.claudeSpeed;
+      "omp/presets/mixed-regular.yml".source = presets.mixedRegular;
+      "omp/presets/mixed-smart.yml".source = presets.mixedSmart;
+      "omp/presets/gpt-only.yml".source = presets.gptOnly;
+      "omp/presets/claude-only.yml".source = presets.claudeOnly;
     };
 
     home.file = {

--- a/omp/PROFILES.md
+++ b/omp/PROFILES.md
@@ -23,9 +23,8 @@ deliver less per dollar than the 5.6 tiers, so nothing routes to them today.
 | --- | --- | --- | --- | --- |
 | `gpt-5.6-sol` | $5 / $30 | 372K | low→max | Flagship. Leads `ompg` and the base default. Out-prices Opus 4.8 per output token. |
 | `gpt-5.6-terra` | $2.50 / $15 | 372K | low→max | Balanced workhorse. Leads `ompb` and the task/librarian roles. Sonnet's price-twin. |
-| `gpt-5.6-luna` | $1 / $6 | 372K | low→max | Fast, high-volume. Sibling hop and cheap worker across the OpenAI-led maps. |
-| `gpt-5.4` | $2.50 / $15 | **1M** | low→xhigh | The only OpenAI 1M card. `ompx`'s cross-net and librarian lead. |
-| `gpt-5.4-nano` | **$0.20 / $1.25** | 272K | low→xhigh | Cheapest model on hand (~5× under Luna). Background trivia (`commit`/`tiny`, all of `ompb`'s background). No `minimal` level — floor is `low`. |
+| `gpt-5.6-luna` | $1 / $6 | 372K | low→max | Fast, high-volume — the cheapest **supported** Codex tier. Sibling hops, cheap workers, and non-Spark background across the maps. |
+| `gpt-5.3-codex-spark` | $1.75 / $14 | 128K | low→xhigh | Coding-tuned and fast. Draws from a **separate, usually-idle** 5h/7d Codex bucket, so the fast-execution roles lead on it (see [Separate rate buckets](#separate-rate-buckets--an-underused-lever)). |
 
 ### Anthropic (provider `anthropic`)
 
@@ -39,7 +38,11 @@ deliver less per dollar than the 5.6 tiers, so nothing routes to them today.
 † Sonnet 5 is at introductory pricing through **2026-08-31**, then $3 / $15 —
 dearer than Terra. See [Revisit triggers](#revisit-triggers).
 
-Not routed: `gpt-5.4-mini` (squeezed between nano and Luna with no niche),
+**Unusable on a ChatGPT/Codex account:** the whole `gpt-5.4` family (`gpt-5.4`,
+`gpt-5.4-nano`, `gpt-5.4-mini`) returns `invalid_request` ("not supported when
+using Codex with a ChatGPT account"), so nothing routes to it — Luna is the
+cheap floor, and there is **no OpenAI 1M model available**, which is why `ompx`
+is Anthropic-1M-only for its substantive roles. Also not routed:
 `gpt-5.1-codex-mini` (cheap but narrow thinking), the rest of the GPT-5.x
 back-catalog, and `claude-mythos-5` (gated private program, not usable).
 
@@ -68,7 +71,7 @@ back-catalog, and `claude-mythos-5` (gated private program, not usable).
    **`:xhigh`** — best output *and* faster drain — while the boilerplate
    one-liners (`tiny`/`commit`) stay at `:low`, where xhigh reasoning would only
    add latency. When the bucket is exhausted each role falls back to the cheap
-   rung: `gpt-5.4-nano` ($0.20/$1.25) under OpenAI-led profiles, `claude-haiku-4-5`
+   rung: `gpt-5.6-luna` ($1/$6) under OpenAI-led profiles, `claude-haiku-4-5`
    ($1/$5) under Anthropic-led ones. Spark stays off `smol`/scout (exploration
    can exceed its 128K window), the thinking roles, and `ompf`.
 5. **Trivial roles carry at most one cheap fallback.** Background is never
@@ -86,7 +89,7 @@ and the providers meter more than one bucket per account. `omp usage` shows them
 (and the `code` picker renders a compact panel of them beside the palette):
 
 - **OpenAI Codex has two independent buckets.** The main 5h/7d window is shared
-  by `sol`/`terra`/`luna`/`gpt-5.4`/`nano`. But `gpt-5.3-codex-spark` draws from
+  by `sol`/`terra`/`luna`. But `gpt-5.3-codex-spark` draws from
   a **separate** 5h/7d "Spark" bucket that is usually sitting at 0%. That idle
   Spark allowance is effectively **free extra Codex capacity every 5h/7d** — in
   an ideal world we drain it too, rather than let it reset unused. Routing some
@@ -99,9 +102,9 @@ and the providers meter more than one bucket per account. `omp usage` shows them
     so the drain is transparent:
     - OpenAI-led (`ompb`, `ompg`): `task` **and** `sonic`/`advisor`/`tiny`/`commit`
       lead on Spark. `task` falls back to its old terra/luna worker chain (then
-      crosses); background falls back to `nano`.
+      crosses); background falls back to `luna`.
     - Anthropic-led (`omps`, `ompc`, `ompx`): the background roles lead on Spark.
-      Because Spark is itself a Codex model, they fall back to `nano` (a regular
+      Because Spark is itself a Codex model, they fall back to `luna` (a regular
       Codex rung) before crossing to `haiku` — drain the free Spark bucket, then
       cheap main-Codex, then the Claude plan only if OpenAI is fully down.
       `task` stays pool-pure on Claude — draining the free Codex bucket for
@@ -134,7 +137,7 @@ specialists and sorted faster → smarter within each.
 | | OpenAI-led (Codex meter) | Anthropic-led (Claude meter) |
 | --- | --- | --- |
 | **fast (mixed)** | `ompz` — fastest tiers of both providers, low thinking, light fallbacks | *(uses both meters)* |
-| **cheap** | `ompb` — routine work, nano background, features off | `omps` — everyday value, Sonnet-led, features on |
+| **cheap** | `ompb` — routine work, Spark/Luna background, features off | `omps` — everyday value, Sonnet-led, features on |
 | **hard** | `ompg` — Sol drives, Claude is the net | `ompc` — Fable drives, GPT is the net |
 | **specialist** | — | `ompf` deterministic Fable · `ompx` huge-context (1M) |
 
@@ -148,7 +151,7 @@ Routing detail is in the YAML; each file's header comment states its thesis.
 Summary:
 
 - **`ompz`** ([fast-mixed.yml](presets/fast-mixed.yml)) — speed-first, mixed. The
-  fastest competent tiers across both providers at low thinking (Luna/nano/Spark
+  fastest competent tiers across both providers at low thinking (Luna/Spark
   + Sonnet/Haiku), with light single-hop fallbacks (cross to Haiku, or a cheap
   sibling). Nothing reaches for Sol/Fable/Opus; plan/slow get one capped step up.
   For snappy interactive work where latency beats depth. Note: unlike the
@@ -157,7 +160,7 @@ Summary:
 - **`ompb`** ([budget.yml](presets/budget.yml)) — minimum burn. Terra/Luna lead
   the interactive and deliberative roles at low thinking. `task` and the
   background roles lead on Spark to drain the free Codex bucket, falling back to
-  their old rungs (`task`→terra→luna→Haiku; background→nano). `default` keeps a
+  their old rungs (`task`→terra→luna→Haiku; background→luna). `default` keeps a
   Luna→Sonnet net; the deliberative roles keep none. Advisor, branch summaries,
   and autolearn off.
 - **`omps`** ([sonnet-value.yml](presets/sonnet-value.yml)) — the profile `ompb`
@@ -172,7 +175,7 @@ Summary:
   overload for free, then the last hop crosses to Fable/Opus so a full OpenAI
   outage still lands on a live vendor. `task` and the background roles lead on
   Spark (fast execution, draining the free Codex bucket), falling back to the
-  terra/luna chain and nano respectively.
+  terra/luna chain and luna respectively.
 - **`ompc`** ([claude-hard.yml](presets/claude-hard.yml)) — `ompg`'s mirror,
   opposite pool. Fable drives, Opus is the sibling (and leads review, its
   strength), Sonnet/Haiku carry workers, every chain reaches back to Sol/Terra.
@@ -186,11 +189,12 @@ Summary:
   burned on commit messages (the mixed pool is the accepted price of
   determinism).
 - **`ompx`** ([context-1m.yml](presets/context-1m.yml)) — work beyond the 372K
-  ceiling of the 5.6 family. Anthropic owns 1M, so Fable/Opus/Sonnet lead;
-  `gpt-5.4` is the only OpenAI 1M card, used as the universal cross-net and the
-  librarian lead (putting the read-everything role on the Codex meter splits the
-  burn). **Invariant: a fallback never shrinks the window mid-job** on a
-  substantive role. Background trivia never sees the big context, so it leads on
+  ceiling of the 5.6 family. Anthropic owns 1M, and OpenAI has no 1M model that
+  runs on a ChatGPT/Codex account, so every substantive role — primary *and*
+  fallback — stays on Anthropic's 1M line (Fable/Opus/Sonnet). **Invariant: a
+  fallback never shrinks the window mid-job**; there is simply no cross-provider
+  net at 1M, so if Anthropic is down, huge-context work waits. Background trivia
+  never sees the big context, so it leads on
   Spark (free Codex bucket) → Haiku.
 
 ## The `code` picker
@@ -236,18 +240,15 @@ the picker, the routing page, and the launchers never drift.
 
 ## Revisit triggers
 
-- **The nano bet.** `commit`/`tiny` and all of `ompb`'s background run on
-  `gpt-5.4-nano` — the ~5× saving is the biggest here, and the only quality
-  gamble. If commit messages or labels degrade, the revert is one line back to
-  Luna per role. Worth a week's trial before judging.
+- **The 5.4 family is out.** `gpt-5.4`/`-nano`/`-mini` aren't usable on a
+  ChatGPT/Codex account (`invalid_request`), so the cheap `nano` background rung
+  is gone — trivia now leads on Spark and falls to Luna — and `ompx` lost its
+  only OpenAI 1M card (its substantive roles are Anthropic-1M-only). If OpenAI
+  ships a ChatGPT-usable cheap or 1M tier, revisit both.
 - **Sonnet's price cliff.** `omps` is built on introductory pricing ($2/$10). On
   **2026-08-31** it steps to $3/$15 — dearer than Terra. The profile stays
   coherent (pool separation still justifies it), but the "cheapest
   premium-adjacent" pitch expires; recheck against Terra then.
-- **`ompx` librarian pool-split.** `gpt-5.4` leads `ompx`'s librarian to spread
-  the read-everything burn onto the Codex meter and give the 1M card a real job.
-  If a previous-gen model leading a role feels wrong, the alternative is
-  all-Anthropic (Sonnet lead, `gpt-5.4` as net only).
 - **How hard to push Spark.** Spark now leads the fast-execution roles (see
   [Separate rate buckets](#separate-rate-buckets--an-underused-lever)). Two dials
   remain: whether `task` should also lead on Spark in the Anthropic-led profiles

--- a/omp/PROFILES.md
+++ b/omp/PROFILES.md
@@ -100,10 +100,12 @@ and the providers meter more than one bucket per account. `omp usage` shows them
     - OpenAI-led (`ompb`, `ompg`): `task` **and** `sonic`/`advisor`/`tiny`/`commit`
       lead on Spark. `task` falls back to its old terra/luna worker chain (then
       crosses); background falls back to `nano`.
-    - Anthropic-led (`omps`, `ompc`, `ompx`): the background roles lead on Spark
-      and fall back to `haiku`. `task` stays pool-pure on Claude — draining the
-      free Codex bucket for trivia is worth a small pool impurity, but the
-      substantial worker is not.
+    - Anthropic-led (`omps`, `ompc`, `ompx`): the background roles lead on Spark.
+      Because Spark is itself a Codex model, they fall back to `nano` (a regular
+      Codex rung) before crossing to `haiku` — drain the free Spark bucket, then
+      cheap main-Codex, then the Claude plan only if OpenAI is fully down.
+      `task` stays pool-pure on Claude — draining the free Codex bucket for
+      trivia is worth a small pool impurity, but the substantial worker is not.
   - *Deliberately kept off Spark:* `smol`/scout (exploration can exceed the 128K
     window — truncation risk), every thinking role (`plan`/`slow`/`reviewer`/
     `designer`/`default` — Spark is fast, not a reasoner), and all of `ompf`

--- a/omp/PROFILES.md
+++ b/omp/PROFILES.md
@@ -124,12 +124,14 @@ which bucket is tight before you choose a harness.
 
 ## The palette
 
-Two everyday profiles per pool (cheap and hard), two specialists, and a base
-layer. `code` (see [below](#the-code-picker)) is an umbrella picker over all of
-them.
+A fast mixed profile, two everyday profiles per pool (cheap and hard), two
+specialists, and a base layer. `code` (see [below](#the-code-picker)) is an
+umbrella picker over all of them, grouped mixed → gpt-led → claude-led →
+specialists and sorted faster → smarter within each.
 
 | | OpenAI-led (Codex meter) | Anthropic-led (Claude meter) |
 | --- | --- | --- |
+| **fast (mixed)** | `ompz` — fastest tiers of both providers, low thinking, light fallbacks | *(uses both meters)* |
 | **cheap** | `ompb` — routine work, nano background, features off | `omps` — everyday value, Sonnet-led, features on |
 | **hard** | `ompg` — Sol drives, Claude is the net | `ompc` — Fable drives, GPT is the net |
 | **specialist** | — | `ompf` deterministic Fable · `ompx` huge-context (1M) |
@@ -143,6 +145,13 @@ posture (approvals, secrets, isolation), not models.
 Routing detail is in the YAML; each file's header comment states its thesis.
 Summary:
 
+- **`ompz`** ([fast-mixed.yml](presets/fast-mixed.yml)) — speed-first, mixed. The
+  fastest competent tiers across both providers at low thinking (Luna/nano/Spark
+  + Sonnet/Haiku), with light single-hop fallbacks (cross to Haiku, or a cheap
+  sibling). Nothing reaches for Sol/Fable/Opus; plan/slow get one capped step up.
+  For snappy interactive work where latency beats depth. Note: unlike the
+  drain-the-bucket profiles, Spark runs at `:low` here — this profile optimises
+  for latency, not for emptying the Spark quota.
 - **`ompb`** ([budget.yml](presets/budget.yml)) — minimum burn. Terra/Luna lead
   the interactive and deliberative roles at low thinking. `task` and the
   background roles lead on Spark to drain the free Codex bucket, falling back to
@@ -184,19 +193,25 @@ Summary:
 
 ## The `code` picker
 
-`code` lists the palette, resolves a selector (menu number, launcher name,
-alias like `plain`, or a single suffix letter — `code ompg`, `code 4`,
-`code g`), and execs the matching launcher, forwarding every remaining argument.
-If the first argument is not a known profile, the picker opens and then forwards
-all arguments to the choice, so `code --resume` picks first, then resumes.
-`code --list` / `code --help` are non-interactive. It is a thin wrapper: the
-chosen launcher applies its own managed overlays unchanged.
+`code` resolves a selector (menu number, launcher name, alias like `plain`, or a
+single suffix letter — `code ompg`, `code 4`, `code z`) and execs the matching
+launcher, forwarding every remaining argument. If the first argument is not a
+known profile, the picker opens and then forwards all arguments to the choice,
+so `code --resume` picks first, then resumes. `code --list` / `code --help` are
+non-interactive. It is a thin wrapper: the chosen launcher applies its own
+managed overlays unchanged.
 
-The interactive picker also renders a compact `omp usage` panel beside the
-palette (best-effort, ~2s from cache; bounded so it never blocks the picker —
-`code --no-usage` skips it). Each provider's quota windows show a bar and
-percent, with `free` on an idle bucket and `tight` at ≥80%, so you can see which
-meter has room before you pick. See [Separate rate buckets](#separate-rate-buckets--an-underused-lever).
+With no (profile) argument it opens an `fzf` picker — arrow keys + Enter, fuzzy
+filtering — with a truecolor list, Nerd Font provider glyphs, and soft group
+labels (mixed → gpt-led → claude-led → specialists, faster → smarter within).
+The preview pane shows the highlighted profile's detail and its live routing,
+with model names coloured by provider (blue/orange) and shaded by thinking level
+(dim `low` → bright `xhigh`). The `omp usage` panel sits in a bottom footer
+(best-effort, ~2s from cache, bounded; `code --no-usage` skips it): each quota
+window shows a green→red bar, `N% used`, and `free`/`tight` tags, so you see
+which meter has room before you pick (see [Separate rate
+buckets](#separate-rate-buckets--an-underused-lever)). It falls back to a plain
+typed menu when `fzf` is absent or `CODE_NO_FZF=1`.
 
 It is defined in [`pkgs/omp-configured/default.nix`](../pkgs/omp-configured/default.nix)
 from a single `paletteProfiles` list that also feeds the `omph` route view, so

--- a/omp/PROFILES.md
+++ b/omp/PROFILES.md
@@ -6,10 +6,9 @@ and [`presets/`](presets/); the operational reference (launcher table, config
 load order, security posture) is [`docs/agent-tools.md`](../docs/agent-tools.md).
 Read this file before reshaping the routing, and update it when you do.
 
-Everything here was derived from `omp models` on 2026-07-11 and prototyped in an
-interactive proposal artifact ("OMP routing proposal"). Prices are list price
-per 1M tokens (input/output); with subscription auth (Codex credits / Claude
-plan) they read as **relative burn rates** rather than direct dollars.
+Everything here was derived from `omp models` on 2026-07-11. Prices are list
+price per 1M tokens (input/output); with subscription auth (Codex credits /
+Claude plan) they read as **relative burn rates** rather than direct dollars.
 
 ## The model catalog
 
@@ -21,203 +20,207 @@ deliver less per dollar than the 5.6 tiers, so nothing routes to them today.
 
 | Model | $ in/out | Context | Thinking | Role in routing |
 | --- | --- | --- | --- | --- |
-| `gpt-5.6-sol` | $5 / $30 | 372K | low→max | Flagship. Leads `ompg` and the base default. Out-prices Opus 4.8 per output token. |
-| `gpt-5.6-terra` | $2.50 / $15 | 372K | low→max | Balanced workhorse. Leads `ompb` and the task/librarian roles. Sonnet's price-twin. |
-| `gpt-5.6-luna` | $1 / $6 | 372K | low→max | Fast, high-volume — the cheapest **supported** Codex tier. Sibling hops, cheap workers, and non-Spark background across the maps. |
-| `gpt-5.3-codex-spark` | $1.75 / $14 | 128K | low→xhigh | Coding-tuned and fast. Draws from a **separate, usually-idle** 5h/7d Codex bucket, so the fast-execution roles lead on it (see [Separate rate buckets](#separate-rate-buckets--an-underused-lever)). |
+| `gpt-5.6-sol` | $5 / $30 | 372K | low→max | Flagship. Leads the `smart` GPT tier (`ompg`, `ompm`, `ompo`). |
+| `gpt-5.6-terra` | $2.50 / $15 | 372K | low→max | Balanced workhorse. Leads the `regular` GPT tier (`ompb`) and the mixed workers. Sonnet's price-twin. |
+| `gpt-5.6-luna` | $1 / $6 | 372K | low→max | Fast, high-volume — the cheapest **supported** Codex tier. Leads the `speed` GPT tier (`ompl`); the cheap rung and same-bucket sibling everywhere. |
+| `gpt-5.3-codex-spark` | $1.75 / $14 | 128K | low→xhigh | Coding-tuned and fast. Draws a **separate, usually-idle** 5h/7d Codex bucket, so the fast-execution/background roles lead on it to drain it (see [Separate rate buckets](#separate-rate-buckets)). |
 
 ### Anthropic (provider `anthropic`)
 
 | Model | $ in/out | Context | Thinking | Role in routing |
 | --- | --- | --- | --- | --- |
-| `claude-fable-5` | $10 / $50 | 1M | low→max | Most capable. Drives `ompf`/`ompc`, plans in `ompx`, holds the base `plan` role. Thinking is always on (levels are effort). |
-| `claude-opus-4-8` | $5 / $25 | 1M | low→max | Top Opus tier. Leads `omps`'s plan/slow and `ompx`'s live thread; the deliberative fallback across the maps. |
-| `claude-sonnet-5` | $2 / $10 † | 1M | low→max | The value pick — near-Opus quality at a fraction of the cost. Leads `omps` and the Anthropic-led worker roles. |
-| `claude-haiku-4-5` | $1 / $5 | 200K | minimal→xhigh | Fastest/cheapest Anthropic tier. Background hum of the Anthropic-led maps; cross-net for `ompb`'s task. |
+| `claude-fable-5` | $10 / $50 | 1M | low→max | Most capable, and its own **scarce** bucket. A *deliberate* elite lead only (`ompc`, `ompf`, `ompm` judgment roles, `ompx` plan) — never an automatic fallback net. |
+| `claude-opus-4-8` | $5 / $25 | 1M | low→max | Top Opus tier. Leads the `smart` Claude tier's judgment roles and `ompe` (claude-only); the main-plan deliberative sibling across the maps. |
+| `claude-sonnet-5` | $2 / $10 † | 1M | low→max | The value pick — near-Opus quality at a fraction of the cost. Leads the `regular` Claude tier (`omps`) and the mixed judgment roles. |
+| `claude-haiku-4-5` | $1 / $5 | 200K | minimal→xhigh | Fastest/cheapest Anthropic tier. Leads the `speed` Claude tier (`ompk`); the Anthropic cheap rung and background hum. |
 
 † Sonnet 5 is at introductory pricing through **2026-08-31**, then $3 / $15 —
 dearer than Terra. See [Revisit triggers](#revisit-triggers).
 
-**Unusable on a ChatGPT/Codex account:** the whole `gpt-5.4` family (`gpt-5.4`,
-`gpt-5.4-nano`, `gpt-5.4-mini`) returns `invalid_request` ("not supported when
-using Codex with a ChatGPT account"), so nothing routes to it — Luna is the
-cheap floor, and there is **no OpenAI 1M model available**, which is why `ompx`
-is Anthropic-1M-only for its substantive roles. Also not routed:
-`gpt-5.1-codex-mini` (cheap but narrow thinking), the rest of the GPT-5.x
-back-catalog, and `claude-mythos-5` (gated private program, not usable).
+**Availability on a ChatGPT/Codex account:** `gpt-5.4` and `gpt-5.4-nano` return
+`invalid_request` ("not supported when using Codex with a ChatGPT account"), so
+they're out. `gpt-5.4-mini` *is* usable and slightly cheaper than Luna, but it's
+a previous-gen small model with a smaller window, so **Luna is the chosen cheap
+floor** and nothing routes to mini. There is **no OpenAI 1M model** on this
+account, which is why `ompx` is Anthropic-1M-only for its substantive roles.
+Also not routed: the GPT-5.x back-catalog and the `-codex`-tuned variants.
 
 ## Principles
 
-1. **Every fallback chain ends by crossing providers.** A same-provider sibling
-   first cheaply rules out a single model being at capacity; the last,
-   load-bearing hop must reach the *other* vendor, or the chain dies with its
-   provider. `Sol → Terra → Luna` is three OpenAI models — one outage takes all
-   three.
-2. **Sibling hops must be price-lateral.** `Sol → Terra` costs nothing extra to
-   try. Sonnet has no lateral Anthropic sibling (Opus is 2.5× up, Haiku a class
-   down), so Sonnet-led chains cross straight to Terra, its price-twin. No chain
-   silently upgrades you. (High-stakes `reviewer` is the deliberate exception:
-   escalating to Opus on failure is a feature, not a surprise.)
-3. **One subscription pool per profile.** All-OpenAI columns burn Codex credits;
-   all-Anthropic columns burn the Claude plan — background roles included. A
-   profile is therefore also a quota lever: when one meter runs dry, switch
-   columns and *everything* moves. The fallback net is the other pool.
-4. **Fast-execution roles drain the free Spark bucket first.** `gpt-5.3-codex-spark`
+1. **Redundancy first: every lead is backed by a same-bucket sibling.** Before a
+   chain crosses providers it tries another model *from the same quota bucket*,
+   so a single model being down or overloaded is absorbed without leaving the
+   bucket you meant to use. The shape is `A → A → B → B`: lead, its same-bucket
+   sibling, then the capability-matched model on the other provider and *its*
+   sibling. `gpt → gpt → claude → claude`, not `gpt → claude`.
+2. **Spark and Fable are their own bucket.** They draw separate quota, so a hop
+   *off* Spark (`spark → luna`) or *off* Fable (`fable → opus`) is a real
+   fallback to a different rate — never a redundancy sibling. They are never an
+   automatic net: Fable-led chains fall to main-plan Opus, and Spark-led roles
+   fall to a main-Codex rung.
+3. **Sibling direction follows the profile's job.** The `smart`/`regular` (quality)
+   profiles escalate to the *capable* neighbour, so a chain never routes below the
+   lead's tier. The `speed` profiles stay lean — a single fast cross, no slower
+   same-bucket detour (that would defeat latency). The pure-pool profiles never
+   cross at all (see 4). The 1M profile can't cross (no OpenAI 1M exists), so its
+   redundancy is Anthropic-internal.
+4. **A profile is a quota lever.** Each lane commits its leads to one pool, so
+   switching launchers switches which meter burns — the *other* pool is the net.
+   The two **pure-pool** profiles (`ompo` gpt-only, `ompe` claude-only) take this
+   to the limit: they never cross, keeping every token on one provider for
+   draining a bucket, or for when the other provider is down or off-limits.
+5. **Speed and cost are the same axis.** The fast models are the cheap ones
+   (Luna/Haiku, low thinking) and the smart models are the dear ones (Sol/Fable/
+   Opus, high thinking). There is no useful "cheap-but-slow" model, so there is no
+   separate "budget" tier — the `speed` lane *is* the cheap option.
+6. **Fast-execution roles drain the free Spark bucket first.** `gpt-5.3-codex-spark`
    has a separate, normally-idle 5h/7d Codex quota (see [Separate rate
-   buckets](#separate-rate-buckets--an-underused-lever)), so the execution and
-   background roles — `sonic`/`advisor`/`tiny`/`commit`, plus `task` in the
-   OpenAI-led profiles — lead on it. Because that bucket is free and the goal is
-   to empty it, the roles that do real work (`task`/`sonic`/`advisor`) run at
-   **`:xhigh`** — best output *and* faster drain — while the boilerplate
-   one-liners (`tiny`/`commit`) stay at `:low`, where xhigh reasoning would only
-   add latency. When the bucket is exhausted each role falls back to the cheap
-   rung: `gpt-5.6-luna` ($1/$6) under OpenAI-led profiles, `claude-haiku-4-5`
-   ($1/$5) under Anthropic-led ones. Spark stays off `smol`/scout (exploration
-   can exceed its 128K window), the thinking roles, and `ompf`.
-5. **Trivial roles carry at most one cheap fallback.** Background is never
-   crossed to a premium model — it gets exactly one hop, from Spark down to the
-   cheap rung, so draining the Spark allowance is transparent. The real chains
-   are reserved for the live thread, the workers, and the deliberative roles.
-6. **Thinking scales with stakes.** xhigh/high for `plan`, `slow`, `reviewer`,
-   `designer`; medium for the interactive default and workers; low/minimal for
-   background. `ompb` caps at high even for its deliberative roles.
+   buckets](#separate-rate-buckets)), so execution/background roles lead on it.
+   Because the bucket is free and the goal is to empty it, the real-work roles
+   (`task`/`sonic`/`advisor`) run at **`:xhigh`** — best output *and* faster
+   drain — while boilerplate (`tiny`/`commit`) stays `:low`. The `speed` profiles
+   are the exception: they run Spark at `:low`, optimising latency over drain.
+   Spark stays off `smol`/scout (exploration can exceed its 128K window), the
+   thinking roles, `ompf`, and the claude-only pure pool.
+7. **Trivial roles stay lean.** Background gets at most a short cheap chain
+   (Spark → a cheap rung → Haiku); a blip on a commit message is harmless. The
+   full `A → A → B → B` redundancy is reserved for the substantive roles.
+8. **Thinking scales with stakes.** high/xhigh for `plan`/`slow`/`reviewer`/
+   `designer` and the `smart` leads; medium for the `regular` interactive default
+   and workers; low/minimal for the `speed` leads and background.
 
-## Separate rate buckets — an underused lever
+## Separate rate buckets
 
 With subscription auth the real constraint is not dollars but **quota windows**,
-and the providers meter more than one bucket per account. `omp usage` shows them
-(and the `code` picker renders a compact panel of them beside the palette):
+and the providers meter more than one bucket per account. `omp usage` shows them,
+and the `code` picker renders a compact live panel of them (see
+[The `code` picker](#the-code-picker)):
 
 - **OpenAI Codex has two independent buckets.** The main 5h/7d window is shared
-  by `sol`/`terra`/`luna`. But `gpt-5.3-codex-spark` draws from
-  a **separate** 5h/7d "Spark" bucket that is usually sitting at 0%. That idle
-  Spark allowance is effectively **free extra Codex capacity every 5h/7d** — in
-  an ideal world we drain it too, rather than let it reset unused. Routing some
-  work to `openai-codex/gpt-5.3-codex-spark` spends the Spark bucket instead of
-  the shared main bucket, and (as a fallback) delays the cross to Anthropic.
-  - *Wired in as of this revision.* The fast-execution roles lead on
-    `gpt-5.3-codex-spark` — at `:xhigh` for the real-work roles
-    (`task`/`sonic`/`advisor`) to drain harder and get better output, `:low` for
-    the `tiny`/`commit` one-liners — and fall back the instant its bucket 429s,
-    so the drain is transparent:
-    - OpenAI-led (`ompb`, `ompg`): `task` **and** `sonic`/`advisor`/`tiny`/`commit`
-      lead on Spark. `task` falls back to its old terra/luna worker chain (then
-      crosses); background falls back to `luna`.
-    - Anthropic-led (`omps`, `ompc`, `ompx`): the background roles lead on Spark.
-      Because Spark is itself a Codex model, they fall back to `luna` (a regular
-      Codex rung) before crossing to `haiku` — drain the free Spark bucket, then
-      cheap main-Codex, then the Claude plan only if OpenAI is fully down.
-      `task` stays pool-pure on Claude — draining the free Codex bucket for
-      trivia is worth a small pool impurity, but the substantial worker is not.
-  - *Deliberately kept off Spark:* `smol`/scout (exploration can exceed the 128K
-    window — truncation risk), every thinking role (`plan`/`slow`/`reviewer`/
-    `designer`/`default` — Spark is fast, not a reasoner), and all of `ompf`
-    (its no-fallback contract means an exhausted Spark bucket would hard-fail).
-  - *Caveats to watch:* Spark is $1.75/$14 list, so this only "wins" under
-    subscription auth where quota, not dollars, is scarce; and a `task` whose
-    context exceeds 128K relies on Spark erroring (not silently truncating) for
-    the fallback to engage.
-- **Anthropic's Fable is the mirror image — a separate but *scarce* bucket.**
-  Fable draws from its own 7-day sub-limit that is frequently the binding
-  Anthropic constraint (often 80%+ while the general Claude 5h/7d bucket sits
-  much lower). So Fable-heavy profiles (`ompf`, and `ompc`'s default/plan/slow)
-  burn that scarce bucket fastest. When the picker panel flags Fable **tight**,
-  lean Sonnet/Opus (general bucket) or an OpenAI-led profile.
+  by `sol`/`terra`/`luna`. But `gpt-5.3-codex-spark` draws a **separate** 5h/7d
+  "Spark" bucket that usually sits at 0% — effectively **free extra Codex
+  capacity every window**. In an ideal world we drain it rather than let it
+  reset unused, so the execution/background roles lead on Spark and fall back the
+  instant it 429s (transparent drain). It's `$1.75/$14` list, so this only
+  "wins" under subscription auth where quota, not dollars, is scarce.
+- **Fable is the mirror image — a separate but *scarce* bucket.** Fable draws its
+  own 7-day sub-limit that is frequently the binding Anthropic constraint (often
+  80%+ while the general Claude bucket sits much lower). So it is spent
+  *deliberately* (as an elite lead) and **never** as an automatic net — the
+  redundancy pairs are built from main-plan models. When the picker panel flags
+  Fable **tight**, lean on a Sonnet/Opus profile or an OpenAI-led one.
 
-The picker panel is exactly there to make this a glance-and-pick decision: see
-which bucket is tight before you choose a harness.
+The picker panel exists to make this a glance-and-pick decision: see which bucket
+is tight before you choose a harness.
 
-## The palette
+## The palette — a lane × tier matrix
 
-A fast mixed profile, two everyday profiles per pool (cheap and hard), two
-specialists, and a base layer. `code` (see [below](#the-code-picker)) is an
-umbrella picker over all of them, grouped mixed → gpt-led → claude-led →
-specialists and sorted faster → smarter within each.
+Three **lanes** (which pool leads) × three **tiers** (`speed`/`regular`/`smart`),
+plus a pure-pool per provider and a few specials. `code` (see
+[below](#the-code-picker)) is an umbrella picker over all of them.
 
-| | OpenAI-led (Codex meter) | Anthropic-led (Claude meter) |
-| --- | --- | --- |
-| **fast (mixed)** | `ompz` — fastest tiers of both providers, low thinking, light fallbacks | *(uses both meters)* |
-| **cheap** | `ompb` — routine work, Spark/Luna background, features off | `omps` — everyday value, Sonnet-led, features on |
-| **hard** | `ompg` — Sol drives, Claude is the net | `ompc` — Fable drives, GPT is the net |
-| **specialist** | — | `ompf` deterministic Fable · `ompx` huge-context (1M) |
+| | speed | regular | smart | pure |
+| --- | --- | --- | --- | --- |
+| **mixed** (both meters) | `ompz` | `ompn` | `ompm` | — |
+| **gpt** (Codex meter) | `ompl` | `ompb` | `ompg` | `ompo` (gpt-only) |
+| **claude** (Claude meter) | `ompk` | `omps` | `ompc` | `ompe` (claude-only) |
 
-Base layer: [`defaults.yml`](defaults.yml) underlies every launcher and is the
-entire model map for `ompu` (untrusted repos), whose real differences are
-posture (approvals, secrets, isolation), not models.
+Specials: `ompf` (deterministic Fable) · `ompx` (huge-context 1M). Base layer:
+[`defaults.yml`](defaults.yml) underlies every launcher and is the entire model
+map for `ompu` (untrusted repos), whose real differences are posture (approvals,
+secrets, isolation), not models. `omp` is the operator's own unmanaged config.
 
 ## Per-profile rationale
 
-Routing detail is in the YAML; each file's header comment states its thesis.
-Summary:
+Routing detail is in the YAML; each file's header comment states its thesis. By
+tier:
 
-- **`ompz`** ([fast-mixed.yml](presets/fast-mixed.yml)) — speed-first, mixed. The
-  fastest competent tiers across both providers at low thinking (Luna/Spark
-  + Sonnet/Haiku), with light single-hop fallbacks (cross to Haiku, or a cheap
-  sibling). Nothing reaches for Sol/Fable/Opus; plan/slow get one capped step up.
-  For snappy interactive work where latency beats depth. Note: unlike the
-  drain-the-bucket profiles, Spark runs at `:low` here — this profile optimises
-  for latency, not for emptying the Spark quota.
-- **`ompb`** ([budget.yml](presets/budget.yml)) — minimum burn. Terra/Luna lead
-  the interactive and deliberative roles at low thinking. `task` and the
-  background roles lead on Spark to drain the free Codex bucket, falling back to
-  their old rungs (`task`→terra→luna→Haiku; background→luna). `default` keeps a
-  Luna→Sonnet net; the deliberative roles keep none. Advisor, branch summaries,
-  and autolearn off.
-- **`omps`** ([sonnet-value.yml](presets/sonnet-value.yml)) — the profile `ompb`
-  can't be: cheap *and* premium-adjacent. Sonnet leads everything but plan/slow,
-  where low-volume Opus is worth the leverage. Chains cross to Terra/Luna
-  (Sonnet's price-twins). All-Anthropic pool for the substantive roles; features
-  stay on. Background leads on Spark (free Codex bucket) → Haiku, so trivia
-  doesn't spend the Claude plan. Doubles as the "Codex credits are spent"
-  everyday driver.
-- **`ompg`** ([gpt56.yml](presets/gpt56.yml)) — difficult work, GPT-led. Every
-  substantive role runs GPT → GPT → Claude: a sibling absorbs a single-model
-  overload for free, then the last hop crosses to Fable/Opus so a full OpenAI
-  outage still lands on a live vendor. `task` and the background roles lead on
-  Spark (fast execution, draining the free Codex bucket), falling back to the
-  terra/luna chain and luna respectively.
-- **`ompc`** ([claude-hard.yml](presets/claude-hard.yml)) — `ompg`'s mirror,
-  opposite pool. Fable drives, Opus is the sibling (and leads review, its
-  strength), Sonnet/Haiku carry workers, every chain reaches back to Sol/Terra.
-  Load it when OpenAI is dark or the Codex meter is empty and the work is still
-  hard. Unlike `ompf`, nothing strands on a single model. Background leads on
-  Spark (free Codex bucket) → Haiku.
+- **`speed`** (`ompz` mixed · `ompl` gpt · `ompk` claude) — fastest competent
+  tiers at low thinking, latency over depth. Leads on Luna/Haiku (and Spark for
+  `task`/background); fallbacks are single fast hops across to the other pool's
+  cheap tier, with no slower same-bucket sibling. Nothing reaches for
+  Sol/Fable/Opus. `ompk` is where Haiku lives as a lead rather than just
+  background.
+- **`regular`** (`ompn` mixed · `ompb` gpt · `omps` claude) — the balanced daily
+  drivers at medium thinking, with full `A → A → B → B` redundancy on every
+  substantive role. `ompn` splits the work by strength (Claude leads judgment,
+  GPT leads execution); `ompb` is routine Codex work kept off the premium tiers
+  (failovers stay on Luna/Terra + Haiku/Sonnet, never Sol/Opus); `omps` is
+  Sonnet-led everyday value, Opus for plan/slow.
+- **`smart`** (`ompm` mixed · `ompg` gpt · `ompc` claude) — hardest work at high
+  thinking, full redundancy. `ompg` runs GPT → GPT → Claude; `ompc` is its mirror
+  (Fable drives, Opus is the sibling and leads review, reaches back to Sol/Terra);
+  `ompm` picks the **best model per task** — Sol on GPT-strength roles, Fable/Opus
+  on the Claude-strength ones (design, planning, review).
+- **`ompo`** (gpt-only) / **`ompe`** (claude-only) — pure pools that **never
+  cross**. Redundancy stays inside one provider (`Sol → Terra → Luna` /
+  `Opus → Sonnet → Haiku`). `ompe` also avoids the separate Spark/Fable buckets
+  entirely. Load them to keep every token on one meter — draining it, or when the
+  other provider is down or off-limits.
 - **`ompf`** ([fable-primary.yml](presets/fable-primary.yml)) — Fable-first,
-  deterministic. Retry and server-side fallback **off**: the contract is "give
-  me Fable, predictably, and never silently swap." Resilience is `ompc`'s job
-  now, so `ompf` stays pure. Background on cheap OpenAI rungs so Fable isn't
-  burned on commit messages (the mixed pool is the accepted price of
-  determinism).
+  deterministic. Retry and server-side fallback **off**: the contract is "give me
+  Fable, predictably, never silently swap." Resilience is `ompc`'s job, so `ompf`
+  stays pure; background rides cheap OpenAI rungs so Fable isn't burned on commit
+  messages (the mixed pool is the accepted price of determinism).
 - **`ompx`** ([context-1m.yml](presets/context-1m.yml)) — work beyond the 372K
-  ceiling of the 5.6 family. Anthropic owns 1M, and OpenAI has no 1M model that
-  runs on a ChatGPT/Codex account, so every substantive role — primary *and*
-  fallback — stays on Anthropic's 1M line (Fable/Opus/Sonnet). **Invariant: a
-  fallback never shrinks the window mid-job**; there is simply no cross-provider
-  net at 1M, so if Anthropic is down, huge-context work waits. Background trivia
-  never sees the big context, so it leads on
-  Spark (free Codex bucket) → Haiku.
+  ceiling. Anthropic owns 1M and no OpenAI 1M runs on this account, so every
+  substantive role — lead *and* fallback — stays on Anthropic's 1M line
+  (Fable/Opus/Sonnet); there is no cross-net, so if Anthropic is down, huge-context
+  work waits. Background trivia never sees the big context, so it drains Spark →
+  Luna → Haiku.
 
 ## The `code` picker
 
 `code` resolves a selector (menu number, launcher name, alias like `plain`, or a
-single suffix letter — `code ompg`, `code 4`, `code z`) and execs the matching
-launcher, forwarding every remaining argument. If the first argument is not a
-known profile, the picker opens and then forwards all arguments to the choice,
-so `code --resume` picks first, then resumes. `code --list` / `code --help` are
+single suffix letter — `code ompg`, `code 7`, `code z`) and execs the matching
+launcher, forwarding every remaining argument. A first argument that is not a
+known profile opens the picker, then forwards all arguments to the choice, so
+`code --resume` picks first, then resumes. `code --list` / `code --help` are
 non-interactive. It is a thin wrapper: the chosen launcher applies its own
 managed overlays unchanged.
 
-With no (profile) argument it opens an `fzf` picker — arrow keys + Enter, fuzzy
-filtering — with a truecolor list, Nerd Font provider glyphs, and soft group
-labels (mixed → gpt-led → claude-led → specialists, faster → smarter within).
-The preview pane shows the highlighted profile's detail and its live routing,
-with model names coloured by provider (blue/orange) and shaded by thinking level
-(dim `low` → bright `xhigh`). The `omp usage` panel sits in a bottom footer
-(best-effort, ~2s from cache, bounded; `code --no-usage` skips it): each quota
-window shows a green→red bar, `N% used`, and `free`/`tight` tags, so you see
-which meter has room before you pick (see [Separate rate
-buckets](#separate-rate-buckets--an-underused-lever)). It falls back to a plain
-typed menu when `fzf` is absent or `CODE_NO_FZF=1`.
+With no profile argument it opens an `fzf` picker — arrow keys + Enter, fuzzy
+filtering, truecolor. Its encoding:
+
+- **Colour = lane.** mixed → purple, gpt → blue, claude → orange, bare → green,
+  special → teal (`ompu` keeps a red warning tint). A quiet category label
+  (`mixed`, `gpt-led`, `claude-led`, `special`) marks the first row of each
+  group on the left, and the lane colour rides the glyph beside it.
+- **Glyph = intended use.** speed → bolt, regular → cogs, smart → lightbulb,
+  pure-pool → broken-link (never crosses), plus per-special icons (deterministic
+  → pin, 1M → book, untrusted → lock). The icon reflects what a profile is *for*,
+  not just its provider — so the `smart` profiles carry a lightbulb, not the bolt
+  they used to inherit from being GPT-led.
+- **Preview.** The highlighted profile's detail (with provider/model mentions
+  tinted) and its routing, model names coloured by provider and shaded by
+  thinking level. `ctrl-f` cycles the routing depth: hidden → the
+  cross-provider net (redundancy siblings collapsed) → the full chain plus the
+  rationale. `ompu` inherits the managed defaults routing and shows it like any
+  preset. The bare `omp` is unmanaged, so it resolves and shows your *own*
+  `~/.omp` role→model routing (cached from `omp config list`, refreshed in the
+  background since that call is ~0.9 s); until the first resolve lands it lists
+  the bundled subagents.
+- **Keys.** The picker is keyboard-driven (`--no-mouse`): arrows or typing
+  filter, Enter selects, `ctrl-f` toggles routing depth, and `shift-↑/↓` (line)
+  or `alt-↑/↓` (half-page) scroll the preview when it overflows a short terminal.
+  Mouse is off entirely — fzf couples wheel-scroll and hover on a trackpad, so
+  the only way to guarantee the right pane never scrolls under the cursor is to
+  disable mouse input and scroll it by key instead.
+- **Usage panel** in the footer: each quota window's green→red bar, `N% used`,
+  time-to-reset (brighter as it nears, relative to the window), and `idle`/`tight`
+  tags — so you see which meter has room before you pick. It reads the
+  tyrode.dev collector snapshot when present (instant, always fresh) or a
+  background-refreshed local cache, and **never blocks the picker**.
+
+Previews render lazily (only the focused profile) with a background pre-warm on
+open, so the picker itself opens in tens of milliseconds. It falls back to a
+plain typed menu (with text group headers) when `fzf` is absent or
+`CODE_NO_FZF=1`.
+
+Picking a launcher holds a full-screen **starting card** — the profile, its
+description, and its lead-only model list (no fallback chains) with a loading
+mark — across omp's ~0.6 s cold start, so the picker never flashes back to a
+bare terminal before omp paints over it.
 
 It is defined in [`pkgs/omp-configured/default.nix`](../pkgs/omp-configured/default.nix)
 from a single `paletteProfiles` list that also feeds the `omph` route view, so
@@ -229,34 +232,30 @@ the picker, the routing page, and the launchers never drift.
    [`presets/`](presets/) file. Model selectors are `provider/model:thinking`,
    e.g. `openai-codex/gpt-5.6-terra:medium`.
 2. Verify the selector and thinking level exist: `omp models --json`. A bad ID
-   or level is a *runtime* error, not a build failure — the YAML is not
-   validated against the registry at build time.
+   or level is a *runtime* error, not a build failure — the YAML is not validated
+   against the registry at build time.
 3. Run `zconf` (`atyrode apply`), then `omph` to see the rendered routing.
-4. If you add or rename a launcher, update `paletteProfiles` in
-   `pkgs/omp-configured/default.nix`, the preset set in
-   `modules/home/agent-tools.nix`, and the assertions in
-   `checks/agent-tools.nix` (the bin inventory and `omph` descriptions are
-   pinned).
+4. If you add or rename a launcher, update `paletteProfiles` (and the `lane_color`
+   / `icon_glyph` maps) in `pkgs/omp-configured/default.nix`, the preset set in
+   `modules/home/agent-tools.nix`, and the assertions in `checks/agent-tools.nix`
+   (the bin inventory and `omph` descriptions are pinned).
 
 ## Revisit triggers
 
-- **The 5.4 family is out.** `gpt-5.4`/`-nano`/`-mini` aren't usable on a
-  ChatGPT/Codex account (`invalid_request`), so the cheap `nano` background rung
-  is gone — trivia now leads on Spark and falls to Luna — and `ompx` lost its
-  only OpenAI 1M card (its substantive roles are Anthropic-1M-only). If OpenAI
-  ships a ChatGPT-usable cheap or 1M tier, revisit both.
-- **Sonnet's price cliff.** `omps` is built on introductory pricing ($2/$10). On
-  **2026-08-31** it steps to $3/$15 — dearer than Terra. The profile stays
-  coherent (pool separation still justifies it), but the "cheapest
-  premium-adjacent" pitch expires; recheck against Terra then.
-- **How hard to push Spark.** Spark now leads the fast-execution roles (see
-  [Separate rate buckets](#separate-rate-buckets--an-underused-lever)). Two dials
-  remain: whether `task` should also lead on Spark in the Anthropic-led profiles
-  (more drain, but the substantial worker leaves the Claude pool), and whether
-  the background `:low` output holds up in practice. If a role degrades, revert
-  it to its cheap rung — one line per role. Watch the Spark 5h/7d bars in the
-  `code` panel: if they never approach full, push more roles onto Spark; if they
-  saturate early and fall back constantly, ease off.
-- **Model registry churn.** New tiers or price changes can invalidate a lead or
-  a price-twin pairing. The presets are policy, not pricing data — re-derive from
+- **The 5.4 family.** `gpt-5.4`/`-nano` aren't usable on a ChatGPT/Codex account;
+  `gpt-5.4-mini` works but is left unused in favour of Luna (current-gen, wider
+  window). There is no ChatGPT-usable OpenAI 1M tier, so `ompx` stays
+  Anthropic-1M-only. If OpenAI ships a usable cheap-and-current or 1M tier,
+  revisit the cheap floor and `ompx`.
+- **Sonnet's price cliff.** `omps` (and the mixed regular/smart judgment roles)
+  ride Sonnet's introductory pricing ($2/$10). On **2026-08-31** it steps to
+  $3/$15 — dearer than Terra. Pool separation still justifies the profiles, but
+  recheck the "cheapest premium-adjacent" pitch against Terra then.
+- **How hard to push Spark.** Spark leads the fast-execution roles. Watch the
+  Spark 5h/7d bars in the `code` panel: if they never approach full, push more
+  roles onto Spark; if they saturate early and fall back constantly, ease off.
+  If a background `:low` output degrades in practice, revert that role to its
+  cheap rung — one line per role.
+- **Model registry churn.** New tiers or price changes can invalidate a lead or a
+  price-twin pairing. The presets are policy, not pricing data — re-derive from
   `omp models` when the catalog moves.

--- a/omp/defaults.yml
+++ b/omp/defaults.yml
@@ -22,30 +22,41 @@ retry:
   enabled: true
   modelFallback: true
   fallbackRevertPolicy: cooldown-expiry
-  # Sibling first (rules out one model at capacity for free), cross last (the
-  # load-bearing step reaches the other provider). Trivial roles carry no chain:
-  # a blip on commit/tiny/sonic is harmless and crossing them is wasteful.
+  # Redundancy first: a same-provider sibling backs each lead before the cross,
+  # so a single-model outage never leaves its bucket; then the matched pair on
+  # the other provider. Chains never route below the lead's tier. Spark (drain)
+  # and Fable (elite) draw separate quota and never appear as a net — plan leads
+  # on Fable deliberately and falls back to main-plan Opus. Trivial roles carry
+  # no chain: a blip on commit/tiny/sonic is harmless.
   fallbackChains:
     default:
       - openai-codex/gpt-5.6-terra:medium
+      - anthropic/claude-opus-4-8:medium
       - anthropic/claude-sonnet-5:medium
     task:
-      - openai-codex/gpt-5.6-luna:medium
+      - openai-codex/gpt-5.6-sol:medium
       - anthropic/claude-sonnet-5:medium
+      - anthropic/claude-opus-4-8:medium
     plan:
       - anthropic/claude-opus-4-8:high
       - openai-codex/gpt-5.6-sol:high
+      - openai-codex/gpt-5.6-terra:high
     slow:
       - openai-codex/gpt-5.6-terra:xhigh
       - anthropic/claude-opus-4-8:xhigh
+      - anthropic/claude-sonnet-5:xhigh
     designer:
+      - anthropic/claude-opus-4-8:medium
       - openai-codex/gpt-5.6-terra:medium
+      - openai-codex/gpt-5.6-sol:medium
     reviewer:
       - anthropic/claude-opus-4-8:high
+      - openai-codex/gpt-5.6-terra:high
       - openai-codex/gpt-5.6-sol:high
     librarian:
-      - openai-codex/gpt-5.6-luna:medium
+      - openai-codex/gpt-5.6-sol:medium
       - anthropic/claude-sonnet-5:medium
+      - anthropic/claude-opus-4-8:medium
 
 personality: pragmatic
 

--- a/omp/defaults.yml
+++ b/omp/defaults.yml
@@ -15,8 +15,8 @@ modelRoles:
   reviewer: anthropic/claude-sonnet-5:high
   plan: anthropic/claude-fable-5:high
   slow: openai-codex/gpt-5.6-sol:xhigh
-  tiny: openai-codex/gpt-5.4-nano:low
-  commit: openai-codex/gpt-5.4-nano:low
+  tiny: openai-codex/gpt-5.6-luna:low
+  commit: openai-codex/gpt-5.6-luna:low
 
 retry:
   enabled: true

--- a/omp/presets/budget.yml
+++ b/omp/presets/budget.yml
@@ -24,26 +24,44 @@ retry:
   enabled: true
   modelFallback: true
   fallbackRevertPolicy: cooldown-expiry
-  # task drains Spark first, then the old terra/luna worker chain, then crosses
-  # to Haiku. Background drains Spark, then nano. The deliberative roles keep no
-  # net (defaults.yml defines chains for them, so they are cleared with []).
+  # Redundancy first, but anchored low — this is the budget pool, so a failover
+  # never climbs to Sol/Opus. Each lead gets its cheaper same-provider sibling,
+  # then crosses to the other provider's cheap rung (+ sibling). Spark is the
+  # separate drain bucket (task/background lead on it and stay lean); a blip on
+  # background trivia is harmless.
   fallbackChains:
     default:
-      - openai-codex/gpt-5.6-luna:medium
-      - anthropic/claude-sonnet-5:medium
+      - openai-codex/gpt-5.6-luna:low
+      - anthropic/claude-haiku-4-5:low
+      - anthropic/claude-sonnet-5:low
     task:
       - openai-codex/gpt-5.6-terra:low
       - openai-codex/gpt-5.6-luna:medium
       - anthropic/claude-haiku-4-5:medium
+    plan:
+      - openai-codex/gpt-5.6-luna:high
+      - anthropic/claude-haiku-4-5:high
+      - anthropic/claude-sonnet-5:high
+    slow:
+      - openai-codex/gpt-5.6-luna:high
+      - anthropic/claude-haiku-4-5:high
+      - anthropic/claude-sonnet-5:high
+    designer:
+      - openai-codex/gpt-5.6-luna:medium
+      - anthropic/claude-haiku-4-5:medium
+      - anthropic/claude-sonnet-5:medium
+    reviewer:
+      - openai-codex/gpt-5.6-luna:medium
+      - anthropic/claude-haiku-4-5:medium
+      - anthropic/claude-sonnet-5:medium
+    librarian:
+      - openai-codex/gpt-5.6-terra:medium
+      - anthropic/claude-haiku-4-5:medium
+      - anthropic/claude-sonnet-5:medium
     sonic: [openai-codex/gpt-5.6-luna:low]
     advisor: [openai-codex/gpt-5.6-luna:low]
     tiny: [openai-codex/gpt-5.6-luna:low]
     commit: [openai-codex/gpt-5.6-luna:low]
-    plan: []
-    slow: []
-    designer: []
-    reviewer: []
-    librarian: []
 
 advisor:
   enabled: false

--- a/omp/presets/budget.yml
+++ b/omp/presets/budget.yml
@@ -9,7 +9,7 @@
 modelRoles:
   default: openai-codex/gpt-5.6-terra:low
   advisor: openai-codex/gpt-5.3-codex-spark:xhigh
-  smol: openai-codex/gpt-5.4-nano:low
+  smol: openai-codex/gpt-5.6-luna:low
   task: openai-codex/gpt-5.3-codex-spark:xhigh
   sonic: openai-codex/gpt-5.3-codex-spark:xhigh
   librarian: openai-codex/gpt-5.6-luna:medium
@@ -35,10 +35,10 @@ retry:
       - openai-codex/gpt-5.6-terra:low
       - openai-codex/gpt-5.6-luna:medium
       - anthropic/claude-haiku-4-5:medium
-    sonic: [openai-codex/gpt-5.4-nano:low]
-    advisor: [openai-codex/gpt-5.4-nano:low]
-    tiny: [openai-codex/gpt-5.4-nano:low]
-    commit: [openai-codex/gpt-5.4-nano:low]
+    sonic: [openai-codex/gpt-5.6-luna:low]
+    advisor: [openai-codex/gpt-5.6-luna:low]
+    tiny: [openai-codex/gpt-5.6-luna:low]
+    commit: [openai-codex/gpt-5.6-luna:low]
     plan: []
     slow: []
     designer: []

--- a/omp/presets/claude-hard.yml
+++ b/omp/presets/claude-hard.yml
@@ -27,19 +27,20 @@ retry:
   enabled: true
   modelFallback: true
   fallbackRevertPolicy: cooldown-expiry
-  # Claude sibling first, then cross to OpenAI. Sol out-prices Opus per output
-  # token, so the crossing is the expensive step; it only fires when Anthropic
-  # is actually down provider-wide. Background drains Spark, then Haiku.
+  # Redundancy first: a same-provider sibling before the cross (the Claude pair,
+  # then the matched OpenAI pair), so a single-model outage never leaves its
+  # bucket, and chains never drop below the lead's tier. Fable is the deliberate
+  # elite lead (default/plan/slow/designer) and falls back to main-plan Opus —
+  # it is never an automatic net. Background drains Spark, then Haiku.
   fallbackChains:
-    default: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high]
-    task: [anthropic/claude-haiku-4-5:medium, openai-codex/gpt-5.6-terra:medium]
-    plan: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high]
-    slow: [anthropic/claude-opus-4-8:xhigh, openai-codex/gpt-5.6-sol:xhigh]
-    designer: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high]
-    reviewer: [anthropic/claude-sonnet-5:high, openai-codex/gpt-5.6-sol:high]
-    librarian: [anthropic/claude-haiku-4-5:medium, openai-codex/gpt-5.6-terra:medium]
-    # Spark is a Codex model, so it falls back to a regular GPT rung before
-    # crossing to Haiku (drain free Spark, then cheap nano, then Claude).
+    default: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high, openai-codex/gpt-5.6-terra:high]
+    task: [anthropic/claude-opus-4-8:medium, openai-codex/gpt-5.6-terra:medium, openai-codex/gpt-5.6-sol:medium]
+    plan: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high, openai-codex/gpt-5.6-terra:high]
+    slow: [anthropic/claude-opus-4-8:xhigh, openai-codex/gpt-5.6-sol:xhigh, openai-codex/gpt-5.6-terra:xhigh]
+    designer: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high, openai-codex/gpt-5.6-terra:high]
+    reviewer: [anthropic/claude-sonnet-5:high, openai-codex/gpt-5.6-sol:high, openai-codex/gpt-5.6-terra:high]
+    librarian: [anthropic/claude-opus-4-8:medium, openai-codex/gpt-5.6-terra:medium, openai-codex/gpt-5.6-sol:medium]
+    # Background drains the free Spark bucket, then a cheap Codex rung, then Haiku.
     sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
     advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
     tiny: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]

--- a/omp/presets/claude-hard.yml
+++ b/omp/presets/claude-hard.yml
@@ -40,10 +40,10 @@ retry:
     librarian: [anthropic/claude-haiku-4-5:medium, openai-codex/gpt-5.6-terra:medium]
     # Spark is a Codex model, so it falls back to a regular GPT rung before
     # crossing to Haiku (drain free Spark, then cheap nano, then Claude).
-    sonic: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
-    advisor: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
-    tiny: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
-    commit: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    tiny: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    commit: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
 
 task:
   agentModelOverrides:

--- a/omp/presets/claude-hard.yml
+++ b/omp/presets/claude-hard.yml
@@ -38,10 +38,12 @@ retry:
     designer: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high]
     reviewer: [anthropic/claude-sonnet-5:high, openai-codex/gpt-5.6-sol:high]
     librarian: [anthropic/claude-haiku-4-5:medium, openai-codex/gpt-5.6-terra:medium]
-    sonic: [anthropic/claude-haiku-4-5:low]
-    advisor: [anthropic/claude-haiku-4-5:low]
-    tiny: [anthropic/claude-haiku-4-5:low]
-    commit: [anthropic/claude-haiku-4-5:low]
+    # Spark is a Codex model, so it falls back to a regular GPT rung before
+    # crossing to Haiku (drain free Spark, then cheap nano, then Claude).
+    sonic: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    tiny: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    commit: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
 
 task:
   agentModelOverrides:

--- a/omp/presets/claude-only.yml
+++ b/omp/presets/claude-only.yml
@@ -1,0 +1,46 @@
+# ompe — claude-only. Pure Anthropic, never crosses to OpenAI and never touches
+# the separate Spark/Fable buckets: Opus drives, redundancy stays inside the
+# Claude plan (Opus -> Sonnet -> Haiku). Load this to keep every token on
+# Anthropic — draining the Claude plan, or when Codex is down or off-limits.
+modelRoles:
+  default: anthropic/claude-opus-4-8:high
+  advisor: anthropic/claude-haiku-4-5:low
+  smol: anthropic/claude-haiku-4-5:low
+  task: anthropic/claude-sonnet-5:medium
+  sonic: anthropic/claude-haiku-4-5:low
+  librarian: anthropic/claude-sonnet-5:medium
+  designer: anthropic/claude-opus-4-8:high
+  reviewer: anthropic/claude-opus-4-8:high
+  plan: anthropic/claude-opus-4-8:high
+  slow: anthropic/claude-opus-4-8:xhigh
+  tiny: anthropic/claude-haiku-4-5:low
+  commit: anthropic/claude-haiku-4-5:low
+
+retry:
+  enabled: true
+  modelFallback: true
+  fallbackRevertPolicy: cooldown-expiry
+  # Claude-internal only — Opus -> Sonnet -> Haiku, never crossing to OpenAI and
+  # never reaching for the separate Spark/Fable buckets.
+  fallbackChains:
+    default: [anthropic/claude-sonnet-5:high, anthropic/claude-haiku-4-5:high]
+    task: [anthropic/claude-opus-4-8:medium, anthropic/claude-haiku-4-5:medium]
+    plan: [anthropic/claude-sonnet-5:high, anthropic/claude-haiku-4-5:high]
+    slow: [anthropic/claude-sonnet-5:xhigh, anthropic/claude-haiku-4-5:xhigh]
+    designer: [anthropic/claude-sonnet-5:high, anthropic/claude-haiku-4-5:high]
+    reviewer: [anthropic/claude-sonnet-5:high, anthropic/claude-haiku-4-5:high]
+    librarian: [anthropic/claude-opus-4-8:medium, anthropic/claude-haiku-4-5:medium]
+    sonic: [anthropic/claude-sonnet-5:low]
+    advisor: [anthropic/claude-sonnet-5:low]
+    tiny: [anthropic/claude-sonnet-5:low]
+    commit: [anthropic/claude-sonnet-5:low]
+
+task:
+  agentModelOverrides:
+    designer: anthropic/claude-opus-4-8:high
+    librarian: anthropic/claude-sonnet-5:medium
+    reviewer: anthropic/claude-opus-4-8:high
+    sonic: anthropic/claude-haiku-4-5:low
+    task: anthropic/claude-sonnet-5:medium
+
+defaultThinkingLevel: medium

--- a/omp/presets/claude-speed.yml
+++ b/omp/presets/claude-speed.yml
@@ -1,0 +1,44 @@
+# ompk — claude·speed. The fastest, cheapest Claude tier at low thinking: Haiku
+# leads, background drains the free Spark bucket, and fallbacks are single fast
+# hops to GPT's cheap tier (Luna). Latency-first — this is Haiku's home.
+modelRoles:
+  default: anthropic/claude-haiku-4-5:low
+  advisor: openai-codex/gpt-5.3-codex-spark:low
+  smol: anthropic/claude-haiku-4-5:low
+  task: anthropic/claude-haiku-4-5:low
+  sonic: openai-codex/gpt-5.3-codex-spark:low
+  librarian: anthropic/claude-haiku-4-5:low
+  designer: anthropic/claude-sonnet-5:low
+  reviewer: anthropic/claude-sonnet-5:low
+  plan: anthropic/claude-sonnet-5:medium
+  slow: anthropic/claude-sonnet-5:high
+  tiny: openai-codex/gpt-5.3-codex-spark:low
+  commit: openai-codex/gpt-5.3-codex-spark:low
+
+retry:
+  enabled: true
+  modelFallback: true
+  fallbackRevertPolicy: cooldown-expiry
+  # Single fast hop across to Luna. Background drains Spark first, then Luna.
+  fallbackChains:
+    default: [openai-codex/gpt-5.6-luna:low]
+    task: [openai-codex/gpt-5.6-luna:low]
+    plan: [openai-codex/gpt-5.6-terra:medium]
+    slow: [openai-codex/gpt-5.6-terra:high]
+    designer: [openai-codex/gpt-5.6-luna:low]
+    reviewer: [openai-codex/gpt-5.6-luna:low]
+    librarian: [openai-codex/gpt-5.6-luna:low]
+    sonic: [openai-codex/gpt-5.6-luna:low]
+    advisor: [openai-codex/gpt-5.6-luna:low]
+    tiny: [openai-codex/gpt-5.6-luna:low]
+    commit: [openai-codex/gpt-5.6-luna:low]
+
+task:
+  agentModelOverrides:
+    designer: anthropic/claude-sonnet-5:low
+    librarian: anthropic/claude-haiku-4-5:low
+    reviewer: anthropic/claude-sonnet-5:low
+    sonic: openai-codex/gpt-5.3-codex-spark:low
+    task: anthropic/claude-haiku-4-5:low
+
+defaultThinkingLevel: low

--- a/omp/presets/context-1m.yml
+++ b/omp/presets/context-1m.yml
@@ -1,21 +1,19 @@
 # ompx — huge-context work: monorepo audits, log forensics, marathon sessions
-# that outgrow the 372K ceiling of the 5.6 family. Anthropic owns 1M across its
-# line, so Fable/Opus/Sonnet lead; gpt-5.4 is the only OpenAI 1M card, used as
-# the universal cross-net and the librarian lead (putting the read-everything
-# role on the Codex meter splits the burn across pools).
+# that outgrow the 372K ceiling of the 5.6 family. OpenAI has no 1M model that
+# runs on a ChatGPT/Codex account, so every substantive role — primary and
+# fallback — stays on Anthropic's 1M line (Fable/Opus/Sonnet). The window never
+# contracts on a fallback; there is simply no cross-provider net at 1M, so if
+# Anthropic is down, huge-context work waits.
 #
-# Invariant: a fallback never shrinks the window mid-job on a substantive role.
-# Background trivia never sees the big context, so it leads on gpt-5.3-codex-spark
-# (128K) to drain the separate idle Codex bucket (see omp/PROFILES.md). The
-# bucket is free, so sonic/advisor run at :xhigh (best output, faster drain)
-# while tiny/commit stay :low; each falls back to Haiku when exhausted.
+# Background trivia never sees the big context, so it drains the free Spark
+# bucket, then falls back to Luna (Codex), then Haiku.
 modelRoles:
   default: anthropic/claude-opus-4-8:medium
   advisor: openai-codex/gpt-5.3-codex-spark:xhigh
   smol: anthropic/claude-haiku-4-5:low
   task: anthropic/claude-sonnet-5:medium
   sonic: openai-codex/gpt-5.3-codex-spark:xhigh
-  librarian: openai-codex/gpt-5.4:medium
+  librarian: anthropic/claude-sonnet-5:medium
   designer: anthropic/claude-opus-4-8:high
   reviewer: anthropic/claude-opus-4-8:high
   plan: anthropic/claude-fable-5:high
@@ -27,28 +25,26 @@ retry:
   enabled: true
   modelFallback: true
   fallbackRevertPolicy: cooldown-expiry
-  # Every substantive hop is a 1M model: Fable/Opus/Sonnet (Anthropic) or
-  # gpt-5.4 (the sole OpenAI 1M). The window never contracts on a fallback.
-  # Background is exempt (it never sees the big context): Spark, then Haiku.
+  # Every substantive hop is an Anthropic 1M model — the window never shrinks.
+  # Background is exempt (it never sees the big context): Spark, then Luna, then
+  # Haiku.
   fallbackChains:
-    default: [anthropic/claude-sonnet-5:medium, openai-codex/gpt-5.4:medium]
-    task: [openai-codex/gpt-5.4:medium]
-    plan: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.4:high]
-    slow: [anthropic/claude-opus-4-8:xhigh, openai-codex/gpt-5.4:xhigh]
-    designer: [openai-codex/gpt-5.4:high]
-    reviewer: [openai-codex/gpt-5.4:high]
-    librarian: [anthropic/claude-sonnet-5:medium]
-    # Spark is a Codex model, so it falls back to a regular GPT rung before
-    # crossing to Haiku (drain free Spark, then cheap nano, then Claude).
-    sonic: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
-    advisor: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
-    tiny: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
-    commit: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    default: [anthropic/claude-sonnet-5:medium, anthropic/claude-fable-5:medium]
+    task: [anthropic/claude-opus-4-8:medium]
+    plan: [anthropic/claude-opus-4-8:high, anthropic/claude-sonnet-5:high]
+    slow: [anthropic/claude-opus-4-8:xhigh, anthropic/claude-sonnet-5:xhigh]
+    designer: [anthropic/claude-fable-5:high]
+    reviewer: [anthropic/claude-fable-5:high]
+    librarian: [anthropic/claude-opus-4-8:medium]
+    sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    tiny: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    commit: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
 
 task:
   agentModelOverrides:
     designer: anthropic/claude-opus-4-8:high
-    librarian: openai-codex/gpt-5.4:medium
+    librarian: anthropic/claude-sonnet-5:medium
     reviewer: anthropic/claude-opus-4-8:high
     sonic: openai-codex/gpt-5.3-codex-spark:xhigh
     task: anthropic/claude-sonnet-5:medium

--- a/omp/presets/context-1m.yml
+++ b/omp/presets/context-1m.yml
@@ -38,10 +38,12 @@ retry:
     designer: [openai-codex/gpt-5.4:high]
     reviewer: [openai-codex/gpt-5.4:high]
     librarian: [anthropic/claude-sonnet-5:medium]
-    sonic: [anthropic/claude-haiku-4-5:low]
-    advisor: [anthropic/claude-haiku-4-5:low]
-    tiny: [anthropic/claude-haiku-4-5:low]
-    commit: [anthropic/claude-haiku-4-5:low]
+    # Spark is a Codex model, so it falls back to a regular GPT rung before
+    # crossing to Haiku (drain free Spark, then cheap nano, then Claude).
+    sonic: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    tiny: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    commit: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
 
 task:
   agentModelOverrides:

--- a/omp/presets/context-1m.yml
+++ b/omp/presets/context-1m.yml
@@ -25,16 +25,18 @@ retry:
   enabled: true
   modelFallback: true
   fallbackRevertPolicy: cooldown-expiry
-  # Every substantive hop is an Anthropic 1M model — the window never shrinks.
-  # Background is exempt (it never sees the big context): Spark, then Luna, then
-  # Haiku.
+  # Every substantive hop stays on Anthropic's 1M line — the window never
+  # shrinks, and there is no cross-provider 1M net, so redundancy is Opus/Sonnet
+  # siblings only. Fable is the deliberate elite lead (plan/slow); it is never an
+  # automatic net. Background is exempt (never sees the big context): Spark, then
+  # Luna, then Haiku.
   fallbackChains:
-    default: [anthropic/claude-sonnet-5:medium, anthropic/claude-fable-5:medium]
+    default: [anthropic/claude-sonnet-5:medium]
     task: [anthropic/claude-opus-4-8:medium]
     plan: [anthropic/claude-opus-4-8:high, anthropic/claude-sonnet-5:high]
     slow: [anthropic/claude-opus-4-8:xhigh, anthropic/claude-sonnet-5:xhigh]
-    designer: [anthropic/claude-fable-5:high]
-    reviewer: [anthropic/claude-fable-5:high]
+    designer: [anthropic/claude-sonnet-5:high]
+    reviewer: [anthropic/claude-sonnet-5:high]
     librarian: [anthropic/claude-opus-4-8:medium]
     sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
     advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]

--- a/omp/presets/fast-mixed.yml
+++ b/omp/presets/fast-mixed.yml
@@ -1,0 +1,45 @@
+# ompz — speed-first, mixed. The fastest competent tiers across both providers
+# at low thinking, with light fast fallbacks, for snappy interactive work where
+# latency beats depth. Luna/nano/Spark (OpenAI) and Sonnet/Haiku (Anthropic) are
+# all fast; nothing here reaches for Sol/Fable/Opus. Mixed pool by design.
+#
+# Note: unlike the drain-the-bucket profiles, task/background run Spark at :low
+# here — this profile optimises for latency, not for emptying the Spark quota.
+modelRoles:
+  default: openai-codex/gpt-5.6-luna:low
+  advisor: openai-codex/gpt-5.4-nano:low
+  smol: openai-codex/gpt-5.4-nano:low
+  task: openai-codex/gpt-5.3-codex-spark:low
+  sonic: openai-codex/gpt-5.4-nano:low
+  librarian: openai-codex/gpt-5.6-luna:low
+  designer: anthropic/claude-sonnet-5:low
+  reviewer: anthropic/claude-sonnet-5:low
+  plan: openai-codex/gpt-5.6-terra:medium
+  slow: openai-codex/gpt-5.6-terra:high
+  tiny: openai-codex/gpt-5.4-nano:low
+  commit: openai-codex/gpt-5.4-nano:low
+
+retry:
+  enabled: true
+  modelFallback: true
+  fallbackRevertPolicy: cooldown-expiry
+  # Fast, single-hop nets: cross to the other provider's fast tier (Haiku), or a
+  # cheap sibling. plan/slow get one step up in capability, still capped.
+  fallbackChains:
+    default: [anthropic/claude-haiku-4-5:low]
+    task: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    librarian: [anthropic/claude-haiku-4-5:low]
+    designer: [openai-codex/gpt-5.6-terra:low]
+    reviewer: [openai-codex/gpt-5.6-terra:low]
+    plan: [anthropic/claude-sonnet-5:medium]
+    slow: [anthropic/claude-sonnet-5:high]
+
+task:
+  agentModelOverrides:
+    designer: anthropic/claude-sonnet-5:low
+    librarian: openai-codex/gpt-5.6-luna:low
+    reviewer: anthropic/claude-sonnet-5:low
+    sonic: openai-codex/gpt-5.4-nano:low
+    task: openai-codex/gpt-5.3-codex-spark:low
+
+defaultThinkingLevel: low

--- a/omp/presets/fast-mixed.yml
+++ b/omp/presets/fast-mixed.yml
@@ -7,17 +7,17 @@
 # here — this profile optimises for latency, not for emptying the Spark quota.
 modelRoles:
   default: openai-codex/gpt-5.6-luna:low
-  advisor: openai-codex/gpt-5.4-nano:low
-  smol: openai-codex/gpt-5.4-nano:low
+  advisor: openai-codex/gpt-5.6-luna:low
+  smol: openai-codex/gpt-5.6-luna:low
   task: openai-codex/gpt-5.3-codex-spark:low
-  sonic: openai-codex/gpt-5.4-nano:low
+  sonic: openai-codex/gpt-5.6-luna:low
   librarian: openai-codex/gpt-5.6-luna:low
   designer: anthropic/claude-sonnet-5:low
   reviewer: anthropic/claude-sonnet-5:low
   plan: openai-codex/gpt-5.6-terra:medium
   slow: openai-codex/gpt-5.6-terra:high
-  tiny: openai-codex/gpt-5.4-nano:low
-  commit: openai-codex/gpt-5.4-nano:low
+  tiny: openai-codex/gpt-5.6-luna:low
+  commit: openai-codex/gpt-5.6-luna:low
 
 retry:
   enabled: true
@@ -39,7 +39,7 @@ task:
     designer: anthropic/claude-sonnet-5:low
     librarian: openai-codex/gpt-5.6-luna:low
     reviewer: anthropic/claude-sonnet-5:low
-    sonic: openai-codex/gpt-5.4-nano:low
+    sonic: openai-codex/gpt-5.6-luna:low
     task: openai-codex/gpt-5.3-codex-spark:low
 
 defaultThinkingLevel: low

--- a/omp/presets/gpt-only.yml
+++ b/omp/presets/gpt-only.yml
@@ -1,0 +1,46 @@
+# ompo — gpt-only. Pure Codex, never crosses to Anthropic: Sol drives, redundancy
+# stays inside the Codex bucket (Sol -> Terra -> Luna), background drains the free
+# Spark bucket. Load this to keep every token on OpenAI — draining Codex, or when
+# the Claude plan is down or off-limits.
+modelRoles:
+  default: openai-codex/gpt-5.6-sol:high
+  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  smol: openai-codex/gpt-5.6-luna:low
+  task: openai-codex/gpt-5.3-codex-spark:xhigh
+  sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+  librarian: openai-codex/gpt-5.6-terra:medium
+  designer: openai-codex/gpt-5.6-sol:high
+  reviewer: openai-codex/gpt-5.6-sol:high
+  plan: openai-codex/gpt-5.6-sol:high
+  slow: openai-codex/gpt-5.6-sol:xhigh
+  tiny: openai-codex/gpt-5.3-codex-spark:low
+  commit: openai-codex/gpt-5.3-codex-spark:low
+
+retry:
+  enabled: true
+  modelFallback: true
+  fallbackRevertPolicy: cooldown-expiry
+  # Codex-internal only — Sol -> Terra -> Luna, never crossing to Anthropic.
+  # Background drains Spark, then Luna.
+  fallbackChains:
+    default: [openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-luna:high]
+    task: [openai-codex/gpt-5.6-terra:medium, openai-codex/gpt-5.6-luna:medium]
+    plan: [openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-luna:high]
+    slow: [openai-codex/gpt-5.6-terra:xhigh, openai-codex/gpt-5.6-luna:xhigh]
+    designer: [openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-luna:high]
+    reviewer: [openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-luna:high]
+    librarian: [openai-codex/gpt-5.6-sol:medium, openai-codex/gpt-5.6-luna:medium]
+    sonic: [openai-codex/gpt-5.6-luna:low]
+    advisor: [openai-codex/gpt-5.6-luna:low]
+    tiny: [openai-codex/gpt-5.6-luna:low]
+    commit: [openai-codex/gpt-5.6-luna:low]
+
+task:
+  agentModelOverrides:
+    designer: openai-codex/gpt-5.6-sol:high
+    librarian: openai-codex/gpt-5.6-terra:medium
+    reviewer: openai-codex/gpt-5.6-sol:high
+    sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+    task: openai-codex/gpt-5.3-codex-spark:xhigh
+
+defaultThinkingLevel: medium

--- a/omp/presets/gpt-speed.yml
+++ b/omp/presets/gpt-speed.yml
@@ -1,0 +1,42 @@
+# ompl — gpt·speed. The fastest, cheapest Codex tier at low thinking: Luna leads,
+# task drains the free Spark bucket, and fallbacks are single fast hops to
+# Claude's cheap tier (Haiku) — no same-bucket sibling detour (that would mean a
+# slower model). Latency-first; nothing reaches for Sol or high thinking. ompz's
+# pure-GPT sibling.
+modelRoles:
+  default: openai-codex/gpt-5.6-luna:low
+  advisor: openai-codex/gpt-5.6-luna:low
+  smol: openai-codex/gpt-5.6-luna:low
+  task: openai-codex/gpt-5.3-codex-spark:low
+  sonic: openai-codex/gpt-5.6-luna:low
+  librarian: openai-codex/gpt-5.6-luna:low
+  designer: openai-codex/gpt-5.6-terra:low
+  reviewer: openai-codex/gpt-5.6-terra:low
+  plan: openai-codex/gpt-5.6-terra:medium
+  slow: openai-codex/gpt-5.6-terra:high
+  tiny: openai-codex/gpt-5.6-luna:low
+  commit: openai-codex/gpt-5.6-luna:low
+
+retry:
+  enabled: true
+  modelFallback: true
+  fallbackRevertPolicy: cooldown-expiry
+  # Single fast hop across to Haiku; task drains Spark, then Luna, then Haiku.
+  fallbackChains:
+    default: [anthropic/claude-haiku-4-5:low]
+    task: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    plan: [anthropic/claude-sonnet-5:medium]
+    slow: [anthropic/claude-sonnet-5:high]
+    designer: [anthropic/claude-haiku-4-5:low]
+    reviewer: [anthropic/claude-haiku-4-5:low]
+    librarian: [anthropic/claude-haiku-4-5:low]
+
+task:
+  agentModelOverrides:
+    designer: openai-codex/gpt-5.6-terra:low
+    librarian: openai-codex/gpt-5.6-luna:low
+    reviewer: openai-codex/gpt-5.6-terra:low
+    sonic: openai-codex/gpt-5.6-luna:low
+    task: openai-codex/gpt-5.3-codex-spark:low
+
+defaultThinkingLevel: low

--- a/omp/presets/gpt56.yml
+++ b/omp/presets/gpt56.yml
@@ -38,10 +38,10 @@ retry:
     designer: [openai-codex/gpt-5.6-terra:high, anthropic/claude-fable-5:high]
     reviewer: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high]
     librarian: [openai-codex/gpt-5.6-luna:medium, anthropic/claude-sonnet-5:medium]
-    sonic: [openai-codex/gpt-5.4-nano:low]
-    advisor: [openai-codex/gpt-5.4-nano:low]
-    tiny: [openai-codex/gpt-5.4-nano:low]
-    commit: [openai-codex/gpt-5.4-nano:low]
+    sonic: [openai-codex/gpt-5.6-luna:low]
+    advisor: [openai-codex/gpt-5.6-luna:low]
+    tiny: [openai-codex/gpt-5.6-luna:low]
+    commit: [openai-codex/gpt-5.6-luna:low]
 
 task:
   agentModelOverrides:

--- a/omp/presets/gpt56.yml
+++ b/omp/presets/gpt56.yml
@@ -24,20 +24,25 @@ retry:
   enabled: true
   modelFallback: true
   fallbackRevertPolicy: cooldown-expiry
-  # Substantive roles run GPT -> GPT -> Claude (sibling absorbs a blip, last hop
-  # crosses). task leads on Spark, then the old terra/luna worker chain, then
-  # crosses to Sonnet. Background drains Spark, then nano.
+  # Redundancy first: same-provider sibling before the cross (the GPT pair, then
+  # the capability-matched Claude pair), so a single-model outage never leaves
+  # its bucket and chains never route below the lead's tier. Fable is a separate
+  # elite bucket spent deliberately (see ompf/ompc), never an automatic net — so
+  # the Claude side here is main-plan Opus/Sonnet. Spark is the separate drain
+  # bucket, exempt for the same reason; task's Spark tail is unchanged pending
+  # the spark-depth decision, and background stays lean (a blip on trivia is
+  # harmless).
   fallbackChains:
-    default: [openai-codex/gpt-5.6-terra:high, anthropic/claude-fable-5:high]
+    default: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high, anthropic/claude-sonnet-5:high]
     task:
       - openai-codex/gpt-5.6-terra:medium
       - openai-codex/gpt-5.6-luna:medium
       - anthropic/claude-sonnet-5:medium
-    plan: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high]
-    slow: [openai-codex/gpt-5.6-terra:xhigh, anthropic/claude-opus-4-8:xhigh]
-    designer: [openai-codex/gpt-5.6-terra:high, anthropic/claude-fable-5:high]
-    reviewer: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high]
-    librarian: [openai-codex/gpt-5.6-luna:medium, anthropic/claude-sonnet-5:medium]
+    plan: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high, anthropic/claude-sonnet-5:high]
+    slow: [openai-codex/gpt-5.6-terra:xhigh, anthropic/claude-opus-4-8:xhigh, anthropic/claude-sonnet-5:xhigh]
+    designer: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high, anthropic/claude-sonnet-5:high]
+    reviewer: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high, anthropic/claude-sonnet-5:high]
+    librarian: [openai-codex/gpt-5.6-sol:medium, anthropic/claude-sonnet-5:medium, anthropic/claude-opus-4-8:medium]
     sonic: [openai-codex/gpt-5.6-luna:low]
     advisor: [openai-codex/gpt-5.6-luna:low]
     tiny: [openai-codex/gpt-5.6-luna:low]

--- a/omp/presets/mixed-regular.yml
+++ b/omp/presets/mixed-regular.yml
@@ -1,0 +1,47 @@
+# ompn — mixed·regular. A balanced daily driver across both pools at medium
+# thinking: Claude leads judgment (default/designer/reviewer/plan), GPT leads
+# execution (task/librarian/slow), background drains Spark. Full redundancy —
+# every substantive lead carries a same-bucket sibling, then crosses to the
+# capability-matched model on the other provider (+ its sibling).
+modelRoles:
+  default: anthropic/claude-sonnet-5:medium
+  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  smol: openai-codex/gpt-5.6-luna:low
+  task: openai-codex/gpt-5.6-terra:medium
+  sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+  librarian: openai-codex/gpt-5.6-terra:medium
+  designer: anthropic/claude-sonnet-5:high
+  reviewer: anthropic/claude-sonnet-5:high
+  plan: anthropic/claude-opus-4-8:high
+  slow: openai-codex/gpt-5.6-sol:high
+  tiny: openai-codex/gpt-5.3-codex-spark:low
+  commit: openai-codex/gpt-5.3-codex-spark:low
+
+retry:
+  enabled: true
+  modelFallback: true
+  fallbackRevertPolicy: cooldown-expiry
+  # Same-bucket sibling first, then the matched cross (+ its sibling). Background
+  # drains Spark, then Luna, then Haiku.
+  fallbackChains:
+    default: [anthropic/claude-opus-4-8:medium, openai-codex/gpt-5.6-terra:medium, openai-codex/gpt-5.6-sol:medium]
+    task: [openai-codex/gpt-5.6-sol:medium, anthropic/claude-sonnet-5:medium, anthropic/claude-opus-4-8:medium]
+    plan: [anthropic/claude-sonnet-5:high, openai-codex/gpt-5.6-sol:high, openai-codex/gpt-5.6-terra:high]
+    slow: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high, anthropic/claude-sonnet-5:high]
+    designer: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-sol:high]
+    reviewer: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-sol:high]
+    librarian: [openai-codex/gpt-5.6-sol:medium, anthropic/claude-sonnet-5:medium, anthropic/claude-opus-4-8:medium]
+    sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    tiny: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    commit: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+
+task:
+  agentModelOverrides:
+    designer: anthropic/claude-sonnet-5:high
+    librarian: openai-codex/gpt-5.6-terra:medium
+    reviewer: anthropic/claude-sonnet-5:high
+    sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+    task: openai-codex/gpt-5.6-terra:medium
+
+defaultThinkingLevel: medium

--- a/omp/presets/mixed-smart.yml
+++ b/omp/presets/mixed-smart.yml
@@ -1,0 +1,47 @@
+# ompm — mixed·smart. The hardest work, best model per task across both pools at
+# high thinking: Sol drives the GPT-strength roles, Fable/Opus the Claude-strength
+# ones (design, planning, review), Spark drains in the background. Full redundancy
+# on every substantive lead. When only the best will do, from either provider.
+modelRoles:
+  default: openai-codex/gpt-5.6-sol:high
+  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  smol: openai-codex/gpt-5.6-luna:low
+  task: openai-codex/gpt-5.6-sol:high
+  sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+  librarian: openai-codex/gpt-5.6-terra:medium
+  designer: anthropic/claude-fable-5:high
+  reviewer: anthropic/claude-opus-4-8:high
+  plan: anthropic/claude-fable-5:high
+  slow: anthropic/claude-fable-5:xhigh
+  tiny: openai-codex/gpt-5.3-codex-spark:low
+  commit: openai-codex/gpt-5.3-codex-spark:low
+
+retry:
+  enabled: true
+  modelFallback: true
+  fallbackRevertPolicy: cooldown-expiry
+  # Same-bucket sibling first, then the matched cross (+ its sibling). Fable
+  # falls back to main-plan Opus (never an automatic net); background drains
+  # Spark, then Luna, then Haiku.
+  fallbackChains:
+    default: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high, anthropic/claude-sonnet-5:high]
+    task: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high, anthropic/claude-sonnet-5:high]
+    plan: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high, openai-codex/gpt-5.6-terra:high]
+    slow: [anthropic/claude-opus-4-8:xhigh, openai-codex/gpt-5.6-sol:xhigh, openai-codex/gpt-5.6-terra:xhigh]
+    designer: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-sol:high, openai-codex/gpt-5.6-terra:high]
+    reviewer: [anthropic/claude-sonnet-5:high, openai-codex/gpt-5.6-sol:high, openai-codex/gpt-5.6-terra:high]
+    librarian: [openai-codex/gpt-5.6-sol:medium, anthropic/claude-sonnet-5:medium, anthropic/claude-opus-4-8:medium]
+    sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    tiny: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    commit: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+
+task:
+  agentModelOverrides:
+    designer: anthropic/claude-fable-5:high
+    librarian: openai-codex/gpt-5.6-terra:medium
+    reviewer: anthropic/claude-opus-4-8:high
+    sonic: openai-codex/gpt-5.3-codex-spark:xhigh
+    task: openai-codex/gpt-5.6-sol:high
+
+defaultThinkingLevel: high

--- a/omp/presets/sonnet-value.yml
+++ b/omp/presets/sonnet-value.yml
@@ -39,10 +39,13 @@ retry:
     designer: [openai-codex/gpt-5.6-terra:high]
     reviewer: [openai-codex/gpt-5.6-terra:high]
     librarian: [openai-codex/gpt-5.6-luna:medium]
-    sonic: [anthropic/claude-haiku-4-5:low]
-    advisor: [anthropic/claude-haiku-4-5:low]
-    tiny: [anthropic/claude-haiku-4-5:low]
-    commit: [anthropic/claude-haiku-4-5:low]
+    # Spark is a Codex model, so it falls back to a regular GPT rung before
+    # crossing to Haiku — drain the free Spark bucket, then cheap main-Codex
+    # nano, then the Claude plan only if OpenAI is fully down.
+    sonic: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    tiny: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    commit: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
 
 task:
   agentModelOverrides:

--- a/omp/presets/sonnet-value.yml
+++ b/omp/presets/sonnet-value.yml
@@ -42,10 +42,10 @@ retry:
     # Spark is a Codex model, so it falls back to a regular GPT rung before
     # crossing to Haiku — drain the free Spark bucket, then cheap main-Codex
     # nano, then the Claude plan only if OpenAI is fully down.
-    sonic: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
-    advisor: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
-    tiny: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
-    commit: [openai-codex/gpt-5.4-nano:low, anthropic/claude-haiku-4-5:low]
+    sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    tiny: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    commit: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
 
 task:
   agentModelOverrides:

--- a/omp/presets/sonnet-value.yml
+++ b/omp/presets/sonnet-value.yml
@@ -27,21 +27,22 @@ retry:
   enabled: true
   modelFallback: true
   fallbackRevertPolicy: cooldown-expiry
-  # Sonnet has no price-lateral Anthropic sibling (Opus is 2.5x up, Haiku a
-  # class down), so its chains cross straight to Terra/Luna, its OpenAI price
-  # twins. plan/slow lead on Opus and take a Sonnet sibling before crossing.
-  # Background drains Spark, then falls back to Haiku.
+  # Redundancy first: each lead carries a same-provider sibling before any
+  # cross, so a single-model outage never has to leave its own bucket — the
+  # Claude pair (lead + Opus/Sonnet sibling), then the capability-matched Codex
+  # pair (Terra/Sol). Chains never route below the lead's tier. Spark (drain
+  # bucket) and Fable (elite bucket) are separate-quota and never a net here.
   fallbackChains:
-    default: [openai-codex/gpt-5.6-terra:medium]
-    task: [openai-codex/gpt-5.6-terra:medium]
-    plan: [anthropic/claude-sonnet-5:high, openai-codex/gpt-5.6-terra:high]
-    slow: [anthropic/claude-sonnet-5:xhigh, openai-codex/gpt-5.6-terra:xhigh]
-    designer: [openai-codex/gpt-5.6-terra:high]
-    reviewer: [openai-codex/gpt-5.6-terra:high]
-    librarian: [openai-codex/gpt-5.6-luna:medium]
-    # Spark is a Codex model, so it falls back to a regular GPT rung before
-    # crossing to Haiku — drain the free Spark bucket, then cheap main-Codex
-    # nano, then the Claude plan only if OpenAI is fully down.
+    default: [anthropic/claude-opus-4-8:medium, openai-codex/gpt-5.6-terra:medium, openai-codex/gpt-5.6-sol:medium]
+    task: [anthropic/claude-opus-4-8:medium, openai-codex/gpt-5.6-terra:medium, openai-codex/gpt-5.6-sol:medium]
+    plan: [anthropic/claude-sonnet-5:high, openai-codex/gpt-5.6-sol:high, openai-codex/gpt-5.6-terra:high]
+    slow: [anthropic/claude-sonnet-5:xhigh, openai-codex/gpt-5.6-sol:xhigh, openai-codex/gpt-5.6-terra:xhigh]
+    designer: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-sol:high]
+    reviewer: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-sol:high]
+    librarian: [anthropic/claude-opus-4-8:low, openai-codex/gpt-5.6-terra:low, openai-codex/gpt-5.6-sol:low]
+    # Background: drain the free Spark bucket, then a cheap Codex rung, then
+    # Haiku. Left lean on purpose — a blip on background trivia is harmless, and
+    # Spark is a separate drain bucket, not a redundancy target.
     sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
     advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
     tiny: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]

--- a/pkgs/omp-configured/README.md
+++ b/pkgs/omp-configured/README.md
@@ -1,0 +1,63 @@
+# omp-configured — the `code` launcher toolkit
+
+`omp-configured` packages a curated set of [oh-my-pi](https://github.com/can1357/oh-my-pi)
+(`omp`) coding-agent launchers, plus **`code`** — an `fzf` picker that browses them with a
+live model-routing preview and a per-provider usage panel.
+
+## What you get
+
+- **`code`** — an interactive picker over the launcher palette (arrow keys / type to filter).
+  The preview shows each profile's routing (`ctrl-f` cycles depth: lead → net → full chain),
+  the bundled subagents, and a usage panel. Keyboard-driven (`--no-mouse`); `shift-↑/↓` or
+  `alt-↑/↓` scroll the preview.
+- **`omp`** — passthrough to your own **unmanaged** `~/.omp` config (the one mutable base).
+- **`ompz / ompn / ompm / ompl / ompb / ompg / …`** — managed launchers, each pinning an
+  opinionated routing profile (lane × tier) over `omp`. Their routing/policy is **immutable**
+  (Nix-owned); only the bare `omp` is yours to edit freely.
+- **`omph`** — prints the managed routing for every profile.
+- **`ompu`** — a sandboxed launcher for untrusted repositories.
+
+See [`../../omp/PROFILES.md`](../../omp/PROFILES.md) for the catalog and the reasoning behind
+each profile.
+
+## Install it standalone (Nix)
+
+This package is a **flake output**, so it does **not** require the rest of these dotfiles. On
+any machine that has Nix and uses `omp`:
+
+```sh
+nix profile install github:atyrode/dotfiles#omp-configured
+```
+
+That puts `code` and all the `ompX` launchers on your PATH. It's self-contained:
+
+- The profile configs (`defaults.yml`, `presets/*.yml`, `policy.yml`) are **baked into the
+  package** — the managed launchers layer them over your own `omp` automatically.
+- Your bare `omp` keeps using your `~/.omp` config unchanged; the `ompX` profiles are just the
+  suggestions layered on top.
+- The usage panel prefers a private collector snapshot (`$TYRODE_MODEL_USAGE_SNAPSHOT`) and
+  **falls back to `omp usage`** when it's absent, so it works anywhere.
+
+**One coupling to know about:** the package currently bakes a small
+[Herdr](https://herdr.dev) integration extension. If you don't use Herdr it's harmless; a
+fully clean standalone build would drop it (see the roadmap).
+
+## How the managed launchers stay reliable
+
+Each `ompX` launcher runs `omp` with its profile config layered via `--config` at higher
+precedence than your machine config, so ~47 managed paths (model roles, retry/fallback,
+advisor, thinking level, approvals, isolation, …) always resolve to the profile's Nix-owned
+values. Editing them in `~/.omp` — or in a running session — does **not** change the profile;
+the overlay wins on every launch. To change a profile, edit the dotfiles and reapply; to
+change the bare `omp`, edit `~/.omp`.
+
+## In these dotfiles
+
+Normally consumed via the Home-Manager module in
+[`../../modules/home/agent-tools.nix`](../../modules/home/agent-tools.nix), which installs the
+launchers and wires the supporting config. The standalone `nix profile install` path above is
+for sharing the toolkit with others without adopting the whole dotfiles.
+
+**Roadmap** (portability, provider-availability awareness, a usage/reset-aware profile
+recommender, an HTML profiles wiki, advisor redesign): see the "code launcher roadmap" tracker
+issue in the repo.

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -4,6 +4,7 @@
   coreutils,
   findutils,
   fzf,
+  gawk,
   gitMinimal,
   gnugrep,
   jq,
@@ -56,6 +57,7 @@ let
     sonnet = ../../omp/presets/sonnet-value.yml;
     claude = ../../omp/presets/claude-hard.yml;
     context = ../../omp/presets/context-1m.yml;
+    fast = ../../omp/presets/fast-mixed.yml;
   };
 
   managedDefaultPaths = [
@@ -986,47 +988,55 @@ let
   ompGpt = mkOmpCommand "ompg" [ presets.gpt ];
   ompClaude = mkOmpCommand "ompc" [ presets.claude ];
   ompContext = mkOmpCommand "ompx" [ presets.context ];
+  ompFast = mkOmpCommand "ompz" [ presets.fast ];
 
-  # Single source of truth for the launcher palette. The `code` picker lists
-  # every entry; `omph` renders the role -> model routing for the preset-backed
-  # ones (those carrying a `preset`). `omp` and `ompu` are special builders, so
-  # they appear in the picker but not in the routing view.
+  # Single source of truth for the launcher palette, ordered into soft groups
+  # (mixed, then gpt-led, then claude-led, then specialists) and faster -> smarter
+  # within each. The `code` picker lists every entry and labels the groups; `omph`
+  # renders the routing for the preset-backed ones (those carrying a `preset`).
+  # `omp`/`ompu` are special builders (no preset), shown in the picker only.
   paletteProfiles = [
     {
-      cmd = "omp";
-      exe = lib.getExe ompDefault;
-      lead = "yours";
-      blurb = "Your mutable daily driver (unmanaged)";
-      detail = "Runs upstream OMP with whatever your writable ~/.omp config selects. No managed defaults, preset, or policy overlay beyond the blocked update.";
+      cmd = "ompz";
+      exe = lib.getExe ompFast;
+      lead = "mixed";
+      group = "mix";
+      blurb = "Fast, mixed, latency-first";
+      detail = "The fastest competent tiers across both providers at low thinking (Luna/nano/Spark + Sonnet/Haiku), with light single-hop fallbacks. For snappy interactive work; nothing reaches for Sol/Fable/Opus. Mixed pool.";
+      preset = presets.fast;
     }
     {
       cmd = "ompb";
       exe = lib.getExe ompBudget;
       lead = "openai";
+      group = "gpt";
       blurb = "Cost-conscious routine work";
       detail = "Terra/Luna lead at low thinking; every background role rides gpt-5.4-nano (~5x under Luna). Only the live thread and task worker get a net. Advisor, branch summaries, and autolearn off.";
       preset = presets.budget;
     }
     {
-      cmd = "omps";
-      exe = lib.getExe ompSonnet;
-      lead = "claude";
-      blurb = "Everyday value, Sonnet-led";
-      detail = "Sonnet 5 (intro pricing) leads all but plan/slow, where Opus earns its leverage. Haiku carries background. Chains cross to Terra, Sonnet's price-twin. All-Anthropic pool; features on.";
-      preset = presets.sonnet;
-    }
-    {
       cmd = "ompg";
       exe = lib.getExe ompGpt;
       lead = "openai";
+      group = "gpt";
       blurb = "Difficult work, GPT-led";
       detail = "Sol leads the deliberative roles; a GPT sibling absorbs a capacity blip, then every substantive chain crosses to Fable/Opus. commit/tiny on nano. All-OpenAI lead pool.";
       preset = presets.gpt;
     }
     {
+      cmd = "omps";
+      exe = lib.getExe ompSonnet;
+      lead = "claude";
+      group = "claude";
+      blurb = "Everyday value, Sonnet-led";
+      detail = "Sonnet 5 (intro pricing) leads all but plan/slow, where Opus earns its leverage. Haiku carries background. Chains cross to Terra, Sonnet's price-twin. All-Anthropic pool; features on.";
+      preset = presets.sonnet;
+    }
+    {
       cmd = "ompc";
       exe = lib.getExe ompClaude;
       lead = "claude";
+      group = "claude";
       blurb = "Difficult work, Claude-led";
       detail = "ompg's mirror. Fable drives, Opus is the sibling (and leads review), Sonnet/Haiku carry workers, every chain reaches back to Sol/Terra. Load this when OpenAI is dark or Codex credits are spent.";
       preset = presets.claude;
@@ -1035,14 +1045,24 @@ let
       cmd = "ompf";
       exe = lib.getExe ompFable;
       lead = "claude";
+      group = "claude";
       blurb = "Fable-first, deterministic routing";
       detail = "Fable for the primary and deliberative roles with retry and server-side fallback OFF. The contract is: give me Fable, predictably, never silently swap. Background on cheap OpenAI rungs.";
       preset = presets.fable;
     }
     {
+      cmd = "omp";
+      exe = lib.getExe ompDefault;
+      lead = "yours";
+      group = "special";
+      blurb = "Your mutable daily driver (unmanaged)";
+      detail = "Runs upstream OMP with whatever your writable ~/.omp config selects. No managed defaults, preset, or policy overlay beyond the blocked update.";
+    }
+    {
       cmd = "ompx";
       exe = lib.getExe ompContext;
       lead = "claude";
+      group = "special";
       blurb = "Huge-context (1M) work";
       detail = "For work beyond 372K. Fable/Opus/Sonnet lead (Anthropic owns 1M); gpt-5.4 is the only OpenAI 1M card, used as the cross-net and librarian lead. Haiku (200K) only touches background trivia.";
       preset = presets.context;
@@ -1051,6 +1071,7 @@ let
       cmd = "ompu";
       exe = lib.getExe ompUntrusted;
       lead = "untrusted";
+      group = "special";
       blurb = "Untrusted repositories (isolated)";
       detail = "Dedicated sanitized state, stripped credentials, restricted tools and approvals for deliberately untrusted repositories. Inherits the managed defaults routing.";
     }
@@ -1294,6 +1315,7 @@ let
       jq
       coreutils
       fzf
+      gawk
     ];
     text = ''
       omp_bin=${lib.escapeShellArg (lib.getExe omp)}
@@ -1303,12 +1325,14 @@ let
       blurbs=( ${lib.escapeShellArgs (map (p: p.blurb) paletteProfiles)} )
       details=( ${lib.escapeShellArgs (map (p: p.detail) paletteProfiles)} )
       exes=( ${lib.escapeShellArgs (map (p: p.exe) paletteProfiles)} )
+      groups=( ${lib.escapeShellArgs (map (p: p.group) paletteProfiles)} )
       count=''${#names[@]}
       show_usage_panel=1
 
       # Nerd Font glyphs by precise codepoint (FontAwesome range, in every Nerd
       # Font) and 24-bit truecolor accents, used by the fzf picker.
       esc=$(printf '\033')
+      g_mixed=$(printf '')  # random / shuffle (mixed pool)
       g_openai=$(printf '')     # bolt
       g_claude=$(printf '')     # lightbulb
       g_yours=$(printf '')      # user
@@ -1319,6 +1343,7 @@ let
       c_claude="''${esc}[38;2;255;159;82m"
       c_yours="''${esc}[38;2;120;200;170m"
       c_untrusted="''${esc}[38;2;230;130;90m"
+      c_mixed="''${esc}[38;2;170;150;225m"
       c_dim="''${esc}[38;2;120;130;145m"
       c_ok="''${esc}[38;2;80;200;120m"
       c_warn="''${esc}[38;2;235;120;90m"
@@ -1335,12 +1360,28 @@ let
         esac
       }
 
-      # Fill the `palette` array with one plain-ASCII line per launcher.
+      group_label() {
+        case "$1" in
+          mix) printf 'mixed' ;;
+          gpt) printf 'gpt-led' ;;
+          claude) printf 'claude-led' ;;
+          special) printf 'specialists' ;;
+          *) printf '%s' "$1" ;;
+        esac
+      }
+
+      # Fill the `palette` array with one plain-ASCII line per launcher, split
+      # into soft groups with a header before each.
       palette=()
       build_palette() {
         palette=( "OMP launchers" "" )
-        local i
+        local i last_group=""
         for (( i = 0; i < count; i++ )); do
+          if [[ "''${groups[$i]}" != "$last_group" ]]; then
+            [[ -n "$last_group" ]] && palette+=( "" )
+            palette+=( "  $(group_label "''${groups[$i]}")" )
+            last_group="''${groups[$i]}"
+          fi
           palette+=( "$(printf '  %d) %-5s %-11s %s' \
             "$(( i + 1 ))" "''${names[$i]}" "$(lead_tag "''${leads[$i]}")" "''${blurbs[$i]}")" )
         done
@@ -1479,6 +1520,7 @@ let
         case "$1" in
           openai) printf '%s' "$g_openai" ;;
           claude) printf '%s' "$g_claude" ;;
+          mixed) printf '%s' "$g_mixed" ;;
           yours) printf '%s' "$g_yours" ;;
           untrusted) printf '%s' "$g_untrusted" ;;
           *) printf ' ' ;;
@@ -1488,16 +1530,45 @@ let
         case "$1" in
           openai) printf '%s' "$c_openai" ;;
           claude) printf '%s' "$c_claude" ;;
+          mixed) printf '%s' "$c_mixed" ;;
           yours) printf '%s' "$c_yours" ;;
           untrusted) printf '%s' "$c_untrusted" ;;
           *) printf '%s' "$c_dim" ;;
         esac
       }
 
+      # Recolour model tokens in a routing block: provider hue (muted blue for
+      # OpenAI, muted orange for Anthropic) with brightness scaled by the
+      # thinking level, so low -> xhigh reads as dim -> bright.
+      colorize_routes() {
+        gawk -v dim="$c_dim" '
+          function lvl(l) { return l=="minimal"?0:l=="low"?1:l=="medium"?2:l=="high"?3:l=="xhigh"?4:5 }
+          function clamp(x) { return x>255?255:(x<0?0:int(x)) }
+          function paint(tok,   idx, level, f, br, bg, bb) {
+            idx = match(tok, /:(minimal|low|medium|high|xhigh|max)$/)
+            if (idx == 0) return tok
+            level = substr(tok, idx + 1)
+            if (tok ~ /^gpt/) { br = 110; bg = 170; bb = 240 }
+            else if (tok ~ /^claude/) { br = 240; bg = 160; bb = 105 }
+            else return tok
+            f = 0.60 + lvl(level) * 0.088
+            return sprintf("\033[38;2;%d;%d;%dm%s%s", clamp(br*f), clamp(bg*f), clamp(bb*f), tok, dim)
+          }
+          {
+            line = $0; out = ""
+            while (match(line, /(gpt|claude)[A-Za-z0-9._-]*:(minimal|low|medium|high|xhigh|max)/)) {
+              out = out substr(line, 1, RSTART - 1) paint(substr(line, RSTART, RLENGTH))
+              line = substr(line, RSTART + RLENGTH)
+            }
+            print out line
+          }
+        '
+      }
+
       # Arrow-key picker via fzf: a truecolor list with Nerd Font provider
-      # glyphs at the top, the usage panel in the footer, and each profile's
-      # detail + live role -> model routing in the preview. Sets picked_idx, or
-      # leaves it empty when cancelled.
+      # glyphs and soft group labels at the top, the usage panel in the footer,
+      # and each profile's detail + colourised role -> model routing in the
+      # preview. Sets picked_idx, or leaves it empty when cancelled.
       picked_idx=""
       fzf_pick() {
         picked_idx=""
@@ -1511,20 +1582,30 @@ let
         fi
         local prevdir
         prevdir="$(mktemp -d)"
-        local i col gly rows="" block
+        local i col gly rows="" block glabel labelcol last_group=""
         for (( i = 0; i < count; i++ )); do
           col="$(lead_color "''${leads[$i]}")"
           gly="$(lead_glyph "''${leads[$i]}")"
-          rows+="$(printf '%s\t%s%s%s  %s%-5s%s  %s%s%s' \
-            "''${names[$i]}" "$col" "$gly" "$c_rst" \
-            "$c_bold" "''${names[$i]}" "$c_rst" "$c_dim" "''${blurbs[$i]}" "$c_rst")"$'\n'
+          glabel=""
+          if [[ "''${groups[$i]}" != "$last_group" ]]; then
+            glabel="$(group_label "''${groups[$i]}")"
+            last_group="''${groups[$i]}"
+          fi
+          labelcol="$(printf '%-10s' "$glabel")"
+          rows+="$(printf '%s\t%s%s%s  %s%s%s  %s%-5s%s  %s%s%s' \
+            "''${names[$i]}" \
+            "$c_dim" "$labelcol" "$c_rst" \
+            "$col" "$gly" "$c_rst" \
+            "$c_bold" "''${names[$i]}" "$c_rst" \
+            "$c_dim" "''${blurbs[$i]}" "$c_rst")"$'\n'
           {
             printf '%s%s  %s%s%s\n\n' "$col" "$gly" "$c_bold" "''${names[$i]}" "$c_rst"
             printf '%s%s%s\n\n' "$c_dim" "''${blurbs[$i]}" "$c_rst"
             printf '%s\n' "''${details[$i]}"
             if [[ -f "$routes_plain" ]]; then
               block="$(sed -n "/^''${names[$i]}  /,/^\$/p" "$routes_plain")"
-              [[ -n "$block" ]] && printf '\n%s%s%s\n' "$c_dim" "$block" "$c_rst"
+              [[ -n "$block" ]] && printf '\n%s%s%s\n' \
+                "$c_dim" "$(printf '%s' "$block" | colorize_routes)" "$c_rst"
             fi
           } > "$prevdir/''${names[$i]}"
         done
@@ -1709,6 +1790,7 @@ runCommand "omp-configured-${lib.getVersion omp}"
     ln -s ${lib.getExe ompClaude} "$out/bin/ompc"
     ln -s ${lib.getExe ompFable} "$out/bin/ompf"
     ln -s ${lib.getExe ompContext} "$out/bin/ompx"
+    ln -s ${lib.getExe ompFast} "$out/bin/ompz"
     ln -s ${lib.getExe ompHelp} "$out/bin/omph"
     ln -s ${lib.getExe ompUntrusted} "$out/bin/ompu"
     ln -s ${lib.getExe codeLauncher} "$out/bin/code"

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1332,6 +1332,7 @@ let
       # Nerd Font glyphs by precise codepoint (FontAwesome range, in every Nerd
       # Font) and 24-bit truecolor accents, used by the fzf picker.
       esc=$(printf '\033')
+      g_reset=$(printf '')  # refresh (time until reset)
       g_mixed=$(printf '')  # random / shuffle (mixed pool)
       g_openai=$(printf '')     # bolt
       g_claude=$(printf '')     # lightbulb
@@ -1432,6 +1433,16 @@ let
       # Fill the `usagep` array with a compact per-provider quota panel from
       # `omp usage --json`. Best-effort: on any failure (offline, timeout, not
       # authed, --no-usage) it is left empty and the picker shows just the list.
+      fmt_reset() {
+        local s="$1"
+        (( s < 0 )) && s=0
+        if (( s >= 86400 )); then printf '%dd%dh' "$(( s / 86400 ))" "$(( (s % 86400) / 3600 ))"
+        elif (( s >= 3600 )); then printf '%dh%dm' "$(( s / 3600 ))" "$(( (s % 3600) / 60 ))"
+        else printf '%dm' "$(( s / 60 ))"; fi
+      }
+
+      # Per-provider quota panel: a coloured provider header, then each window's
+      # bar, percent used, and time until reset. No redundant "usage" label.
       usagep=()
       build_usage() {
         usagep=()
@@ -1440,37 +1451,30 @@ let
         json="$(timeout 8 "$omp_bin" usage --json 2>/dev/null)" || return 0
         [[ -n "$json" ]] || return 0
         rows="$(printf '%s' "$json" | jq -r '
-            ( "HDR\t" + ((now - (.generatedAt / 1000)) | floor | tostring) ),
-            ( .reports[] | .provider as $p | .limits[]
-              | "ROW\t" + $p + "\t" + .label + "\t"
-                + ((.amount.usedFraction * 100) | round | tostring) + "\t"
-                + (.scope.tier // "-") )
+            .reports[] | .provider as $p | .limits[]
+            | $p + "\t" + .label + "\t"
+              + ((.amount.usedFraction * 100) | round | tostring) + "\t"
+              + (.scope.tier // "-") + "\t"
+              + (((.window.resetsAt / 1000) - now) | floor | tostring)
           ' 2>/dev/null)" || return 0
         [[ -n "$rows" ]] || return 0
-        local kind a b c d last_provider="" pname when note
-        while IFS=$'\t' read -r kind a b c d; do
-          case "$kind" in
-            HDR)
-              if (( a >= 60 )); then when="$(( a / 60 ))m ago"; else when="''${a}s ago"; fi
-              usagep+=( "usage · $when" "" )
-              ;;
-            ROW)
-              case "$a" in
-                openai-codex) pname="Codex" ;;
-                anthropic) pname="Claude" ;;
-                *) pname="$a" ;;
-              esac
-              if [[ "$a" != "$last_provider" ]]; then
-                usagep+=( "$pname" )
-                last_provider="$a"
-              fi
-              note=""
-              (( c >= 80 )) && note=" · ''${c_warn}tight''${c_rst}"
-              [[ "$d" == spark && "$c" -eq 0 ]] && note=" · ''${c_ok}free''${c_rst}"
-              usagep+=( "$(printf '  %-8s %s %3d%% used%s' \
-                "$(short_window "$b")" "$(bar "$c")" "$c" "$note")" )
-              ;;
+        local a b c d e last_provider="" pname pcol note
+        while IFS=$'\t' read -r a b c d e; do
+          case "$a" in
+            openai-codex) pname="Codex"; pcol="$c_openai" ;;
+            anthropic) pname="Claude"; pcol="$c_claude" ;;
+            *) pname="$a"; pcol="$c_dim" ;;
           esac
+          if [[ "$a" != "$last_provider" ]]; then
+            usagep+=( "''${pcol}''${c_bold}$pname''${c_rst}" )
+            last_provider="$a"
+          fi
+          note=""
+          (( c >= 80 )) && note="  ''${c_warn}tight''${c_rst}"
+          [[ "$d" == spark && "$c" -eq 0 ]] && note="  ''${c_ok}free''${c_rst}"
+          usagep+=( "$(printf '  %-8s %s %3d%% used  %s%s %s%s%s' \
+            "$(short_window "$b")" "$(bar "$c")" "$c" \
+            "$c_dim" "$g_reset" "$(fmt_reset "$e")" "$c_rst" "$note")" )
         done <<< "$rows"
       }
 
@@ -1544,7 +1548,7 @@ let
       # level (low -> xhigh reads as dim -> bright). Kept narrow so fzf's preview
       # (nowrap) never has to wrap ANSI lines, which it renders incorrectly.
       colorize_routes() {
-        gawk -v dim="$c_dim" '
+        gawk -v dim="$c_dim" -v ok="$c_ok" -v bold="$c_bold" -v rst="$c_rst" '
           function lvl(l) { return l=="minimal"?0:l=="low"?1:l=="medium"?2:l=="high"?3:l=="xhigh"?4:5 }
           function clamp(x) { return x>255?255:(x<0?0:int(x)) }
           function short(name,   a, n) {
@@ -1565,6 +1569,15 @@ let
           }
           {
             line = $0
+            # Reformat the metadata line: bold the thinking level, green/dim the
+            # on/off states, so it parses at a glance.
+            if (line ~ /^  thinking .* fallback /) {
+              match(line, /thinking ([a-z]+)/, m); tl = m[1]
+              fb = (line ~ /fallback enabled/) ? "on" : "off"; fbc = (fb == "on") ? ok : dim
+              ad = (line ~ /advisor on/) ? "on" : "off"; adc = (ad == "on") ? ok : dim
+              print dim "  thinking " bold tl rst dim "    fallback " fbc fb dim "    advisor " adc ad rst
+              next
+            }
             gsub(/ +→/, " →", line)
             out = ""
             # paint() calls match() internally, which clobbers RSTART/RLENGTH, so

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1653,7 +1653,7 @@ let
           --border-label=" code $g_point pick a launcher " \
           --prompt="$g_search  " --pointer="$g_point" --marker='+' --info=inline \
           --delimiter=$'\t' --with-nth=2 \
-          --preview="cat $prevdir/{1}" --preview-window='right:52%:nowrap:border-left' \
+          --preview="cat $prevdir/{1}" --preview-window='right:52%:wrap:border-left' \
           "''${footer_args[@]}" \
           --color="$theme" || true)"
         rm -rf "$prevdir"

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1348,6 +1348,7 @@ let
       c_dim="''${esc}[38;2;120;130;145m"
       c_ok="''${esc}[38;2;80;200;120m"
       c_warn="''${esc}[38;2;235;120;90m"
+      c_near="''${esc}[38;2;235;238;242m"
       c_bold="''${esc}[1m"
       c_rst="''${esc}[0m"
 
@@ -1441,6 +1442,15 @@ let
         else printf '%dm' "$(( s / 60 ))"; fi
       }
 
+      # Nearer resets stand out: bold + bright under an hour, bright under four
+      # hours, dim beyond that.
+      reset_style() {
+        local s="$1"
+        if (( s < 3600 )); then printf '%s%s' "$c_bold" "$c_near"
+        elif (( s < 14400 )); then printf '%s' "$c_near"
+        else printf '%s' "$c_dim"; fi
+      }
+
       # Per-provider quota panel: a coloured provider header, then each window's
       # bar, percent used, and time until reset. No redundant "usage" label.
       usagep=()
@@ -1471,10 +1481,10 @@ let
           fi
           note=""
           (( c >= 80 )) && note="  ''${c_warn}tight''${c_rst}"
-          [[ "$d" == spark && "$c" -eq 0 ]] && note="  ''${c_ok}free''${c_rst}"
+          [[ "$d" == spark && "$c" -eq 0 ]] && note="  ''${c_ok}idle''${c_rst}"
           usagep+=( "$(printf '  %-8s %s %3d%% used  %s%s %s%s%s' \
             "$(short_window "$b")" "$(bar "$c")" "$c" \
-            "$c_dim" "$g_reset" "$(fmt_reset "$e")" "$c_rst" "$note")" )
+            "$(reset_style "$e")" "$g_reset" "$(fmt_reset "$e")" "$c_rst" "$note")" )
         done <<< "$rows"
       }
 

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -3,6 +3,7 @@
   cacert,
   coreutils,
   findutils,
+  fzf,
   gitMinimal,
   gnugrep,
   jq,
@@ -1292,9 +1293,11 @@ let
     runtimeInputs = [
       jq
       coreutils
+      fzf
     ];
     text = ''
       omp_bin=${lib.escapeShellArg (lib.getExe omp)}
+      routes_plain=${routesHelp}/share/omp/routes.plain
       names=( ${lib.escapeShellArgs (map (p: p.cmd) paletteProfiles)} )
       leads=( ${lib.escapeShellArgs (map (p: p.lead) paletteProfiles)} )
       blurbs=( ${lib.escapeShellArgs (map (p: p.blurb) paletteProfiles)} )
@@ -1302,6 +1305,25 @@ let
       exes=( ${lib.escapeShellArgs (map (p: p.exe) paletteProfiles)} )
       count=''${#names[@]}
       show_usage_panel=1
+
+      # Nerd Font glyphs by precise codepoint (FontAwesome range, in every Nerd
+      # Font) and 24-bit truecolor accents, used by the fzf picker.
+      esc=$(printf '\033')
+      g_openai=$(printf '')     # bolt
+      g_claude=$(printf '')     # lightbulb
+      g_yours=$(printf '')      # user
+      g_untrusted=$(printf '')  # lock
+      g_point=$(printf '')      # chevron-right
+      g_search=$(printf '')     # search
+      c_openai="''${esc}[38;2;98;167;255m"
+      c_claude="''${esc}[38;2;255;159;82m"
+      c_yours="''${esc}[38;2;120;200;170m"
+      c_untrusted="''${esc}[38;2;230;130;90m"
+      c_dim="''${esc}[38;2;120;130;145m"
+      c_ok="''${esc}[38;2;80;200;120m"
+      c_warn="''${esc}[38;2;235;120;90m"
+      c_bold="''${esc}[1m"
+      c_rst="''${esc}[0m"
 
       lead_tag() {
         case "$1" in
@@ -1335,15 +1357,34 @@ let
         esac
       }
 
+      # Green (low use) -> red (near capacity), as an "r;g;b" triple.
+      bar_rgb() {
+        local p="$1" r g
+        if (( p <= 50 )); then
+          r=$(( 90 + p * 3 ))
+          g=200
+        else
+          r=235
+          g=$(( 200 - (p - 50) * 3 ))
+        fi
+        (( r > 235 )) && r=235
+        (( g < 60 )) && g=60
+        printf '%d;%d;70' "$r" "$g"
+      }
+
+      # A 10-cell bar: filled cells in the usage gradient, empty cells dim.
       bar() {
         local pct="$1"
         local fill=$(( (pct * 10 + 50) / 100 ))
-        local k out=""
         (( fill > 10 )) && fill=10
         (( fill < 0 )) && fill=0
-        for (( k = 0; k < 10; k++ )); do
-          if (( k < fill )); then out+='█'; else out+='░'; fi
-        done
+        local k rgb
+        rgb="$(bar_rgb "$pct")"
+        local out="''${esc}[38;2;''${rgb}m"
+        for (( k = 0; k < fill; k++ )); do out+='█'; done
+        out+="$c_dim"
+        for (( k = fill; k < 10; k++ )); do out+='░'; done
+        out+="$c_rst"
         printf '%s' "$out"
       }
 
@@ -1383,9 +1424,9 @@ let
                 last_provider="$a"
               fi
               note=""
-              (( c >= 80 )) && note=" tight"
-              [[ "$d" == spark && "$c" -eq 0 ]] && note=" free"
-              usagep+=( "$(printf '  %-8s %s %3d%%%s' \
+              (( c >= 80 )) && note=" · ''${c_warn}tight''${c_rst}"
+              [[ "$d" == spark && "$c" -eq 0 ]] && note=" · ''${c_ok}free''${c_rst}"
+              usagep+=( "$(printf '  %-8s %s %3d%% used%s' \
                 "$(short_window "$b")" "$(bar "$c")" "$c" "$note")" )
               ;;
           esac
@@ -1432,6 +1473,81 @@ let
         local i="$1"
         printf '\n  %s  %s\n  %s\n\n' \
           "''${names[$i]}" "$(lead_tag "''${leads[$i]}")" "''${details[$i]}"
+      }
+
+      lead_glyph() {
+        case "$1" in
+          openai) printf '%s' "$g_openai" ;;
+          claude) printf '%s' "$g_claude" ;;
+          yours) printf '%s' "$g_yours" ;;
+          untrusted) printf '%s' "$g_untrusted" ;;
+          *) printf ' ' ;;
+        esac
+      }
+      lead_color() {
+        case "$1" in
+          openai) printf '%s' "$c_openai" ;;
+          claude) printf '%s' "$c_claude" ;;
+          yours) printf '%s' "$c_yours" ;;
+          untrusted) printf '%s' "$c_untrusted" ;;
+          *) printf '%s' "$c_dim" ;;
+        esac
+      }
+
+      # Arrow-key picker via fzf: a truecolor list with Nerd Font provider
+      # glyphs at the top, the usage panel in the footer, and each profile's
+      # detail + live role -> model routing in the preview. Sets picked_idx, or
+      # leaves it empty when cancelled.
+      picked_idx=""
+      fzf_pick() {
+        picked_idx=""
+        build_usage
+        local footer=""
+        local -a footer_args=()
+        if (( ''${#usagep[@]} > 0 )); then
+          printf -v footer '%s\n' "''${usagep[@]}"
+          footer="''${footer%$'\n'}"
+          footer_args=( --footer="$footer" --footer-border=top )
+        fi
+        local prevdir
+        prevdir="$(mktemp -d)"
+        local i col gly rows="" block
+        for (( i = 0; i < count; i++ )); do
+          col="$(lead_color "''${leads[$i]}")"
+          gly="$(lead_glyph "''${leads[$i]}")"
+          rows+="$(printf '%s\t%s%s%s  %s%-5s%s  %s%s%s' \
+            "''${names[$i]}" "$col" "$gly" "$c_rst" \
+            "$c_bold" "''${names[$i]}" "$c_rst" "$c_dim" "''${blurbs[$i]}" "$c_rst")"$'\n'
+          {
+            printf '%s%s  %s%s%s\n\n' "$col" "$gly" "$c_bold" "''${names[$i]}" "$c_rst"
+            printf '%s%s%s\n\n' "$c_dim" "''${blurbs[$i]}" "$c_rst"
+            printf '%s\n' "''${details[$i]}"
+            if [[ -f "$routes_plain" ]]; then
+              block="$(sed -n "/^''${names[$i]}  /,/^\$/p" "$routes_plain")"
+              [[ -n "$block" ]] && printf '\n%s%s%s\n' "$c_dim" "$block" "$c_rst"
+            fi
+          } > "$prevdir/''${names[$i]}"
+        done
+        local theme chosen cmd
+        theme='fg:-1,bg:-1,fg+:#ffffff,bg+:#1b212b,hl:#62a7ff,hl+:#8ec7ff'
+        theme+=',pointer:#ff9f52,marker:#ff9f52,prompt:#ff9f52,spinner:#ff9f52'
+        theme+=',border:#3a4453,label:#9aa4b1,info:#69727e'
+        theme+=',footer:#9aa4b1,footer-border:#3a4453'
+        theme+=',gutter:-1,preview-border:#3a4453'
+        chosen="$(printf '%s' "$rows" | fzf \
+          --ansi --layout=reverse --height=100% --border=rounded \
+          --border-label=" code $g_point pick a launcher " \
+          --prompt="$g_search  " --pointer="$g_point" --marker='+' --info=inline \
+          --delimiter=$'\t' --with-nth=2 \
+          --preview="cat $prevdir/{1}" --preview-window='right:50%:wrap:border-left' \
+          "''${footer_args[@]}" \
+          --color="$theme" || true)"
+        rm -rf "$prevdir"
+        cmd="''${chosen%%$'\t'*}"
+        [[ -n "$cmd" ]] || return 0
+        for (( i = 0; i < count; i++ )); do
+          [[ "''${names[$i]}" == "$cmd" ]] && { picked_idx="$i"; return 0; }
+        done
       }
 
       # Print a 0-based index for a selector, or return non-zero when unmatched.
@@ -1515,6 +1631,14 @@ let
         printf 'code: no profile given and no interactive terminal.\n\n' >&2
         printf '%s\n' "''${palette[@]}" >&2
         exit 2
+      fi
+
+      # Prefer the fzf arrow-key picker; fall back to the typed menu when fzf is
+      # unavailable or CODE_NO_FZF is set.
+      if command -v fzf >/dev/null 2>&1 && [[ -z "''${CODE_NO_FZF:-}" ]]; then
+        fzf_pick
+        [[ -n "$picked_idx" ]] && exec "''${exes[$picked_idx]}" "$@"
+        exit 0
       fi
 
       render_screen

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1366,7 +1366,7 @@ let
           mix) printf 'mixed' ;;
           gpt) printf 'gpt-led' ;;
           claude) printf 'claude-led' ;;
-          special) printf 'specialists' ;;
+          special) printf 'special' ;;
           *) printf '%s' "$1" ;;
         esac
       }
@@ -1548,7 +1548,7 @@ let
       # level (low -> xhigh reads as dim -> bright). Kept narrow so fzf's preview
       # (nowrap) never has to wrap ANSI lines, which it renders incorrectly.
       colorize_routes() {
-        gawk -v dim="$c_dim" -v ok="$c_ok" -v bold="$c_bold" -v rst="$c_rst" '
+        gawk -v dim="$c_dim" '
           function lvl(l) { return l=="minimal"?0:l=="low"?1:l=="medium"?2:l=="high"?3:l=="xhigh"?4:5 }
           function clamp(x) { return x>255?255:(x<0?0:int(x)) }
           function short(name,   a, n) {
@@ -1569,15 +1569,11 @@ let
           }
           {
             line = $0
-            # Reformat the metadata line: bold the thinking level, green/dim the
-            # on/off states, so it parses at a glance.
-            if (line ~ /^  thinking .* fallback /) {
-              match(line, /thinking ([a-z]+)/, m); tl = m[1]
-              fb = (line ~ /fallback enabled/) ? "on" : "off"; fbc = (fb == "on") ? ok : dim
-              ad = (line ~ /advisor on/) ? "on" : "off"; adc = (ad == "on") ? ok : dim
-              print dim "  thinking " bold tl rst dim "    fallback " fbc fb dim "    advisor " adc ad rst
-              next
-            }
+            # Drop the redundant profile header (col 0) — the preview shows the
+            # name/blurb itself — and the profile-level thinking/fallback/advisor
+            # line, which is redundant with the per-role levels and chains.
+            if (line ~ /^[a-z]/) next
+            if (line ~ /thinking .* fallback/) next
             gsub(/ +→/, " →", line)
             out = ""
             # paint() calls match() internally, which clobbers RSTART/RLENGTH, so
@@ -1618,7 +1614,7 @@ let
             glabel="$(group_label "''${groups[$i]}")"
             last_group="''${groups[$i]}"
           fi
-          labelcol="$(printf '%-10s' "$glabel")"
+          labelcol="$(printf '%-11s' "$glabel")"
           rows+="$(printf '%s\t%s%s%s  %s%s%s  %s%-5s%s  %s%s%s' \
             "''${names[$i]}" \
             "$c_dim" "$labelcol" "$c_rst" \
@@ -1626,13 +1622,13 @@ let
             "$c_bold" "''${names[$i]}" "$c_rst" \
             "$c_dim" "''${blurbs[$i]}" "$c_rst")"$'\n'
           {
-            printf '%s%s  %s%s%s\n\n' "$col" "$gly" "$c_bold" "''${names[$i]}" "$c_rst"
-            printf '%s%s%s\n\n' "$c_dim" "''${blurbs[$i]}" "$c_rst"
-            printf '%s\n' "''${details[$i]}"
+            printf '%s%s %s%s%s\n' "$col" "$gly" "$c_bold" "''${names[$i]}" "$c_rst"
+            printf '%s%s%s\n\n' "$col" "''${blurbs[$i]}" "$c_rst"
+            printf '%s%s%s\n' "$c_dim" "''${details[$i]}" "$c_rst"
             if [[ -f "$routes_plain" ]]; then
-              block="$(sed -n "/^''${names[$i]}  /,/^\$/p" "$routes_plain")"
-              [[ -n "$block" ]] && printf '\n%s%s%s\n' \
-                "$c_dim" "$(printf '%s' "$block" | colorize_routes)" "$c_rst"
+              block="$(sed -n "/^''${names[$i]}  /,/^\$/p" "$routes_plain" | colorize_routes)"
+              [[ -n "$block" ]] && printf '\n%s── routing ────────────────%s\n%s%s%s\n' \
+                "$c_dim" "$c_rst" "$c_dim" "$block" "$c_rst"
             fi
           } > "$prevdir/''${names[$i]}"
         done

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -58,6 +58,12 @@ let
     claude = ../../omp/presets/claude-hard.yml;
     context = ../../omp/presets/context-1m.yml;
     fast = ../../omp/presets/fast-mixed.yml;
+    gptSpeed = ../../omp/presets/gpt-speed.yml;
+    claudeSpeed = ../../omp/presets/claude-speed.yml;
+    mixedRegular = ../../omp/presets/mixed-regular.yml;
+    mixedSmart = ../../omp/presets/mixed-smart.yml;
+    gptOnly = ../../omp/presets/gpt-only.yml;
+    claudeOnly = ../../omp/presets/claude-only.yml;
   };
 
   managedDefaultPaths = [
@@ -989,6 +995,12 @@ let
   ompClaude = mkOmpCommand "ompc" [ presets.claude ];
   ompContext = mkOmpCommand "ompx" [ presets.context ];
   ompFast = mkOmpCommand "ompz" [ presets.fast ];
+  ompGptSpeed = mkOmpCommand "ompl" [ presets.gptSpeed ];
+  ompClaudeSpeed = mkOmpCommand "ompk" [ presets.claudeSpeed ];
+  ompMixedRegular = mkOmpCommand "ompn" [ presets.mixedRegular ];
+  ompMixedSmart = mkOmpCommand "ompm" [ presets.mixedSmart ];
+  ompGptOnly = mkOmpCommand "ompo" [ presets.gptOnly ];
+  ompClaudeOnly = mkOmpCommand "ompe" [ presets.claudeOnly ];
 
   # Single source of truth for the launcher palette, ordered into soft groups
   # (mixed, then gpt-led, then claude-led, then specialists) and faster -> smarter
@@ -1001,7 +1013,7 @@ let
       exe = lib.getExe ompDefault;
       lead = "yours";
       group = "";
-      blurb = "Your mutable daily driver (unmanaged)";
+      blurb = "Your unmanaged ~/.omp config";
       detail = "Runs upstream OMP with whatever your writable ~/.omp config selects. No managed defaults, preset, or policy overlay beyond the blocked update.";
     }
     {
@@ -1009,17 +1021,44 @@ let
       exe = lib.getExe ompFast;
       lead = "mixed";
       group = "mix";
-      blurb = "Fast, mixed, latency-first";
-      detail = "The fastest competent tiers across both providers at low thinking (Luna/nano/Spark + Sonnet/Haiku), with light single-hop fallbacks. For snappy interactive work; nothing reaches for Sol/Fable/Opus. Mixed pool.";
+      blurb = "Luna + Haiku, low thinking";
+      detail = "The fastest competent tiers across both providers at low thinking — Luna and Spark on the GPT side, Sonnet and Haiku on the Claude side — with light single-hop crosses. For snappy interactive work; nothing reaches for Sol/Fable/Opus.";
       preset = presets.fast;
+    }
+    {
+      cmd = "ompn";
+      exe = lib.getExe ompMixedRegular;
+      lead = "mixed";
+      group = "mix";
+      blurb = "Claude judges, GPT executes";
+      detail = "Both pools at medium thinking: Claude leads judgment (default/design/review/plan), GPT leads execution (task/librarian/slow), Spark drains in the background. Full same-bucket-then-cross redundancy on every substantive role.";
+      preset = presets.mixedRegular;
+    }
+    {
+      cmd = "ompm";
+      exe = lib.getExe ompMixedSmart;
+      lead = "mixed";
+      group = "mix";
+      blurb = "Best model per task";
+      detail = "The best model per task at high thinking: Sol drives GPT-strength roles, Fable/Opus the Claude-strength ones (design, planning, review). Full redundancy; Fable never an automatic net. When only the best will do, from either provider.";
+      preset = presets.mixedSmart;
+    }
+    {
+      cmd = "ompl";
+      exe = lib.getExe ompGptSpeed;
+      lead = "openai";
+      group = "gpt";
+      blurb = "Luna; task drains Spark";
+      detail = "Luna leads at low thinking, task drains the free Spark bucket, and fallbacks are single fast hops to Haiku. Latency-first Codex; nothing reaches for Sol or high thinking. ompz's pure-GPT sibling.";
+      preset = presets.gptSpeed;
     }
     {
       cmd = "ompb";
       exe = lib.getExe ompBudget;
       lead = "openai";
       group = "gpt";
-      blurb = "Cost-conscious routine work";
-      detail = "Terra/Luna lead at low thinking; every background role rides gpt-5.4-nano (~5x under Luna). Only the live thread and task worker get a net. Advisor, branch summaries, and autolearn off.";
+      blurb = "Terra, off the premium tiers";
+      detail = "Terra leads routine Codex work, kept off the premium tiers — failovers stay on Luna/Terra + Haiku/Sonnet, never Sol/Opus. Background drains Spark. The cost-conscious middle of the GPT lane.";
       preset = presets.budget;
     }
     {
@@ -1027,17 +1066,35 @@ let
       exe = lib.getExe ompGpt;
       lead = "openai";
       group = "gpt";
-      blurb = "Difficult work, GPT-led";
-      detail = "Sol leads the deliberative roles; a GPT sibling absorbs a capacity blip, then every substantive chain crosses to Fable/Opus. commit/tiny on nano. All-OpenAI lead pool.";
+      blurb = "Sol drives, Claude is the net";
+      detail = "Sol leads the deliberative roles; a GPT sibling absorbs a capacity blip, then every substantive chain crosses to Opus/Sonnet. task/background drain Spark. All-OpenAI lead pool.";
       preset = presets.gpt;
+    }
+    {
+      cmd = "ompo";
+      exe = lib.getExe ompGptOnly;
+      lead = "openai";
+      group = "gpt";
+      blurb = "Codex only, never crosses";
+      detail = "Pure Codex: Sol drives, redundancy stays inside the bucket (Sol → Terra → Luna), background drains Spark. Keeps every token on OpenAI — for draining Codex, or when the Claude plan is down or off-limits.";
+      preset = presets.gptOnly;
+    }
+    {
+      cmd = "ompk";
+      exe = lib.getExe ompClaudeSpeed;
+      lead = "claude";
+      group = "claude";
+      blurb = "Haiku, fast and cheap";
+      detail = "Haiku leads at low thinking, background drains the free Spark bucket, and fallbacks are single fast hops to Luna. Latency-first Claude — Haiku's home.";
+      preset = presets.claudeSpeed;
     }
     {
       cmd = "omps";
       exe = lib.getExe ompSonnet;
       lead = "claude";
       group = "claude";
-      blurb = "Everyday value, Sonnet-led";
-      detail = "Sonnet 5 (intro pricing) leads all but plan/slow, where Opus earns its leverage. Haiku carries background. Chains cross to Terra, Sonnet's price-twin. All-Anthropic pool; features on.";
+      blurb = "Sonnet value, Opus for depth";
+      detail = "Sonnet 5 (intro pricing) leads all but plan/slow, where Opus earns its leverage. Every substantive chain is sibling-first, then crosses to Terra/Sol. Background drains Spark, then Haiku. All-Anthropic lead pool.";
       preset = presets.sonnet;
     }
     {
@@ -1045,16 +1102,25 @@ let
       exe = lib.getExe ompClaude;
       lead = "claude";
       group = "claude";
-      blurb = "Difficult work, Claude-led";
-      detail = "ompg's mirror. Fable drives, Opus is the sibling (and leads review), Sonnet/Haiku carry workers, every chain reaches back to Sol/Terra. Load this when OpenAI is dark or Codex credits are spent.";
+      blurb = "Fable drives, Opus reviews";
+      detail = "ompg's mirror. Fable drives, Opus is the sibling (and leads review), Sonnet/Haiku carry workers, every chain reaches back to Sol/Terra. Load this when OpenAI is dark or the Codex meter is empty and the work is hard.";
       preset = presets.claude;
+    }
+    {
+      cmd = "ompe";
+      exe = lib.getExe ompClaudeOnly;
+      lead = "claude";
+      group = "claude";
+      blurb = "Claude only, never crosses";
+      detail = "Pure Anthropic: Opus drives, redundancy stays inside the Claude plan (Opus → Sonnet → Haiku), never touching the separate Spark/Fable buckets. Keeps every token on Anthropic — for draining the plan, or when Codex is down.";
+      preset = presets.claudeOnly;
     }
     {
       cmd = "ompf";
       exe = lib.getExe ompFable;
       lead = "claude";
-      group = "claude";
-      blurb = "Fable-first, deterministic routing";
+      group = "special";
+      blurb = "Fable, deterministic (no net)";
       detail = "Fable for the primary and deliberative roles with retry and server-side fallback OFF. The contract is: give me Fable, predictably, never silently swap. Background on cheap OpenAI rungs.";
       preset = presets.fable;
     }
@@ -1063,8 +1129,8 @@ let
       exe = lib.getExe ompContext;
       lead = "claude";
       group = "special";
-      blurb = "Huge-context (1M) work";
-      detail = "For work beyond 372K. Fable/Opus/Sonnet lead (Anthropic owns 1M); gpt-5.4 is the only OpenAI 1M card, used as the cross-net and librarian lead. Haiku (200K) only touches background trivia.";
+      blurb = "Beyond 372K — Anthropic 1M";
+      detail = "For work beyond the 372K ceiling. Anthropic's 1M line (Fable/Opus/Sonnet) leads and is the only redundancy — no OpenAI model runs 1M on a ChatGPT account, so there is no cross-net. Background trivia drains Spark, then Luna, then Haiku.";
       preset = presets.context;
     }
     {
@@ -1072,12 +1138,20 @@ let
       exe = lib.getExe ompUntrusted;
       lead = "untrusted";
       group = "special";
-      blurb = "Untrusted repositories (isolated)";
+      blurb = "Sandboxed, restricted tools";
       detail = "Dedicated sanitized state, stripped credentials, restricted tools and approvals for deliberately untrusted repositories. Inherits the managed defaults routing.";
     }
   ];
   presetProfiles = builtins.filter (p: p ? preset) paletteProfiles;
-  routeSpecs = map (p: "${p.cmd}|${p.blurb}|${p.preset}") presetProfiles;
+  ompuProfile = lib.findFirst (p: p.cmd == "ompu") (throw "ompu missing from palette") paletteProfiles;
+  # ompu loads defaultsConfig then untrusted.yml, and untrusted.yml overrides only
+  # tools/approvals — never modelRoles/retry/thinking — so its routing is exactly the
+  # managed defaults. Render it like any preset so the picker preview and omph show a
+  # real model list (GUI parity) instead of a blank. (The bare `omp` genuinely has no
+  # managed routing — upstream's built-in modelRoles is empty — so it stays off this list.)
+  routeSpecs =
+    (map (p: "${p.cmd}|${p.blurb}|${p.preset}") presetProfiles)
+    ++ [ "ompu|${ompuProfile.blurb}|${untrustedConfig}" ];
   routesHelp =
     runCommand "omp-routes-help-${lib.getVersion omp}"
       {
@@ -1332,6 +1406,10 @@ let
       # Nerd Font glyphs by precise codepoint (FontAwesome range, in every Nerd
       # Font) and 24-bit truecolor accents, used by the fzf picker.
       esc=$(printf '\033')
+      g_cogs=$(printf '')    # cogs — regular / routine work
+      g_unlink=$(printf '')  # broken link — pure-pool, never crosses
+      g_pin=$(printf '')     # thumbtack — deterministic (ompf)
+      g_book=$(printf '')    # book — huge context (ompx)
       g_reset=$(printf '')  # refresh (time until reset)
       g_mixed=$(printf '')  # random / shuffle (mixed pool)
       g_openai=$(printf '')     # bolt
@@ -1343,14 +1421,17 @@ let
       c_openai="''${esc}[38;2;98;167;255m"
       c_claude="''${esc}[38;2;255;159;82m"
       c_yours="''${esc}[38;2;120;200;170m"
-      c_untrusted="''${esc}[38;2;230;130;90m"
+      c_untrusted="''${esc}[38;2;208;92;96m"    # clear red (warning) — not the claude orange
       c_mixed="''${esc}[38;2;170;150;225m"
+      c_special="''${esc}[38;2;70;190;200m"      # teal — special-purpose group
       c_dim="''${esc}[38;2;120;130;145m"
       c_ok="''${esc}[38;2;80;200;120m"
       c_warn="''${esc}[38;2;235;120;90m"
       c_near="''${esc}[38;2;235;238;242m"
       c_bold="''${esc}[1m"
       c_rst="''${esc}[0m"
+      c_gpt_soft="''${esc}[38;2;110;145;190m"     # muted, grayed blue for flavour text
+      c_claude_soft="''${esc}[38;2;195;160;120m"  # muted, grayed orange for flavour text
 
       lead_tag() {
         case "$1" in
@@ -1389,66 +1470,155 @@ let
         done
       }
 
-      short_window() {
-        case "$1" in
-          "5 hours" | "Claude 5 Hour") printf '5h' ;;
-          "7 days" | "Claude 7 Day") printf '7d' ;;
-          "5 hours (Spark)") printf '5h spark' ;;
-          "7 days (Spark)") printf '7d spark' ;;
-          "Claude 7 Day (Fable)") printf '7d fable' ;;
-          *) printf '%s' "$1" ;;
-        esac
+      # Render the usage rows (provider TAB label TAB pct TAB tier TAB secs TAB
+      # windowSecs) into the coloured panel in a single gawk pass — a provider
+      # header, then each window's gradient bar, percent used, and time to reset.
+      # "Near reset" is relative to the window length (bold within the last tenth,
+      # bright within the last quarter) so a barely-used 5h window resetting in
+      # ~4h no longer reads as urgent.
+      render_usage_panel() {
+        gawk -F'\t' \
+          -v c_openai="$c_openai" -v c_claude="$c_claude" -v c_dim="$c_dim" \
+          -v c_bold="$c_bold" -v c_rst="$c_rst" -v c_near="$c_near" \
+          -v c_ok="$c_ok" -v c_warn="$c_warn" -v esc="$esc" -v greset="$g_reset" '
+          function shortwin(l) {
+            if (l == "5 hours" || l == "Claude 5 Hour") return "5h"
+            if (l == "7 days" || l == "Claude 7 Day") return "7d"
+            if (l == "5 hours (Spark)") return "5h spark"
+            if (l == "7 days (Spark)") return "7d spark"
+            if (l == "Claude 7 Day (Fable)") return "7d fable"
+            return l
+          }
+          function barstr(p,   r, g, fill, k, o) {
+            if (p <= 50) { r = 90 + p * 3; g = 200 } else { r = 235; g = 200 - (p - 50) * 3 }
+            if (r > 235) r = 235
+            if (g < 60) g = 60
+            fill = int((p * 10 + 50) / 100)
+            if (fill > 10) fill = 10
+            if (fill < 0) fill = 0
+            o = esc "[38;2;" r ";" g ";70m"
+            for (k = 0; k < fill; k++) o = o "█"
+            o = o c_dim
+            for (k = fill; k < 10; k++) o = o "░"
+            return o c_rst
+          }
+          function fmtreset(s,   d, h, m) {
+            if (s < 0) s = 0
+            if (s >= 86400) return int(s / 86400) "d" int((s % 86400) / 3600) "h"
+            if (s >= 3600) return int(s / 3600) "h" int((s % 3600) / 60) "m"
+            return int(s / 60) "m"
+          }
+          function rstyle(s, dur) {
+            if (dur > 0 && s * 10 < dur) return c_bold c_near
+            if (dur > 0 && s * 4 < dur) return c_near
+            return c_dim
+          }
+          {
+            prov = $1; label = $2; pct = $3 + 0; tier = $4; rs = $5 + 0; dur = $6 + 0
+            if (prov != last) {
+              pcol = (prov == "openai-codex") ? c_openai : ((prov == "anthropic") ? c_claude : c_dim)
+              pname = (prov == "openai-codex") ? "Codex" : ((prov == "anthropic") ? "Claude" : prov)
+              print pcol c_bold pname c_rst
+              last = prov
+            }
+            note = ""
+            if (pct >= 80) note = "  " c_warn "tight" c_rst
+            if (tier == "spark" && pct == 0) note = "  " c_ok "idle" c_rst
+            printf "  %-8s %s %3d%% used  %s%s %s%s%s\n", shortwin(label), barstr(pct), pct, rstyle(rs, dur), greset, fmtreset(rs), c_rst, note
+          }
+        '
       }
 
-      # Green (low use) -> red (near capacity), as an "r;g;b" triple.
-      bar_rgb() {
-        local p="$1" r g
-        if (( p <= 50 )); then
-          r=$(( 90 + p * 3 ))
-          g=200
-        else
-          r=235
-          g=$(( 200 - (p - 50) * 3 ))
-        fi
-        (( r > 235 )) && r=235
-        (( g < 60 )) && g=60
-        printf '%d;%d;70' "$r" "$g"
+      # Per-provider quota panel, filled without blocking the picker. Source
+      # preference: (1) the tyrode.dev collector snapshot when present and recent
+      # — refreshed continuously, so instant and always fresh; (2) a local cache
+      # of `omp usage --json`, repopulated in the background so the next open is
+      # warm; (3) a "fetching…" note while the first background fetch lands.
+      usage_snapshot="''${TYRODE_MODEL_USAGE_SNAPSHOT:-/opt/tyrode/runtime/model-usage/snapshot.json}"
+      usage_cache="''${XDG_CACHE_HOME:-$HOME/.cache}/atyrode/code-usage.json"
+
+      # Seconds since a file's mtime, or non-zero when it is missing.
+      file_age() {
+        local m now
+        m="$(stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null)" || return 1
+        [[ -n "$m" ]] || return 1
+        now="$(date +%s)"
+        printf '%d' "$(( now - m ))"
       }
 
-      # A 10-cell bar: filled cells in the usage gradient, empty cells dim.
-      bar() {
-        local pct="$1"
-        local fill=$(( (pct * 10 + 50) / 100 ))
-        (( fill > 10 )) && fill=10
-        (( fill < 0 )) && fill=0
-        local k rgb
-        rgb="$(bar_rgb "$pct")"
-        local out="''${esc}[38;2;''${rgb}m"
-        for (( k = 0; k < fill; k++ )); do out+='█'; done
-        out+="$c_dim"
-        for (( k = fill; k < 10; k++ )); do out+='░'; done
-        out+="$c_rst"
-        printf '%s' "$out"
+      # Both sources normalise to provider<TAB>label<TAB>pct<TAB>tier<TAB>secs<TAB>
+      # windowSecs, sorted so a provider's regular buckets come before its
+      # separate-quota ones (Spark after Codex, Fable after Claude).
+      usage_rows_from_omp() {
+        jq -r '
+            .reports[] | .provider as $p
+            | .limits
+            | sort_by((if (.scope.tier // "-") == "-" then 0 else 1 end), .window.durationMs)[]
+            | $p + "\t" + .label + "\t"
+              + ((.amount.usedFraction * 100) | round | tostring) + "\t"
+              + (.scope.tier // "-") + "\t"
+              + (((.window.resetsAt / 1000) - now) | floor | tostring) + "\t"
+              + ((.window.durationMs / 1000) | floor | tostring)
+          ' 2>/dev/null
+      }
+      usage_rows_from_snapshot() {
+        jq -r '
+            .providers | to_entries[]
+            | (if .key == "openai" then "openai-codex" else .key end) as $p
+            | (.value.lastGood.limits // [])
+            | sort_by((if (.id | test("spark|fable")) then 1 else 0 end), .durationMs)[]
+            | (.id | test("spark")) as $spark
+            | (.id | test("fable")) as $fable
+            | (.durationMs == 18000000) as $h5
+            | $p + "\t"
+              + (if $p == "openai-codex"
+                   then (if $spark then (if $h5 then "5 hours (Spark)" else "7 days (Spark)" end)
+                                   else (if $h5 then "5 hours" else "7 days" end) end)
+                   else (if $fable then "Claude 7 Day (Fable)"
+                                   else (if $h5 then "Claude 5 Hour" else "Claude 7 Day" end) end)
+                 end) + "\t"
+              + ((.usedFraction * 100) | round | tostring) + "\t"
+              + (if $spark then "spark" elif $fable then "fable" else "-" end) + "\t"
+              + (((.resetsAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) - now) | floor | tostring) + "\t"
+              + ((.durationMs / 1000) | floor | tostring)
+          ' 2>/dev/null
+      }
+      # Detached refresh of the local cache — only reached when no fresh snapshot.
+      refresh_usage_cache() {
+        mkdir -p "$(dirname "$usage_cache")" 2>/dev/null || return 0
+        {
+          tmp="$(mktemp "$usage_cache.XXXXXX" 2>/dev/null)" || exit 0
+          if timeout 8 "$omp_bin" usage --json > "$tmp" 2>/dev/null && [[ -s "$tmp" ]]; then
+            mv -f "$tmp" "$usage_cache" 2>/dev/null
+          else
+            rm -f "$tmp" 2>/dev/null
+          fi
+        } &
       }
 
-      # Fill the `usagep` array with a compact per-provider quota panel from
-      # `omp usage --json`. Best-effort: on any failure (offline, timeout, not
-      # authed, --no-usage) it is left empty and the picker shows just the list.
-      fmt_reset() {
-        local s="$1"
-        (( s < 0 )) && s=0
-        if (( s >= 86400 )); then printf '%dd%dh' "$(( s / 86400 ))" "$(( (s % 86400) / 3600 ))"
-        elif (( s >= 3600 )); then printf '%dh%dm' "$(( s / 3600 ))" "$(( (s % 3600) / 60 ))"
-        else printf '%dm' "$(( s / 60 ))"; fi
-      }
-
-      # Nearer resets stand out: bold + bright under an hour, bright under four
-      # hours, dim beyond that.
-      reset_style() {
-        local s="$1"
-        if (( s < 3600 )); then printf '%s%s' "$c_bold" "$c_near"
-        elif (( s < 14400 )); then printf '%s' "$c_near"
-        else printf '%s' "$c_dim"; fi
+      # The bare `omp` runs the user's unmanaged ~/.omp. Resolve its role→model map
+      # (`omp config list` is ~0.9s) into a routes.plain lead block, refreshed in the
+      # background and cached, so the preview shows the *real* routing — the same as
+      # the managed profiles — without ever blocking the picker.
+      omp_routes_cache="''${XDG_CACHE_HOME:-$HOME/.cache}/atyrode/code-omp-routes"
+      refresh_omp_routes() {
+        mkdir -p "$(dirname "$omp_routes_cache")" 2>/dev/null || return 0
+        {
+          tmp="$(mktemp "$omp_routes_cache.XXXXXX" 2>/dev/null)" || exit 0
+          if timeout 8 "$omp_bin" config get modelRoles --json 2>/dev/null \
+            | jq -r '
+                (.value // .) as $r
+                | ["default","task","plan","slow","designer","reviewer","librarian","sonic","advisor","smol","tiny","commit"] as $ord
+                | ([$ord[] | select($r[.])] + (($r | keys) - $ord))
+                | .[] | "\(.)\t\($r[.])"' 2>/dev/null \
+            | awk -F'\t' '{ m = $2; sub(/^[a-z-]+\//, "", m);
+                mark = ($1 ~ /^(designer|librarian|reviewer|scout|sonic|task)$/) ? "  ● " : "    ";
+                printf "%s%-10s %s\n", mark, $1, m }' > "$tmp" 2>/dev/null && [[ -s "$tmp" ]]; then
+            mv -f "$tmp" "$omp_routes_cache" 2>/dev/null
+          else
+            rm -f "$tmp" 2>/dev/null
+          fi
+        } &
       }
 
       # Per-provider quota panel: a coloured provider header, then each window's
@@ -1457,35 +1627,22 @@ let
       build_usage() {
         usagep=()
         (( show_usage_panel == 1 )) || return 0
-        local json rows
-        json="$(timeout 8 "$omp_bin" usage --json 2>/dev/null)" || return 0
-        [[ -n "$json" ]] || return 0
-        rows="$(printf '%s' "$json" | jq -r '
-            .reports[] | .provider as $p | .limits[]
-            | $p + "\t" + .label + "\t"
-              + ((.amount.usedFraction * 100) | round | tostring) + "\t"
-              + (.scope.tier // "-") + "\t"
-              + (((.window.resetsAt / 1000) - now) | floor | tostring)
-          ' 2>/dev/null)" || return 0
-        [[ -n "$rows" ]] || return 0
-        local a b c d e last_provider="" pname pcol note
-        while IFS=$'\t' read -r a b c d e; do
-          case "$a" in
-            openai-codex) pname="Codex"; pcol="$c_openai" ;;
-            anthropic) pname="Claude"; pcol="$c_claude" ;;
-            *) pname="$a"; pcol="$c_dim" ;;
-          esac
-          if [[ "$a" != "$last_provider" ]]; then
-            usagep+=( "''${pcol}''${c_bold}$pname''${c_rst}" )
-            last_provider="$a"
+        local rows="" fetching=0 age
+        if [[ -r "$usage_snapshot" ]] && age="$(file_age "$usage_snapshot")" && (( age < 1800 )); then
+          rows="$(usage_rows_from_snapshot < "$usage_snapshot")"
+        fi
+        if [[ -z "$rows" ]]; then
+          if ! age="$(file_age "$usage_cache")" || (( age >= 120 )); then
+            refresh_usage_cache
+            fetching=1
           fi
-          note=""
-          (( c >= 80 )) && note="  ''${c_warn}tight''${c_rst}"
-          [[ "$d" == spark && "$c" -eq 0 ]] && note="  ''${c_ok}idle''${c_rst}"
-          usagep+=( "$(printf '  %-8s %s %3d%% used  %s%s %s%s%s' \
-            "$(short_window "$b")" "$(bar "$c")" "$c" \
-            "$(reset_style "$e")" "$g_reset" "$(fmt_reset "$e")" "$c_rst" "$note")" )
-        done <<< "$rows"
+          [[ -r "$usage_cache" ]] && rows="$(usage_rows_from_omp < "$usage_cache")"
+        fi
+        if [[ -z "$rows" ]]; then
+          (( fetching )) && usagep+=( "''${c_dim}fetching usage…''${c_rst}" )
+          return 0
+        fi
+        mapfile -t usagep < <(render_usage_panel <<< "$rows")
       }
 
       term_cols() {
@@ -1530,35 +1687,42 @@ let
           "''${names[$i]}" "$(lead_tag "''${leads[$i]}")" "''${details[$i]}"
       }
 
-      lead_glyph() {
+      # Colour by lane (mixed/gpt/claude/special/bare) and glyph by intended use
+      # (speed/regular/smart/pure-pool + per-special icons), keyed on the launcher
+      # name so the icon matches what the profile is for, not just its provider.
+      lane_color() {
         case "$1" in
-          openai) printf '%s' "$g_openai" ;;
-          claude) printf '%s' "$g_claude" ;;
-          mixed) printf '%s' "$g_mixed" ;;
-          yours) printf '%s' "$g_yours" ;;
-          untrusted) printf '%s' "$g_untrusted" ;;
-          *) printf ' ' ;;
+          ompz | ompn | ompm) printf '%s' "$c_mixed" ;;
+          ompl | ompb | ompg | ompo) printf '%s' "$c_openai" ;;
+          ompk | omps | ompc | ompe) printf '%s' "$c_claude" ;;
+          ompf | ompx) printf '%s' "$c_special" ;;
+          ompu) printf '%s' "$c_untrusted" ;;
+          *) printf '%s' "$c_yours" ;;
         esac
       }
-      lead_color() {
+      icon_glyph() {
         case "$1" in
-          openai) printf '%s' "$c_openai" ;;
-          claude) printf '%s' "$c_claude" ;;
-          mixed) printf '%s' "$c_mixed" ;;
-          yours) printf '%s' "$c_yours" ;;
-          untrusted) printf '%s' "$c_untrusted" ;;
-          *) printf '%s' "$c_dim" ;;
+          ompz | ompl | ompk) printf '%s' "$g_openai" ;;
+          ompn | ompb | omps) printf '%s' "$g_cogs" ;;
+          ompm | ompg | ompc) printf '%s' "$g_claude" ;;
+          ompo | ompe) printf '%s' "$g_unlink" ;;
+          ompf) printf '%s' "$g_pin" ;;
+          ompx) printf '%s' "$g_book" ;;
+          ompu) printf '%s' "$g_untrusted" ;;
+          omp) printf '%s' "$g_yours" ;;
+          *) printf '%s' "$g_mixed" ;;
         esac
       }
 
-      # Compact + recolour a routing block for the preview: shorten model names
-      # to their tier (gpt-5.6-sol -> sol, claude-fable-5 -> fable), collapse the
-      # column padding, and colour each token by provider hue (muted blue for
-      # OpenAI, muted orange for Anthropic) with brightness scaled by thinking
-      # level (low -> xhigh reads as dim -> bright). Kept narrow so fzf's preview
-      # (nowrap) never has to wrap ANSI lines, which it renders incorrectly.
+      # Compact + recolour a routing block for the preview. Mode selects depth:
+      # "lead" keeps only the primary per role, "base" collapses same-provider
+      # redundancy siblings to show just the cross-provider net, "full" keeps the
+      # whole chain (the picker cycles lead -> base -> full on ctrl-f). Names
+      # shorten to their tier (gpt-5.6-sol -> sol) and colour by provider hue with
+      # brightness scaled by thinking level (low -> xhigh reads as dim -> bright).
       colorize_routes() {
-        gawk -v dim="$c_dim" '
+        local mode="''${1:-base}"
+        gawk -v dim="$c_dim" -v mode="$mode" '
           function lvl(l) { return l=="minimal"?0:l=="low"?1:l=="medium"?2:l=="high"?3:l=="xhigh"?4:5 }
           function clamp(x) { return x>255?255:(x<0?0:int(x)) }
           function short(name,   a, n) {
@@ -1577,14 +1741,46 @@ let
             f = 0.60 + lvl(level) * 0.088
             return sprintf("\033[38;2;%d;%d;%dm%s:%s%s", clamp(br*f), clamp(bg*f), clamp(bb*f), short(name), level, dim)
           }
+          function prov_of(s) {
+            # Spark and Fable draw separate quota, so they are their own bucket —
+            # a hop off them is a real fallback (different rate), never a
+            # same-bucket redundancy sibling to collapse.
+            if (s ~ /spark/) return "s"
+            if (s ~ /fable/) return "f"
+            return s ~ /claude/ ? "c" : (s ~ /gpt/ ? "g" : "x")
+          }
           {
             line = $0
             # Drop the redundant profile header (col 0) — the preview shows the
             # name/blurb itself — and the profile-level thinking/fallback/advisor
-            # line, which is redundant with the per-role levels and chains.
+            # line, which is redundant with the per-role levels.
             if (line ~ /^[a-z]/) next
             if (line ~ /thinking .* fallback/) next
-            gsub(/ +→/, " →", line)
+            # Split off any trailing task override so it never confuses the
+            # provider walk, then re-append it before painting.
+            ov = ""
+            if (match(line, / +\(task override:/)) {
+              ov = substr(line, RSTART); line = substr(line, 1, RSTART - 1)
+            }
+            # Normalise the padded arrow gaps to a single space either side.
+            gsub(/ +→ +/, " → ", line)
+            if (mode == "lead") {
+              # Primary only — drop the whole chain.
+              sub(/ +→.*$/, "", line)
+            } else if (mode == "base") {
+              # Collapse consecutive same-bucket models (the redundancy siblings)
+              # so only the lead and each bucket transition remain — Spark and
+              # Fable are their own bucket, so a hop off them is always kept.
+              n = split(line, parts, / +→ +/)
+              line = parts[1]
+              lastprov = prov_of(parts[1])
+              for (j = 2; j <= n; j++) {
+                if (prov_of(parts[j]) != lastprov) {
+                  line = line " → " parts[j]; lastprov = prov_of(parts[j])
+                }
+              }
+            }
+            line = line ov
             out = ""
             # paint() calls match() internally, which clobbers RSTART/RLENGTH, so
             # snapshot them before each call.
@@ -1598,14 +1794,164 @@ let
         '
       }
 
+      # Colour provider/model mentions in flavour text with a muted, grayed
+      # version of the provider hue, restoring to the surrounding dim gray.
+      flavorize() {
+        gawk -v g="$c_gpt_soft" -v c="$c_claude_soft" -v dim="$c_dim" '
+          {
+            line = $0
+            gsub(/\<(GPT|gpt|OpenAI|Codex|Spark|spark|Sol|Terra|Luna|Nano|nano)\>/, g "&" dim, line)
+            gsub(/\<(Claude|claude|Anthropic|Opus|opus|Sonnet|sonnet|Haiku|haiku|Fable|fable)\>/, c "&" dim, line)
+            print line
+          }
+        '
+      }
+
       # Arrow-key picker via fzf: a truecolor list with Nerd Font provider
       # glyphs and soft group labels at the top, the usage panel in the footer,
       # and each profile's detail + colourised role -> model routing in the
       # preview. Sets picked_idx, or leaves it empty when cancelled.
+      # Render profile <name> at depth <state> (0/1/2) to stdout. Shared by the
+      # on-demand fzf preview and the background preloader, so startup pre-renders
+      # nothing and navigation is still instant once the cache is warm.
+      # Bundled OMP subagents shown in the preview for the profiles with no managed
+      # routing to display (bare omp, ompu). Built once from the pinned agents dir.
+      agents_block=""
+      build_agents_block() {
+        [[ -n "$agents_block" ]] && return 0
+        local f n d line
+        for f in ${omp-agents}/share/omp/agents/*.md; do
+          [[ -e "$f" ]] || continue
+          n="''${f##*/}"; n="''${n%.md}"
+          case "$n" in
+            designer)  d="UI/UX design & visual refinement" ;;
+            librarian) d="reads external libraries & APIs" ;;
+            reviewer)  d="code quality & security review" ;;
+            scout)     d="fast codebase exploration" ;;
+            sonic)     d="mechanical, low-reasoning edits" ;;
+            task)      d="general multi-step delegation" ;;
+            *)         d="" ;;
+          esac
+          printf -v line '  %s●%s %s%-10s%s %s%s%s' \
+            "$c_dim" "$c_rst" "$c_bold" "$n" "$c_rst" "$c_dim" "$d" "$c_rst"
+          agents_block+="$line"$'\n'
+        done
+        agents_block="''${agents_block%$'\n'}"
+      }
+
+      render_one() {
+        local profile="$1" s="$2" i idx=-1 col gly fdetail block why
+        for (( i = 0; i < count; i++ )); do
+          [[ "''${names[$i]}" == "$profile" ]] && { idx=$i; break; }
+        done
+        (( idx >= 0 )) || return 0
+        col="$(lane_color "''${names[$idx]}")"
+        gly="$(icon_glyph "''${names[$idx]}")"
+        fdetail="$(printf '%s' "''${details[$idx]}" | flavorize)"
+        printf '%s%s %s%s%s\n' "$col" "$gly" "$c_bold" "''${names[$idx]}" "$c_rst"
+        printf '%s%s%s\n\n' "$col" "''${blurbs[$idx]}" "$c_rst"
+        printf '%s%s%s\n' "$c_dim" "$fdetail" "$c_rst"
+        # the bare omp has no managed routing — show the user's own resolved ~/.omp
+        # routing (cached, refreshed in the background), or its bundled subagents until
+        # the first resolve lands. ompu falls through: its routing is in routes.plain.
+        case "''${names[$idx]}" in
+          omp)
+            local orblock=""
+            [[ -r "$omp_routes_cache" ]] && orblock="$(colorize_routes lead < "$omp_routes_cache")"
+            if [[ -n "$orblock" ]]; then
+              printf '\n%s── routing · your ~/.omp ────%s\n%s%s%s\n' "$c_dim" "$c_rst" "$c_dim" "$orblock" "$c_rst"
+            else
+              build_agents_block
+              printf '\n%s── agents ──────────────────%s\n%s\n' "$c_dim" "$c_rst" "$agents_block"
+            fi
+            return 0
+            ;;
+        esac
+        [[ -f "$routes_plain" ]] || return 0
+        case "$s" in
+          0)
+            block="$(sed -n "/^''${names[$idx]}  /,/^\$/p" "$routes_plain" | colorize_routes lead)"
+            [[ -n "$block" ]] || return 0
+            printf '\n%s── routing ─────────────────%s\n%s%s%s\n' "$c_dim" "$c_rst" "$c_dim" "$block" "$c_rst"
+            printf '\n%sctrl-f · show fallback route · shift↑↓ scroll%s\n' "$c_dim" "$c_rst"
+            ;;
+          2)
+            block="$(sed -n "/^''${names[$idx]}  /,/^\$/p" "$routes_plain" | colorize_routes full)"
+            [[ -n "$block" ]] || return 0
+            why="$(printf '%s' 'why the extra hops: each lead keeps a same-provider backup before it crosses providers, so a single-model outage or fault is absorbed in its own bucket first (gpt→gpt→claude→claude). Spark and Fable draw separate quota, so they sit out.' | flavorize)"
+            printf '\n%s── routing + redundancy ────%s\n%s%s%s\n' "$c_dim" "$c_rst" "$c_dim" "$block" "$c_rst"
+            printf '\n%s%s%s\n' "$c_dim" "$why" "$c_rst"
+            printf '\n%sctrl-f · hide fallbacks · shift↑↓ scroll%s\n' "$c_dim" "$c_rst"
+            ;;
+          *)
+            block="$(sed -n "/^''${names[$idx]}  /,/^\$/p" "$routes_plain" | colorize_routes base)"
+            [[ -n "$block" ]] || return 0
+            printf '\n%s── routing + fallback ──────%s\n%s%s%s\n' "$c_dim" "$c_rst" "$c_dim" "$block" "$c_rst"
+            printf '\n%sctrl-f · show sibling redundancy · shift↑↓ scroll%s\n' "$c_dim" "$c_rst"
+            ;;
+        esac
+      }
+      # On-demand preview for fzf: render at the current depth from the state file.
+      render_preview() {
+        render_one "$2" "$(cat "$1/.state" 2>/dev/null || echo 0)"
+      }
+      # Warm every profile × depth into the cache (run in the background on start).
+      render_all() {
+        local prevdir="$1" i st
+        for (( i = 0; i < count; i++ )); do
+          for st in 0 1 2; do
+            render_one "''${names[$i]}" "$st" > "$prevdir/''${names[$i]}.s$st.part" 2>/dev/null \
+              && mv -f "$prevdir/''${names[$i]}.s$st.part" "$prevdir/''${names[$i]}.s$st" 2>/dev/null
+          done
+        done
+      }
+
+      # Full-screen "starting" card held across omp's cold start (see the launch
+      # path): the profile, its description, and its lead-only routing, so the
+      # hand-off amplifies the picker instead of dropping to a bare terminal.
+      starting_card() {
+        local idx="$1" rows="" cols="" col gly block nlines top margin width r line
+        read -r rows cols < <(stty size 2>/dev/null) || true
+        [[ "$rows" =~ ^[0-9]+$ ]] && (( rows >= 8 )) || rows=24
+        [[ "$cols" =~ ^[0-9]+$ ]] && (( cols >= 24 )) || cols=80
+        col="$(lane_color "''${names[$idx]}")"
+        gly="$(icon_glyph "''${names[$idx]}")"
+        margin=$(( (cols - 56) / 2 )); (( margin < 2 )) && margin=2
+        width=$(( cols - margin - 2 )); (( width < 20 )) && width=20
+        local -a dlines=() rlines=()
+        mapfile -t dlines < <(printf '%s' "''${details[$idx]}" | fold -s -w "$width" | flavorize)
+        block=""
+        [[ -f "$routes_plain" ]] && block="$(sed -n "/^''${names[$idx]}  /,/^\$/p" "$routes_plain" | colorize_routes lead)"
+        [[ -n "$block" ]] && mapfile -t rlines <<< "$block"
+        nlines=$(( 3 + ''${#dlines[@]} + ''${#rlines[@]} ))
+        top=$(( (rows - nlines) / 2 )); (( top < 1 )) && top=1
+        printf '\e[2J\e[H\e[?25l'
+        printf '\e[%d;%dH%s%s %s%s%s  %s⟳ starting…%s' "$top" "$margin" \
+          "$col" "$gly" "$c_bold" "''${names[$idx]}" "$c_rst" "$c_dim" "$c_rst"
+        r=$(( top + 2 ))
+        for line in "''${dlines[@]}"; do
+          printf '\e[%d;%dH%s%s%s' "$r" "$margin" "$c_dim" "$line" "$c_rst"; r=$(( r + 1 ))
+        done
+        r=$(( r + 1 ))
+        for line in "''${rlines[@]}"; do
+          printf '\e[%d;%dH%s%s%s' "$r" "$margin" "$c_dim" "$line" "$c_rst"; r=$(( r + 1 ))
+        done
+      }
+
+      # Optional startup profiler: CODE_PROFILE=1 prints section timestamps.
+      _prof() { [[ -z "''${CODE_PROFILE:-}" ]] || printf 'PROF %-10s %s\n' "$1" "$EPOCHREALTIME" >&2; }
       picked_idx=""
       fzf_pick() {
         picked_idx=""
+        _prof entry
         build_usage
+        # Kick a background refresh of the bare-omp routing cache when stale (~0.9s;
+        # never blocks — the omp preview reads whatever is cached, agents until then).
+        local rt_age=""
+        if ! rt_age="$(file_age "$omp_routes_cache")" || (( rt_age >= 3600 )); then
+          refresh_omp_routes
+        fi
+        _prof usage
         local footer=""
         local -a footer_args=()
         if (( ''${#usagep[@]} > 0 )); then
@@ -1613,47 +1959,88 @@ let
           footer="''${footer%$'\n'}"
           footer_args=( --footer="$footer" --footer-border=top )
         fi
-        local prevdir
+        local prevdir self
         prevdir="$(mktemp -d)"
-        local i col gly rows="" block glabel labelcol last_group=""
+        self="$(command -v -- "$0" 2>/dev/null)" || self="$0"
+        # Previews cache under $prevdir as <name>.s<depth>. fzf calls `show`, which
+        # cats the cached file when ready or renders on demand via `code __preview`;
+        # a background `code __preload` (kicked on fzf start) warms them all so
+        # navigation is instant. `cycle` bumps the depth (0 hidden · 1 net · 2 full).
+        # shellcheck disable=SC2016
+        printf '%s\n' \
+          '#!/bin/sh' \
+          "self=$self" \
+          'd=''${0%/*}' \
+          's=$(cat "$d/.state" 2>/dev/null || echo 0)' \
+          'f="$d/$1.s$s"' \
+          '[ -f "$f" ] && cat "$f" || "$self" __preview "$d" "$1"' > "$prevdir/show"
+        # shellcheck disable=SC2016
+        printf '%s\n' \
+          '#!/bin/sh' \
+          'd=''${0%/*}' \
+          's=$(cat "$d/.state" 2>/dev/null || echo 0)' \
+          'echo "$(( (s + 1) % 3 ))" > "$d/.state"' > "$prevdir/cycle"
+        chmod +x "$prevdir/show" "$prevdir/cycle"
+        local i col gly rows="" row glabel labelcol last_group=""
+        # Flavour-tint the blurbs (openai/claude/model mentions) in one gawk pass
+        # so the hot loop stays subshell-free.
+        local -a fblurbs=()
+        mapfile -t fblurbs < <(printf '%s\n' "''${blurbs[@]}" | flavorize)
+        # Colour by lane, glyph by intended use, both inlined; the category label
+        # is printed once on each group's first row.
         for (( i = 0; i < count; i++ )); do
-          col="$(lead_color "''${leads[$i]}")"
-          gly="$(lead_glyph "''${leads[$i]}")"
+          case "''${names[$i]}" in
+            ompz | ompn | ompm) col="$c_mixed" ;;
+            ompl | ompb | ompg | ompo) col="$c_openai" ;;
+            ompk | omps | ompc | ompe) col="$c_claude" ;;
+            ompf | ompx) col="$c_special" ;;
+            ompu) col="$c_untrusted" ;;
+            *) col="$c_yours" ;;
+          esac
+          case "''${names[$i]}" in
+            ompz | ompl | ompk) gly="$g_openai" ;;
+            ompn | ompb | omps) gly="$g_cogs" ;;
+            ompm | ompg | ompc) gly="$g_claude" ;;
+            ompo | ompe) gly="$g_unlink" ;;
+            ompf) gly="$g_pin" ;;
+            ompx) gly="$g_book" ;;
+            ompu) gly="$g_untrusted" ;;
+            omp) gly="$g_yours" ;;
+            *) gly="$g_mixed" ;;
+          esac
           glabel=""
           if [[ "''${groups[$i]}" != "$last_group" ]]; then
             glabel="$(group_label "''${groups[$i]}")"
             last_group="''${groups[$i]}"
           fi
-          labelcol="$(printf '%-11s' "$glabel")"
-          rows+="$(printf '%s\t%s%s%s  %s%s%s  %s%-5s%s  %s%s%s' \
+          printf -v labelcol '%-10s' "$glabel"
+          printf -v row '%s\t%s%s%s  %s%s%s  %s%-5s%s  %s%s%s' \
             "''${names[$i]}" \
             "$c_dim" "$labelcol" "$c_rst" \
             "$col" "$gly" "$c_rst" \
             "$c_bold" "''${names[$i]}" "$c_rst" \
-            "$c_dim" "''${blurbs[$i]}" "$c_rst")"$'\n'
-          {
-            printf '%s%s %s%s%s\n' "$col" "$gly" "$c_bold" "''${names[$i]}" "$c_rst"
-            printf '%s%s%s\n\n' "$col" "''${blurbs[$i]}" "$c_rst"
-            printf '%s%s%s\n' "$c_dim" "''${details[$i]}" "$c_rst"
-            if [[ -f "$routes_plain" ]]; then
-              block="$(sed -n "/^''${names[$i]}  /,/^\$/p" "$routes_plain" | colorize_routes)"
-              [[ -n "$block" ]] && printf '\n%s── routing ────────────────%s\n%s%s%s\n' \
-                "$c_dim" "$c_rst" "$c_dim" "$block" "$c_rst"
-            fi
-          } > "$prevdir/''${names[$i]}"
+            "$c_dim" "''${fblurbs[$i]}" "$c_rst"
+          rows+="$row"$'\n'
         done
+        _prof rows
         local theme chosen cmd
         theme='fg:-1,bg:-1,fg+:#ffffff,bg+:#1b212b,hl:#62a7ff,hl+:#8ec7ff'
         theme+=',pointer:#ff9f52,marker:#ff9f52,prompt:#ff9f52,spinner:#ff9f52'
         theme+=',border:#3a4453,label:#9aa4b1,info:#69727e'
         theme+=',footer:#9aa4b1,footer-border:#3a4453'
         theme+=',gutter:-1,preview-border:#3a4453'
+        _prof fzf
         chosen="$(printf '%s' "$rows" | fzf \
-          --ansi --layout=reverse --height=100% --border=rounded \
-          --border-label=" code $g_point pick a launcher " \
-          --prompt="$g_search  " --pointer="$g_point" --marker='+' --info=inline \
+          --ansi --layout=reverse --height=99% --border=rounded \
+          --border-label=" pick a launcher " \
+          --prompt="$g_search  " --pointer="$g_point" --marker='+' --info=inline --no-mouse \
           --delimiter=$'\t' --with-nth=2 \
-          --preview="cat $prevdir/{1}" --preview-window='right:52%:wrap:border-left' \
+          --preview="$prevdir/show {1}" \
+          --preview-window='right:52%:wrap:border-left' \
+          --bind="start:execute-silent($self __preload $prevdir &)" \
+          --bind="ctrl-f:execute-silent($prevdir/cycle)+refresh-preview" \
+          --bind="shift-up:preview-up,shift-down:preview-down" \
+          --bind="alt-up:preview-half-page-up,alt-down:preview-half-page-down" \
           "''${footer_args[@]}" \
           --color="$theme" || true)"
         rm -rf "$prevdir"
@@ -1714,6 +2101,15 @@ let
           'for the full role/model routing of each managed profile, run omph.'
       }
 
+      if [[ "''${1:-}" == __preview ]]; then
+        render_preview "$2" "$3"
+        exit 0
+      fi
+      if [[ "''${1:-}" == __preload ]]; then
+        render_all "$2"
+        exit 0
+      fi
+
       case "''${1:-}" in
         -U | --no-usage)
           show_usage_panel=0
@@ -1751,7 +2147,12 @@ let
       # unavailable or CODE_NO_FZF is set.
       if command -v fzf >/dev/null 2>&1 && [[ -z "''${CODE_NO_FZF:-}" ]]; then
         fzf_pick
-        [[ -n "$picked_idx" ]] && exec "''${exes[$picked_idx]}" "$@"
+        if [[ -n "$picked_idx" ]]; then
+          # Hold the starting card across omp's ~0.6s cold start (it clears + draws
+          # inline once ready) so the picker never flashes back to the terminal.
+          starting_card "$picked_idx"
+          exec "''${exes[$picked_idx]}" "$@"
+        fi
         exit 0
       fi
 
@@ -1824,6 +2225,12 @@ runCommand "omp-configured-${lib.getVersion omp}"
     ln -s ${lib.getExe ompFable} "$out/bin/ompf"
     ln -s ${lib.getExe ompContext} "$out/bin/ompx"
     ln -s ${lib.getExe ompFast} "$out/bin/ompz"
+    ln -s ${lib.getExe ompGptSpeed} "$out/bin/ompl"
+    ln -s ${lib.getExe ompClaudeSpeed} "$out/bin/ompk"
+    ln -s ${lib.getExe ompMixedRegular} "$out/bin/ompn"
+    ln -s ${lib.getExe ompMixedSmart} "$out/bin/ompm"
+    ln -s ${lib.getExe ompGptOnly} "$out/bin/ompo"
+    ln -s ${lib.getExe ompClaudeOnly} "$out/bin/ompe"
     ln -s ${lib.getExe ompHelp} "$out/bin/omph"
     ln -s ${lib.getExe ompUntrusted} "$out/bin/ompu"
     ln -s ${lib.getExe codeLauncher} "$out/bin/code"

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -997,6 +997,14 @@ let
   # `omp`/`ompu` are special builders (no preset), shown in the picker only.
   paletteProfiles = [
     {
+      cmd = "omp";
+      exe = lib.getExe ompDefault;
+      lead = "yours";
+      group = "";
+      blurb = "Your mutable daily driver (unmanaged)";
+      detail = "Runs upstream OMP with whatever your writable ~/.omp config selects. No managed defaults, preset, or policy overlay beyond the blocked update.";
+    }
+    {
       cmd = "ompz";
       exe = lib.getExe ompFast;
       lead = "mixed";
@@ -1049,14 +1057,6 @@ let
       blurb = "Fable-first, deterministic routing";
       detail = "Fable for the primary and deliberative roles with retry and server-side fallback OFF. The contract is: give me Fable, predictably, never silently swap. Background on cheap OpenAI rungs.";
       preset = presets.fable;
-    }
-    {
-      cmd = "omp";
-      exe = lib.getExe ompDefault;
-      lead = "yours";
-      group = "special";
-      blurb = "Your mutable daily driver (unmanaged)";
-      detail = "Runs upstream OMP with whatever your writable ~/.omp config selects. No managed defaults, preset, or policy overlay beyond the blocked update.";
     }
     {
       cmd = "ompx";
@@ -1537,28 +1537,42 @@ let
         esac
       }
 
-      # Recolour model tokens in a routing block: provider hue (muted blue for
-      # OpenAI, muted orange for Anthropic) with brightness scaled by the
-      # thinking level, so low -> xhigh reads as dim -> bright.
+      # Compact + recolour a routing block for the preview: shorten model names
+      # to their tier (gpt-5.6-sol -> sol, claude-fable-5 -> fable), collapse the
+      # column padding, and colour each token by provider hue (muted blue for
+      # OpenAI, muted orange for Anthropic) with brightness scaled by thinking
+      # level (low -> xhigh reads as dim -> bright). Kept narrow so fzf's preview
+      # (nowrap) never has to wrap ANSI lines, which it renders incorrectly.
       colorize_routes() {
         gawk -v dim="$c_dim" '
           function lvl(l) { return l=="minimal"?0:l=="low"?1:l=="medium"?2:l=="high"?3:l=="xhigh"?4:5 }
           function clamp(x) { return x>255?255:(x<0?0:int(x)) }
-          function paint(tok,   idx, level, f, br, bg, bb) {
+          function short(name,   a, n) {
+            if (name == "gpt-5.4") return "gpt-5.4"
+            n = split(name, a, "-")
+            if (name ~ /^claude/) return a[2]
+            return a[n]
+          }
+          function paint(tok,   idx, name, level, f, br, bg, bb) {
             idx = match(tok, /:(minimal|low|medium|high|xhigh|max)$/)
             if (idx == 0) return tok
-            level = substr(tok, idx + 1)
+            name = substr(tok, 1, idx - 1); level = substr(tok, idx + 1)
             if (tok ~ /^gpt/) { br = 110; bg = 170; bb = 240 }
             else if (tok ~ /^claude/) { br = 240; bg = 160; bb = 105 }
             else return tok
             f = 0.60 + lvl(level) * 0.088
-            return sprintf("\033[38;2;%d;%d;%dm%s%s", clamp(br*f), clamp(bg*f), clamp(bb*f), tok, dim)
+            return sprintf("\033[38;2;%d;%d;%dm%s:%s%s", clamp(br*f), clamp(bg*f), clamp(bb*f), short(name), level, dim)
           }
           {
-            line = $0; out = ""
+            line = $0
+            gsub(/ +→/, " →", line)
+            out = ""
+            # paint() calls match() internally, which clobbers RSTART/RLENGTH, so
+            # snapshot them before each call.
             while (match(line, /(gpt|claude)[A-Za-z0-9._-]*:(minimal|low|medium|high|xhigh|max)/)) {
-              out = out substr(line, 1, RSTART - 1) paint(substr(line, RSTART, RLENGTH))
-              line = substr(line, RSTART + RLENGTH)
+              s = RSTART; l = RLENGTH
+              out = out substr(line, 1, s - 1) paint(substr(line, s, l))
+              line = substr(line, s + l)
             }
             print out line
           }
@@ -1620,7 +1634,7 @@ let
           --border-label=" code $g_point pick a launcher " \
           --prompt="$g_search  " --pointer="$g_point" --marker='+' --info=inline \
           --delimiter=$'\t' --with-nth=2 \
-          --preview="cat $prevdir/{1}" --preview-window='right:50%:wrap:border-left' \
+          --preview="cat $prevdir/{1}" --preview-window='right:52%:nowrap:border-left' \
           "''${footer_args[@]}" \
           --color="$theme" || true)"
         rm -rf "$prevdir"

--- a/pkgs/omp-configured/render-omp-routes.sh
+++ b/pkgs/omp-configured/render-omp-routes.sh
@@ -131,8 +131,8 @@ done
 
 printf '%s' "$dim"
 printf 'scout is deliberately unpinned: it rides the smol route via its upstream frontmatter.\n'
-printf 'omp runs your own mutable config, unmanaged; ompu is the untrusted launcher\n'
-printf '(defaults routing, isolated state, restricted tools).\n'
+printf 'omp runs your own mutable config, unmanaged, so it is not listed above.\n'
+printf 'ompu adds isolated state and restricted tools over the defaults routing shown.\n'
 printf "pick a launcher interactively with 'code'; design rationale in omp/PROFILES.md.\n"
 printf 'source: omp/defaults.yml + omp/presets/*.yml — edit in the dotfiles repo, then zconf.\n'
 printf '%s' "$reset"


### PR DESCRIPTION
## Summary

Overhauls the `code` launcher picker and completes the managed omp profile matrix.

### Picker (`pkgs/omp-configured`)
- fzf picker with lazy + background-prewarmed previews (opens in ~tens of ms)
- category labels (mixed / gpt-led / claude-led / special), lane colours, flavourised blurbs
- per-provider usage panel (collector snapshot → `omp usage` fallback)
- `ctrl-f` cycles routing depth (lead → cross-provider net → full chain + rationale)
- full-screen "starting" card held across omp's cold start
- keyboard-driven (`--no-mouse`, kills trackpad hover-scroll); `shift/alt ↑↓` scroll the preview
- `omp`/`ompu` previews show real routing: `ompu` inherits the managed defaults; bare `omp`
  resolves *your* `~/.omp` (cached, background `omp config get`)

### Profiles (`omp/presets`, `defaults.yml`)
- 3×3 lane × tier matrix (mixed / gpt / claude × speed / regular / smart) + `gpt-only`,
  `claude-only`, and the fable / context / untrusted specials
- same-bucket → cross-provider redundancy doctrine in the fallback chains

### Docs
- `PROFILES.md` rewrite; new `pkgs/omp-configured/README.md` documenting the standalone
  `nix profile install github:atyrode/dotfiles#omp-configured` path

## Testing
- `nix build .#omp-configured` (shellcheck gate) — green
- `.#checks.x86_64-linux.omp-stack` — green
- Picker visuals verified via tmux captures (rows, previews, starting card, mouse bindings,
  usage panel)

## Follow-ups (roadmap)
Tracked in #80 + project "code launcher roadmap" (#3): advisor redesign (#73), preview config
surface (#74), portability (#75), provider-awareness (#76), usage-aware recommender (#77),
config immutability (#78), HTML wiki (#79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
