### PR TITLE
fix(checks): expect container-engine ok on alex-x86_64-linux

### DIFF
--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -185,9 +185,12 @@ pkgs.runCommand "check-atyrode-cli"
     fi
 
     minimal_result="$(atyrode doctor system alex-x86_64-linux --json)"
+    # alex-x86_64-linux carries the containers capability but not mobile, so
+    # container-engine resolves against the rootless fixture (ok) while
+    # device-permissions stays not-applicable — a mixed host, unlike the desktop.
     jq -e '
       .ok
-      and (.checks[] | select(.id == "container-engine") | .status) == "not-applicable"
+      and (.checks[] | select(.id == "container-engine") | .status) == "ok"
       and (.checks[] | select(.id == "device-permissions") | .status) == "not-applicable"
     ' <<< "$minimal_result" >/dev/null
 

--- a/inventory/hosts.tsv
+++ b/inventory/hosts.tsv
@@ -1,4 +1,4 @@
 alex-aarch64-darwin	aarch64-darwin	base,development,agent-tools,desktop,mobile,media,containers	Primary Apple Silicon Mac with the full development, agent, and desktop stack
 alex-aarch64-linux	aarch64-linux	base,development,agent-tools	Headless arm64 Linux development machine with agent tooling
-alex-x86_64-linux	x86_64-linux	base,development,agent-tools	Headless x86_64 Linux development machine with agent tooling
+alex-x86_64-linux	x86_64-linux	base,development,agent-tools,containers	Headless x86_64 Linux development machine with agent tooling
 alex-x86_64-linux-desktop	x86_64-linux	base,development,agent-tools,desktop,mobile,media,containers	x86_64 Linux workstation adding the desktop, mobile, media, and container stack


### PR DESCRIPTION
## Why

`d2629e7` (\"feat(hosts): enable containers on Linux host\") added the `containers` capability to `alex-x86_64-linux` but did **not** update the `atyrode-cli` doctor-system assertion, which still expected `container-engine` to be `not-applicable` for that host.

That commit was **pushed directly to `main`** (no PR), and its own CI run failed on exactly this contradiction — but a direct push is already landed, so `main` has been **red ever since** (the push run plus every nightly `schedule` run fail here). Any PR inherits the break through the `pull_request` merge commit.

## What

Update the minimal-host assertion to expect `container-engine == "ok"` (it resolves against the rootless fixture now that the capability is present), keeping `device-permissions == "not-applicable"` since the host still lacks `mobile`. This is a genuinely mixed host now — distinct from the desktop — which is a slightly better test than before.

## Verification

CI on this PR. Once green and merged, `main` is healthy again and the `code`-picker PR (#72) can rebase onto it to clear the same inherited failure.

## Follow-up (process, not code)

The root cause was a red change reaching `main` via a direct push. Worth enabling **branch protection** on `main` (require a PR + a green `Nix` status check before merge) so this can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)