### PR TITLE
fix(agent-tools): accept safe empty completed receipts

### DIFF
--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -1091,6 +1091,40 @@ in
             "$migration" finalize "$empty_home_files"
             test "$(find "$state_root" -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1
 
+            reboot_home="$TMPDIR/reboot-home"
+            HOME="$reboot_home" "$migration" prepare
+            reboot_complete="$reboot_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete"
+            HOME="$reboot_home" "$migration" finalize "$empty_home_files"
+            : > "$reboot_complete/receipt.tsv"
+            HOME="$reboot_home" "$migration" prepare
+            HOME="$reboot_home" "$migration" finalize "$empty_home_files"
+            test -d "$reboot_complete"
+            test -z "$(find "$reboot_complete/backup" "$reboot_complete/work" -mindepth 1 -print -quit)"
+
+            retained_empty_home="$TMPDIR/retained-empty-home"
+            retained_empty_complete="$retained_empty_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete"
+            mkdir -p "$retained_empty_complete/backup/.local/bin" "$retained_empty_complete/work"
+            : > "$retained_empty_complete/receipt.tsv"
+            printf 'unrecorded operator data\n' > "$retained_empty_complete/backup/.local/bin/omp"
+            if HOME="$retained_empty_home" "$migration" prepare \
+              > "$TMPDIR/retained-empty.out" 2> "$TMPDIR/retained-empty.err"; then
+              exit 1
+            fi
+            grep -q 'empty receipt with retained migration data' "$TMPDIR/retained-empty.err"
+
+            symlinked_complete_home="$TMPDIR/symlinked-complete-home"
+            mkdir -p "$symlinked_complete_home/state-target/backup" \
+              "$symlinked_complete_home/state-target/work" \
+              "$symlinked_complete_home/.local/state/atyrode/agent-tools-migration"
+            : > "$symlinked_complete_home/state-target/receipt.tsv"
+            ln -s "$symlinked_complete_home/state-target" \
+              "$symlinked_complete_home/.local/state/atyrode/agent-tools-migration/migration-v2.complete"
+            if HOME="$symlinked_complete_home" "$migration" prepare \
+              > "$TMPDIR/symlinked-complete.out" 2> "$TMPDIR/symlinked-complete.err"; then
+              exit 1
+            fi
+            grep -q 'not a migration receipt directory' "$TMPDIR/symlinked-complete.err"
+
             dry_home="$TMPDIR/dry-home"
             mkdir -p "$dry_home/.local/bin"
             cp "$complete/backup/.local/bin/omp" "$dry_home/.local/bin/omp"

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -323,7 +323,10 @@ finalizer verifies every retired path and transformed config, then atomically
 renames the pending directory to `migration-v2.complete`; the backups remain
 inside it for manual recovery. Existing installations with the former
 `migration-v2.complete` marker
-file remain recognized.
+file remain recognized. A zero-length receipt produced by an earlier blank-home
+activation is also recognized only when both its backup and work trees are
+empty; retained data, malformed non-empty receipts, and unsafe links still stop
+activation for manual review.
 
 Receipts, backup/work directories, lock handling, and same-directory temporary
 files are validated so symlinks cannot redirect writes outside the transaction.

--- a/scripts/agent-tools-migrate.sh
+++ b/scripts/agent-tools-migrate.sh
@@ -204,6 +204,30 @@ validate_receipt() {
     fail "$receipt is incomplete"
 }
 
+validate_completed_receipt() {
+  local transaction_dir="$1"
+  local receipt="$transaction_dir/receipt.tsv"
+
+  if [[ -f "$receipt" && ! -L "$receipt" && ! -s "$receipt" ]]; then
+    local receipt_dir
+    [[ -d "$transaction_dir" && ! -L "$transaction_dir" ]] ||
+      fail "$transaction_dir is not a migration receipt directory"
+    for receipt_dir in "$transaction_dir/backup" "$transaction_dir/work"; do
+      [[ -d "$receipt_dir" && ! -L "$receipt_dir" ]] ||
+        fail "$receipt_dir is not a safe receipt directory"
+      local -a entries=()
+      shopt -s dotglob nullglob
+      entries=("$receipt_dir"/*)
+      shopt -u dotglob nullglob
+      [[ "${#entries[@]}" -eq 0 ]] ||
+        fail "$transaction_dir has an empty receipt with retained migration data"
+    done
+    return 0
+  fi
+
+  validate_receipt "$transaction_dir"
+}
+
 validate_terminal_state() {
   if path_exists "$pending" && path_exists "$complete"; then
     fail "both pending and completed migration state exist under $state_root"
@@ -213,7 +237,7 @@ validate_terminal_state() {
     if [[ -f "$complete" && ! -L "$complete" ]]; then
       [[ "$(cat "$complete")" == "completed" ]] || fail "$complete is not a recognized legacy marker"
     else
-      validate_receipt "$complete"
+      validate_completed_receipt "$complete"
     fi
     return 0
   fi


### PR DESCRIPTION
## Summary

- accept legacy zero-length completed migration receipts only when backup and work trees are safe and empty
- retain strict rejection for pending, populated, malformed, symlinked, or ambiguous receipts
- add reboot-equivalent and security regression coverage

## Validation

- `nix build .#checks.x86_64-linux.agent-tools-migration --no-link`
- `bash -n scripts/agent-tools-migrate.sh`
- `git diff --check`

The full flake evaluated successfully but its 87 broad builds were left to CI.

Closes #91. Unblocks the disposable runtime proof in `tyrode-dev/infra#23` and draft PR `tyrode-dev/infra#104`.
