### PR TITLE
fix(omp): advisor settings line shows on/off, not the model (dedup)

### DIFF
--- a/pkgs/omp-configured/render-omp-routes.sh
+++ b/pkgs/omp-configured/render-omp-routes.sh
@@ -76,14 +76,10 @@ render_profile() {
   advisor_enabled=$(jq -r '.advisor.enabled // false' <<<"$merged")
   fallback=$(jq -r '(.retry.enabled // false) and (.retry.modelFallback // false)' <<<"$merged")
 
-  local advisor_note fallback_note
-  if [[ $advisor_enabled == true ]]; then
-    local advisor_model
-    advisor_model=$(jq -r '.modelRoles.advisor // "?"' <<<"$merged")
-    advisor_note="advisor $(short_model "$advisor_model")"
-  else
-    advisor_note='advisor off'
-  fi
+  # advisor on/off only — the model itself is shown once, in the advisor route
+  # row below (which is hidden entirely when the advisor is off).
+  local advisor_note='advisor off' fallback_note
+  [[ $advisor_enabled == true ]] && advisor_note='advisor on'
   fallback_note='fallback off'
   [[ $fallback == true ]] && fallback_note='fallback on'
 


### PR DESCRIPTION
Follow-up to #85, per operator feedback: the per-launcher settings line duplicated the advisor model, which already appears in the advisor route row right below it.

Now the settings line reads `advisor on` / `advisor off`; the model is shown once, in the routing row (hidden when off, so "off" in the settings line is unambiguous).

```
ompm   thinking high · fallback on · advisor on       ← settings line
  ● advisor  claude-sonnet-5:high → …                 ← model, once
ompk   thinking low · fallback on · advisor off        ← no advisor row below
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)