### PR TITLE
feat(omp): redesign the advisor model per launcher (drop codex-spark)

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -106,7 +106,8 @@ The balanced routing rationale is:
 | `default` | Interactive daily work on Sol | Medium | Sol is the user-selected default; a Terra sibling absorbs a Sol blip, then Sonnet is the cross-provider net |
 | `task` | General implementation on Terra | Medium | Mid-cost worker; a Luna sibling first, then Sonnet crosses providers |
 | `librarian` | Repository and documentation research on Terra | Medium | A Luna sibling keeps the read-heavy role cheap, then Sonnet crosses for depth |
-| `advisor`, `smol`, `sonic` | Fast review, lookup, and naming on Luna | Minimal–low | Cheapest recurring work; no fallback chain — a blip is harmless and crossing them is wasteful |
+| `smol`, `sonic` | Fast lookup and naming on Luna | Minimal–low | Cheapest recurring work; no fallback chain — a blip is harmless and crossing them is wasteful |
+| `advisor` | Per-turn peer review — a judgment role, not a drain target | Tier-dependent | Base is a budget Haiku; per launcher it follows the tiered policy — Sonnet 5 on `smart` (Terra on `gpt-only`), Haiku on `regular`, **off** on `speed`/`budget` and `ompx`. See [PROFILES.md](../omp/PROFILES.md) principle 7 |
 | `tiny`, `commit` | Labels and commit messages on GPT-5.6-luna | Low | The cheapest supported Codex rung for text-trivial, always-on work; no fallback chain |
 | `designer` | Product and interface design on Sonnet | Medium | Crosses straight to Terra, Sonnet's price-twin (Sonnet has no lateral Anthropic sibling) |
 | `reviewer` | High-scrutiny review on Sonnet | High | Higher-cost quality gate; escalates to Opus, then Sol, if the primary is unavailable |

--- a/omp/PROFILES.md
+++ b/omp/PROFILES.md
@@ -76,16 +76,27 @@ Also not routed: the GPT-5.x back-catalog and the `-codex`-tuned variants.
 6. **Fast-execution roles drain the free Spark bucket first.** `gpt-5.3-codex-spark`
    has a separate, normally-idle 5h/7d Codex quota (see [Separate rate
    buckets](#separate-rate-buckets)), so execution/background roles lead on it.
-   Because the bucket is free and the goal is to empty it, the real-work roles
-   (`task`/`sonic`/`advisor`) run at **`:xhigh`** — best output *and* faster
-   drain — while boilerplate (`tiny`/`commit`) stays `:low`. The `speed` profiles
-   are the exception: they run Spark at `:low`, optimising latency over drain.
-   Spark stays off `smol`/scout (exploration can exceed its 128K window), the
-   thinking roles, `ompf`, and the claude-only pure pool.
-7. **Trivial roles stay lean.** Background gets at most a short cheap chain
+   Because the bucket is free and the goal is to empty it, the real-work coding
+   roles (`task`/`sonic`) run at **`:xhigh`** — best output *and* faster drain —
+   while boilerplate (`tiny`/`commit`) stays `:low`. The `speed` profiles are the
+   exception: they run Spark at `:low`, optimising latency over drain. Spark stays
+   off `smol`/scout (exploration can exceed its 128K window), the thinking roles,
+   `ompf`, the claude-only pure pool, and the `advisor` (principle 7).
+7. **The advisor is a judge, not a drain target.** It shadows every turn as a peer
+   reviewer, so it is a *judgment* role — matched to a model that reviews well,
+   never to whatever is cheap or idle (Spark is "coding-tuned and fast," a poor
+   reviewer). It scales with stakes: `smart` profiles run **Sonnet 5** (best
+   judgment-per-token, cheaper than their premium main; `gpt-only` stays on Terra
+   to remain single-auth), `regular` profiles a lighter **Haiku 4.5** at lower
+   cadence, and `speed`/`budget` turn it **off** — its ~2× token cost rivals their
+   cheap main, so those tokens buy a better main instead. `ompx` (1M context) also
+   runs it off: mirroring a million-token transcript every turn would cost more
+   than the work it shadows. Never the main model itself; cadence
+   (`advisor.syncBacklog`/`immuneTurns`) tightens on `smart`, loosens on `regular`.
+8. **Trivial roles stay lean.** Background gets at most a short cheap chain
    (Spark → a cheap rung → Haiku); a blip on a commit message is harmless. The
    full `A → A → B → B` redundancy is reserved for the substantive roles.
-8. **Thinking scales with stakes.** high/xhigh for `plan`/`slow`/`reviewer`/
+9. **Thinking scales with stakes.** high/xhigh for `plan`/`slow`/`reviewer`/
    `designer` and the `smart` leads; medium for the `regular` interactive default
    and workers; low/minimal for the `speed` leads and background.
 

--- a/omp/defaults.yml
+++ b/omp/defaults.yml
@@ -6,7 +6,7 @@ colorBlindMode: true
 
 modelRoles:
   default: openai-codex/gpt-5.6-sol:medium
-  advisor: openai-codex/gpt-5.6-luna:low
+  advisor: anthropic/claude-haiku-4-5:low
   smol: openai-codex/gpt-5.6-luna:low
   task: openai-codex/gpt-5.6-terra:medium
   sonic: openai-codex/gpt-5.6-luna:minimal

--- a/omp/presets/claude-hard.yml
+++ b/omp/presets/claude-hard.yml
@@ -6,12 +6,13 @@
 # single model.
 #
 # Background leads on gpt-5.3-codex-spark to drain its separate idle Codex bucket
-# (see omp/PROFILES.md). The bucket is free, so sonic/advisor run at :xhigh
-# (best output, faster drain) while tiny/commit stay :low; each falls back to
-# Haiku when exhausted. The substantive roles stay pool-pure on Claude.
+# (see omp/PROFILES.md). The bucket is free, so sonic runs at :xhigh (best output,
+# faster drain) while tiny/commit stay :low; each falls back to Haiku when
+# exhausted. The substantive roles stay pool-pure on Claude — including the
+# advisor, which judges on Sonnet 5 (a class under the Fable main), not Spark.
 modelRoles:
   default: anthropic/claude-fable-5:high
-  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  advisor: anthropic/claude-sonnet-5:high
   smol: anthropic/claude-haiku-4-5:low
   task: anthropic/claude-sonnet-5:medium
   sonic: openai-codex/gpt-5.3-codex-spark:xhigh
@@ -42,7 +43,7 @@ retry:
     librarian: [anthropic/claude-opus-4-8:medium, openai-codex/gpt-5.6-terra:medium, openai-codex/gpt-5.6-sol:medium]
     # Background drains the free Spark bucket, then a cheap Codex rung, then Haiku.
     sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
-    advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.6-terra:medium, anthropic/claude-haiku-4-5:low]
     tiny: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
     commit: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
 
@@ -53,5 +54,10 @@ task:
     reviewer: anthropic/claude-opus-4-8:high
     sonic: openai-codex/gpt-5.3-codex-spark:xhigh
     task: anthropic/claude-sonnet-5:medium
+
+# Smart tier: fresh, responsive advice on high-stakes work.
+advisor:
+  syncBacklog: "3"
+  immuneTurns: 2
 
 defaultThinkingLevel: medium

--- a/omp/presets/claude-only.yml
+++ b/omp/presets/claude-only.yml
@@ -4,7 +4,7 @@
 # Anthropic — draining the Claude plan, or when Codex is down or off-limits.
 modelRoles:
   default: anthropic/claude-opus-4-8:high
-  advisor: anthropic/claude-haiku-4-5:low
+  advisor: anthropic/claude-sonnet-5:high
   smol: anthropic/claude-haiku-4-5:low
   task: anthropic/claude-sonnet-5:medium
   sonic: anthropic/claude-haiku-4-5:low
@@ -31,7 +31,7 @@ retry:
     reviewer: [anthropic/claude-sonnet-5:high, anthropic/claude-haiku-4-5:high]
     librarian: [anthropic/claude-opus-4-8:medium, anthropic/claude-haiku-4-5:medium]
     sonic: [anthropic/claude-sonnet-5:low]
-    advisor: [anthropic/claude-sonnet-5:low]
+    advisor: [anthropic/claude-haiku-4-5:low]
     tiny: [anthropic/claude-sonnet-5:low]
     commit: [anthropic/claude-sonnet-5:low]
 
@@ -42,5 +42,10 @@ task:
     reviewer: anthropic/claude-opus-4-8:high
     sonic: anthropic/claude-haiku-4-5:low
     task: anthropic/claude-sonnet-5:medium
+
+# Smart tier: fresh, responsive advice on high-stakes work.
+advisor:
+  syncBacklog: "3"
+  immuneTurns: 2
 
 defaultThinkingLevel: medium

--- a/omp/presets/claude-speed.yml
+++ b/omp/presets/claude-speed.yml
@@ -1,6 +1,7 @@
 # ompk — claude·speed. The fastest, cheapest Claude tier at low thinking: Haiku
 # leads, background drains the free Spark bucket, and fallbacks are single fast
-# hops to GPT's cheap tier (Luna). Latency-first — this is Haiku's home.
+# hops to GPT's cheap tier (Luna). The advisor is off — a per-turn reviewer would
+# cost as much as the Haiku main it shadows. Latency-first — this is Haiku's home.
 modelRoles:
   default: anthropic/claude-haiku-4-5:low
   advisor: openai-codex/gpt-5.3-codex-spark:low
@@ -40,5 +41,9 @@ task:
     reviewer: anthropic/claude-sonnet-5:low
     sonic: openai-codex/gpt-5.3-codex-spark:low
     task: anthropic/claude-haiku-4-5:low
+
+# Speed tier: advisor off — its ~2x token cost rivals the cheap main model.
+advisor:
+  enabled: false
 
 defaultThinkingLevel: low

--- a/omp/presets/context-1m.yml
+++ b/omp/presets/context-1m.yml
@@ -51,4 +51,11 @@ task:
     sonic: openai-codex/gpt-5.3-codex-spark:xhigh
     task: anthropic/claude-sonnet-5:medium
 
+# Advisor off on ompx: it mirrors the full transcript every turn, so on a 1M
+# session each advise call would ingest up to a million tokens — a per-turn
+# watchdog that costs more than the huge-context work it shadows. Spend the
+# quota on the actual audit, not on shadowing it.
+advisor:
+  enabled: false
+
 defaultThinkingLevel: medium

--- a/omp/presets/fast-mixed.yml
+++ b/omp/presets/fast-mixed.yml
@@ -1,7 +1,8 @@
 # ompz — speed-first, mixed. The fastest competent tiers across both providers
 # at low thinking, with light fast fallbacks, for snappy interactive work where
 # latency beats depth. Luna/nano/Spark (OpenAI) and Sonnet/Haiku (Anthropic) are
-# all fast; nothing here reaches for Sol/Fable/Opus. Mixed pool by design.
+# all fast; nothing here reaches for Sol/Fable/Opus, and the advisor is off (it
+# would cost as much as the Luna main it shadows). Mixed pool by design.
 #
 # Note: unlike the drain-the-bucket profiles, task/background run Spark at :low
 # here — this profile optimises for latency, not for emptying the Spark quota.
@@ -41,5 +42,9 @@ task:
     reviewer: anthropic/claude-sonnet-5:low
     sonic: openai-codex/gpt-5.6-luna:low
     task: openai-codex/gpt-5.3-codex-spark:low
+
+# Speed tier: advisor off — its ~2x token cost rivals the cheap main model.
+advisor:
+  enabled: false
 
 defaultThinkingLevel: low

--- a/omp/presets/gpt-only.yml
+++ b/omp/presets/gpt-only.yml
@@ -1,10 +1,11 @@
 # ompo — gpt-only. Pure Codex, never crosses to Anthropic: Sol drives, redundancy
 # stays inside the Codex bucket (Sol -> Terra -> Luna), background drains the free
-# Spark bucket. Load this to keep every token on OpenAI — draining Codex, or when
-# the Claude plan is down or off-limits.
+# Spark bucket, and the advisor judges on Terra (Spark is too shallow to review,
+# and staying in-pool keeps this a single-auth profile). Load this to keep every
+# token on OpenAI — draining Codex, or when the Claude plan is down or off-limits.
 modelRoles:
   default: openai-codex/gpt-5.6-sol:high
-  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  advisor: openai-codex/gpt-5.6-terra:high
   smol: openai-codex/gpt-5.6-luna:low
   task: openai-codex/gpt-5.3-codex-spark:xhigh
   sonic: openai-codex/gpt-5.3-codex-spark:xhigh
@@ -42,5 +43,10 @@ task:
     reviewer: openai-codex/gpt-5.6-sol:high
     sonic: openai-codex/gpt-5.3-codex-spark:xhigh
     task: openai-codex/gpt-5.3-codex-spark:xhigh
+
+# Smart tier: fresh, responsive advice on high-stakes work.
+advisor:
+  syncBacklog: "3"
+  immuneTurns: 2
 
 defaultThinkingLevel: medium

--- a/omp/presets/gpt-speed.yml
+++ b/omp/presets/gpt-speed.yml
@@ -1,8 +1,9 @@
 # ompl — gpt·speed. The fastest, cheapest Codex tier at low thinking: Luna leads,
 # task drains the free Spark bucket, and fallbacks are single fast hops to
 # Claude's cheap tier (Haiku) — no same-bucket sibling detour (that would mean a
-# slower model). Latency-first; nothing reaches for Sol or high thinking. ompz's
-# pure-GPT sibling.
+# slower model). Latency-first; nothing reaches for Sol or high thinking. The
+# advisor is off — a per-turn reviewer would cost as much as the Luna main it
+# shadows, so those tokens go to the work instead. ompz's pure-GPT sibling.
 modelRoles:
   default: openai-codex/gpt-5.6-luna:low
   advisor: openai-codex/gpt-5.6-luna:low
@@ -38,5 +39,9 @@ task:
     reviewer: openai-codex/gpt-5.6-terra:low
     sonic: openai-codex/gpt-5.6-luna:low
     task: openai-codex/gpt-5.3-codex-spark:low
+
+# Speed tier: advisor off — its ~2x token cost rivals the cheap main model.
+advisor:
+  enabled: false
 
 defaultThinkingLevel: low

--- a/omp/presets/gpt56.yml
+++ b/omp/presets/gpt56.yml
@@ -1,14 +1,15 @@
 # Sol drives the thinking roles; the fast-execution roles (task + background)
 # lead on gpt-5.3-codex-spark to drain its separate idle 5h/7d Codex bucket (see
-# omp/PROFILES.md "Separate rate buckets"). The bucket is free, so the roles
-# that do real work (task/sonic/advisor) run at :xhigh — best output and faster
-# drain — while boilerplate (tiny/commit) stays :low. Each falls back the
-# instant its bucket is exhausted — task to the terra/luna chain, background to
-# nano. The substantive chains still end on Anthropic. smol/scout stay off Spark
-# (exploration context can exceed 128K).
+# omp/PROFILES.md "Separate rate buckets"). The bucket is free, so the coding
+# roles that drain it (task/sonic) run at :xhigh — best output and faster drain —
+# while boilerplate (tiny/commit) stays :low. The advisor is a judgment role, not
+# a drain target, so it runs on Sonnet 5 (cheaper than the Sol main) rather than
+# Spark. Each falls back the instant its bucket is exhausted — task to the
+# terra/luna chain, background to nano. The substantive chains still end on
+# Anthropic. smol/scout stay off Spark (exploration context can exceed 128K).
 modelRoles:
   default: openai-codex/gpt-5.6-sol:high
-  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  advisor: anthropic/claude-sonnet-5:high
   smol: openai-codex/gpt-5.6-luna:low
   task: openai-codex/gpt-5.3-codex-spark:xhigh
   sonic: openai-codex/gpt-5.3-codex-spark:xhigh
@@ -44,7 +45,7 @@ retry:
     reviewer: [openai-codex/gpt-5.6-terra:high, anthropic/claude-opus-4-8:high, anthropic/claude-sonnet-5:high]
     librarian: [openai-codex/gpt-5.6-sol:medium, anthropic/claude-sonnet-5:medium, anthropic/claude-opus-4-8:medium]
     sonic: [openai-codex/gpt-5.6-luna:low]
-    advisor: [openai-codex/gpt-5.6-luna:low]
+    advisor: [openai-codex/gpt-5.6-terra:medium, anthropic/claude-haiku-4-5:low]
     tiny: [openai-codex/gpt-5.6-luna:low]
     commit: [openai-codex/gpt-5.6-luna:low]
 
@@ -55,3 +56,8 @@ task:
     reviewer: openai-codex/gpt-5.6-sol:high
     sonic: openai-codex/gpt-5.3-codex-spark:xhigh
     task: openai-codex/gpt-5.3-codex-spark:xhigh
+
+# Smart tier: fresh, responsive advice on high-stakes work.
+advisor:
+  syncBacklog: "3"
+  immuneTurns: 2

--- a/omp/presets/mixed-regular.yml
+++ b/omp/presets/mixed-regular.yml
@@ -1,11 +1,12 @@
 # ompn — mixed·regular. A balanced daily driver across both pools at medium
 # thinking: Claude leads judgment (default/designer/reviewer/plan), GPT leads
-# execution (task/librarian/slow), background drains Spark. Full redundancy —
-# every substantive lead carries a same-bucket sibling, then crosses to the
-# capability-matched model on the other provider (+ its sibling).
+# execution (task/librarian/slow), background drains Spark, and a light Haiku
+# advisor watches at low cadence. Full redundancy — every substantive lead
+# carries a same-bucket sibling, then crosses to the capability-matched model on
+# the other provider (+ its sibling).
 modelRoles:
   default: anthropic/claude-sonnet-5:medium
-  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  advisor: anthropic/claude-haiku-4-5:low
   smol: openai-codex/gpt-5.6-luna:low
   task: openai-codex/gpt-5.6-terra:medium
   sonic: openai-codex/gpt-5.3-codex-spark:xhigh
@@ -32,7 +33,7 @@ retry:
     reviewer: [anthropic/claude-opus-4-8:high, openai-codex/gpt-5.6-terra:high, openai-codex/gpt-5.6-sol:high]
     librarian: [openai-codex/gpt-5.6-sol:medium, anthropic/claude-sonnet-5:medium, anthropic/claude-opus-4-8:medium]
     sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
-    advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.6-luna:low]
     tiny: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
     commit: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
 
@@ -43,5 +44,10 @@ task:
     reviewer: anthropic/claude-sonnet-5:high
     sonic: openai-codex/gpt-5.3-codex-spark:xhigh
     task: openai-codex/gpt-5.6-terra:medium
+
+# Regular tier: a lighter-touch advisor — lower sync, longer anti-nag debounce.
+advisor:
+  syncBacklog: "1"
+  immuneTurns: 4
 
 defaultThinkingLevel: medium

--- a/omp/presets/mixed-smart.yml
+++ b/omp/presets/mixed-smart.yml
@@ -1,10 +1,11 @@
 # ompm — mixed·smart. The hardest work, best model per task across both pools at
 # high thinking: Sol drives the GPT-strength roles, Fable/Opus the Claude-strength
-# ones (design, planning, review), Spark drains in the background. Full redundancy
-# on every substantive lead. When only the best will do, from either provider.
+# ones (design, planning, review), Spark drains the background, and a Sonnet 5
+# sidecar advises. Full redundancy on every substantive lead. When only the best
+# will do, from either provider.
 modelRoles:
   default: openai-codex/gpt-5.6-sol:high
-  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  advisor: anthropic/claude-sonnet-5:high
   smol: openai-codex/gpt-5.6-luna:low
   task: openai-codex/gpt-5.6-sol:high
   sonic: openai-codex/gpt-5.3-codex-spark:xhigh
@@ -32,7 +33,7 @@ retry:
     reviewer: [anthropic/claude-sonnet-5:high, openai-codex/gpt-5.6-sol:high, openai-codex/gpt-5.6-terra:high]
     librarian: [openai-codex/gpt-5.6-sol:medium, anthropic/claude-sonnet-5:medium, anthropic/claude-opus-4-8:medium]
     sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
-    advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.6-terra:medium, anthropic/claude-haiku-4-5:low]
     tiny: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
     commit: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
 
@@ -43,5 +44,10 @@ task:
     reviewer: anthropic/claude-opus-4-8:high
     sonic: openai-codex/gpt-5.3-codex-spark:xhigh
     task: openai-codex/gpt-5.6-sol:high
+
+# Smart tier: fresh, responsive advice on high-stakes work.
+advisor:
+  syncBacklog: "3"
+  immuneTurns: 2
 
 defaultThinkingLevel: high

--- a/omp/presets/sonnet-value.yml
+++ b/omp/presets/sonnet-value.yml
@@ -6,12 +6,13 @@
 #
 # Background leads on gpt-5.3-codex-spark to drain its separate idle Codex bucket
 # (see omp/PROFILES.md) rather than spend the Claude plan on trivia. The bucket
-# is free, so sonic/advisor run at :xhigh (best output, faster drain) while the
+# is free, so sonic runs at :xhigh (best output, faster drain) while the
 # tiny/commit one-liners stay :low; each falls back to Haiku when Spark is
-# exhausted. The substantive roles stay pool-pure on Claude.
+# exhausted. The substantive roles stay pool-pure on Claude — and the advisor
+# judges on Haiku (a class under the Sonnet main), not Spark.
 modelRoles:
   default: anthropic/claude-sonnet-5:medium
-  advisor: openai-codex/gpt-5.3-codex-spark:xhigh
+  advisor: anthropic/claude-haiku-4-5:low
   smol: anthropic/claude-haiku-4-5:low
   task: anthropic/claude-sonnet-5:medium
   sonic: openai-codex/gpt-5.3-codex-spark:xhigh
@@ -44,7 +45,7 @@ retry:
     # Haiku. Left lean on purpose — a blip on background trivia is harmless, and
     # Spark is a separate drain bucket, not a redundancy target.
     sonic: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
-    advisor: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
+    advisor: [openai-codex/gpt-5.6-luna:low]
     tiny: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
     commit: [openai-codex/gpt-5.6-luna:low, anthropic/claude-haiku-4-5:low]
 
@@ -55,5 +56,10 @@ task:
     reviewer: anthropic/claude-sonnet-5:high
     sonic: openai-codex/gpt-5.3-codex-spark:xhigh
     task: anthropic/claude-sonnet-5:medium
+
+# Regular tier: a lighter-touch advisor — lower sync, longer anti-nag debounce.
+advisor:
+  syncBacklog: "1"
+  immuneTurns: 4
 
 defaultThinkingLevel: medium

--- a/pkgs/omp-configured/render-omp-routes.sh
+++ b/pkgs/omp-configured/render-omp-routes.sh
@@ -97,6 +97,8 @@ render_profile() {
   local primary override marker line step
   local -a chain
   for role in "${roles[@]}"; do
+    # A disabled advisor never runs; don't list it as a route.
+    [[ $role == advisor && $advisor_enabled != true ]] && continue
     primary=$(jq -r --arg role "$role" '.modelRoles[$role]' <<<"$merged")
     marker=' '
     if is_agent "$role"; then


### PR DESCRIPTION
Closes #73.

## Why

The advisor shadows every turn as a peer reviewer — a **judgment** role — yet 8 launchers pinned it to `gpt-5.3-codex-spark:xhigh`, a speed-first coding model with deliberately shallow reasoning (a poor reviewer). The only rationale was draining Spark's free quota bucket — the wrong reason to pick a reviewer.

## Policy (tiered by stakes)

| Tier | Launchers | Advisor | Cadence |
| --- | --- | --- | --- |
| Smart | mixed-smart, gpt56, claude-hard, claude-only | **Sonnet 5** (best judgment-per-token, cheaper than the premium main) | sync 3 / immune 2 |
| Smart (pure-GPT) | gpt-only | **Terra** (stays single-auth) | sync 3 / immune 2 |
| Regular | mixed-regular, sonnet-value | **Haiku 4.5** | sync 1 / immune 4 |
| Off | gpt-speed, claude-speed, fast-mixed, budget | — (cost rivals the cheap main) | — |
| Off | **ompx / context-1m** | — (a per-turn mirror of a 1M transcript costs more than the work) | — |

Decisions confirmed with the operator: Sonnet-5-cross-provider for smart, advisor off on speed/budget, cadence tuned per tier. `ompx` off is my call (the 1M-mirror cost argument) — flagging it for your review.

## Also

- **Spark stays where it belongs** — draining on `sonic`/background coding roles (unchanged).
- **Renderer** skips the advisor row when `advisor.enabled` is false, so advisor-off profiles read cleanly; the `code` picker preview sources the same routes page, so it's fixed too.
- **Base** `defaults.yml` advisor moves from extraction-tuned Luna to a budget Haiku judge.
- **Docs**: PROFILES.md gains principle 7 ("the advisor is a judge, not a drain target"); docs/agent-tools.md splits the advisor out of the trivial-roles row.
- `advisor.immuneTurns` is set per-preset but deliberately **not** added to the managed-path list, so the migration test's preserved-unmanaged-key example still holds.
- Advisor-off profiles keep their prior `modelRoles.advisor` pin as an **inert** value (hidden by the renderer); not worth churning pre-existing profiles to strip.

## Verification

Rendered the routes locally (via `render-omp-routes.sh`): smart shows `advisor claude-sonnet-5:high`, gpt-only `advisor gpt-5.6-terra:high`, regular `advisor claude-haiku-4-5:low`, and advisor-off profiles show `advisor off` with **no** advisor row while `sonic` keeps `codex-spark:xhigh`. All preset YAML validated. CI on this PR is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)