### PR TITLE
feat(omp): surface per-launcher behaviour in the code picker preview

### DIFF
--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1868,6 +1868,12 @@ let
             ;;
         esac
         [[ -f "$routes_plain" ]] || return 0
+        # Behaviour summary (thinking baseline / fallback / advisor), lifted from
+        # the 2nd line of the profile's block in the generated routes page so it
+        # cannot drift from the deployed config.
+        local cfg
+        cfg="$(sed -n "/^''${names[$idx]}  /,/^\$/p" "$routes_plain" | sed -n '2s/^  *//p')"
+        [[ -n "$cfg" ]] && printf '\n%s%s%s\n' "$c_dim" "$cfg" "$c_rst"
         case "$s" in
           0)
             block="$(sed -n "/^''${names[$idx]}  /,/^\$/p" "$routes_plain" | colorize_routes lead)"

--- a/pkgs/omp-configured/render-omp-routes.sh
+++ b/pkgs/omp-configured/render-omp-routes.sh
@@ -76,9 +76,16 @@ render_profile() {
   advisor_enabled=$(jq -r '.advisor.enabled // false' <<<"$merged")
   fallback=$(jq -r '(.retry.enabled // false) and (.retry.modelFallback // false)' <<<"$merged")
 
-  local advisor_note='advisor off' fallback_note='fallback disabled'
-  [[ $advisor_enabled == true ]] && advisor_note='advisor on'
-  [[ $fallback == true ]] && fallback_note='fallback enabled'
+  local advisor_note fallback_note
+  if [[ $advisor_enabled == true ]]; then
+    local advisor_model
+    advisor_model=$(jq -r '.modelRoles.advisor // "?"' <<<"$merged")
+    advisor_note="advisor $(short_model "$advisor_model")"
+  else
+    advisor_note='advisor off'
+  fi
+  fallback_note='fallback off'
+  [[ $fallback == true ]] && fallback_note='fallback on'
 
   printf '%s%s%s  %s\n' "$bold" "$name" "$reset" "$description"
   printf '  %sthinking %s · %s · %s%s\n' "$dim" "$thinking" "$fallback_note" "$advisor_note" "$reset"
@@ -132,6 +139,10 @@ for spec in "$@"; do
 done
 
 printf '%s' "$dim"
+printf 'the per-profile line reads: thinking baseline · fallback · advisor. A role'"'"'s :level\n'
+printf 'always wins; "thinking" is only the default for unpinned/ad-hoc calls ("auto" = a\n'
+printf 'per-turn classifier). All managed launchers share the enforced posture: approvals\n'
+printf 'yolo · task isolation auto · secrets on.\n'
 printf 'scout is deliberately unpinned: it rides the smol route via its upstream frontmatter.\n'
 printf 'omp runs your own mutable config, unmanaged, so it is not listed above.\n'
 printf 'ompu adds isolated state and restricted tools over the defaults routing shown.\n'


### PR DESCRIPTION
Part of #74.

## Problem

The `code` picker preview showed each launcher's routing but hid the config that most shapes its behaviour — you couldn't tell at a glance whether a launcher runs the advisor, on what model, or whether fallback is on. `colorize_routes` deliberately dropped the `thinking · fallback · advisor` line as "redundant with the per-role levels" — but after the #73 advisor redesign that line now carries real per-launcher signal.

## What

- **Enrich** the line `render-omp-routes.sh` emits: advisor shows its *model* (`advisor claude-sonnet-5:high`) or `off`; fallback reads `on`/`off`.
- **Surface** it in the picker preview, lifted from the 2nd line of the profile's block in the generated routes page (so it can't drift from deployed config), shown once above the routing section at every `ctrl-f` depth.
- **Footer legend** explaining the thinking model (a role's `:level` always wins; the profile "thinking" is only the baseline for unpinned/ad-hoc calls; `auto` = per-turn classifier) and the enforced posture shared by all launchers.

## Rendered (verified locally)

```
ompm   thinking high · fallback on · advisor claude-sonnet-5:high
ompo   thinking medium · fallback on · advisor gpt-5.6-terra:high
ompn   thinking medium · fallback on · advisor claude-haiku-4-5:low
ompk   thinking low · fallback on · advisor off
ompf   thinking medium · fallback off · advisor off
```

## Scope decisions (issue open questions)

- **One-line summary, always shown** (not a labeled block behind `ctrl-f`) — fits the preview, stays legible.
- **Approvals/isolation/memory** are policy-enforced and *identical* across all managed launchers, so they'd be per-launcher noise — surfaced once in the footer instead.
- **Bare `omp`'s** own thinking/advisor summary deferred to a follow-up (it reads the user's live config via `omp config get`, not the routes page). This keeps the issue mostly done; I left it as "Part of #74" rather than "Closes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)