### PR TITLE
remove plaintext git credential store

### DIFF
--- a/home/git.nix
+++ b/home/git.nix
@@ -9,7 +9,8 @@
       user.email = "alex@tyrode.dev";
       user.signingKey = "${config.home.homeDirectory}/.ssh/id_ed25519_git_signing.pub";
       
-      credential.helper = "store";
+      # Never persist Git credentials in plaintext; use SSH remotes/agents or
+      # a platform credential manager instead.
       gpg.format = "ssh";
       gpg.ssh.allowedSignersFile = "${config.home.homeDirectory}/.config/git/allowed_signers";
       


### PR DESCRIPTION
## What changed

- Remove Git's `credential.helper = "store"` setting from the managed Git configuration.
- Document the intended SSH/agent or platform credential-manager boundary.

## Why

Git's `store` helper writes credentials in plaintext to `~/.git-credentials`. Removing it prevents the dotfiles from enabling that unsafe storage path.

## Validation

- `git diff --check`
- `nix flake check --all-systems --no-build --show-trace`

The commit is SSH-signed with the Mac key registered on GitHub.
