### PR TITLE
feat(omp): cross-provider diversity + stacked narrow layout for `code`

### DIFF
--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -556,12 +556,14 @@ func parseAdvisors(rows []string) map[string][]string {
 	return out
 }
 
-// advisorChain returns the advisor role's model chain for an intensity + lane:
-// a pure GPT pool keeps a GPT advisor, otherwise it crosses to Claude for the
-// most independent second opinion. Sourced from the baked __advisors__ table.
+// advisorChain returns the advisor role's model chain for an intensity + lane,
+// sourced from the baked __advisors__ table. The advisor is the independent
+// second opinion, so it uses the opposite provider to the lane's preference — GPT
+// on a Claude-led (or pure-GPT) lane, Claude otherwise. Only the pure lanes stay
+// on their own provider (gpt-only keeps GPT; claude-only keeps Claude).
 func (m model) advisorChain(level, lane string) []string {
 	ctx := "claude"
-	if lane == "gpt-only" {
+	if lane == "gpt-only" || lane == "claude-led" {
 		ctx = "gpt"
 	}
 	return m.advisors[level+"/"+ctx]
@@ -729,12 +731,12 @@ const (
 
 // layout modes, chosen from the terminal size (unless the user collapses):
 //
-//	stacked   — wide+tall: generator on top, profiles below, preview on the right
-//	split     — medium:    the focused list on the left, preview on the right
-//	collapsed — narrow/‹p›: one full-width pane (list, or the result with showResult)
+//	split     — wide:            the focused list on the left, preview on the right
+//	stacked   — narrow but tall: list on top, preview stacked below it (full width)
+//	collapsed — narrow+short/‹p›: one full-width pane (list, or result w/ showResult)
 const (
-	modeStacked = iota
-	modeSplit
+	modeSplit = iota
+	modeStacked
 	modeCollapsed
 )
 
@@ -758,10 +760,71 @@ func (m model) mode() int {
 	if m.collapse {
 		return modeCollapsed
 	}
-	if m.w < m.genRowWidth()+33 { // no room for the gen list + a useful preview
-		return modeCollapsed
+	if m.w >= m.genRowWidth()+33 { // room for the list + a useful side preview
+		return modeSplit
 	}
-	return modeSplit
+	// too narrow for side-by-side; stack the preview below the list if the
+	// terminal is tall enough to give both panes a usable share, else collapse.
+	if m.bodyH() >= 15 {
+		return modeStacked
+	}
+	return modeCollapsed
+}
+
+// bodyH is the height available above the pinned footer.
+func (m model) bodyH() int {
+	h := m.h - lipgloss.Height(m.footer())
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+// bodyLines renders the active section's scrolling list (the generator facets or
+// the profile palette) and reports the cursor's line index within it.
+func (m model) bodyLines(w int) ([]string, int) {
+	if m.view == pickerView {
+		return m.pickerLines(true, w)
+	}
+	return m.genLines(true)
+}
+
+// stackedSplit divides the inner body height (minus the 2-line tab head and the
+// 1-line divider) between the list and the preview: the list takes what its
+// content needs, capped at ~60% and floored so the preview keeps ≥ minPrev rows.
+func stackedSplit(bodyH, bodyLen int) (listH, prevH int) {
+	const head, sep, minPrev, minList = 2, 1, 6, 3
+	inner := bodyH - head - sep
+	listH = bodyLen
+	if c := inner * 3 / 5; listH > c {
+		listH = c
+	}
+	if listH > inner-minPrev {
+		listH = inner - minPrev
+	}
+	if listH < minList {
+		listH = minList
+	}
+	prevH = inner - listH
+	if prevH < minPrev {
+		prevH = minPrev
+	}
+	return
+}
+
+// previewDims returns the preview viewport's inner (width, height) for the mode.
+func (m model) previewDims() (int, int) {
+	bodyH := m.bodyH()
+	switch m.mode() {
+	case modeCollapsed:
+		return m.w, bodyH
+	case modeStacked:
+		body, _ := m.bodyLines(m.w)
+		_, ph := stackedSplit(bodyH, len(body))
+		return m.w, ph
+	default: // split
+		return m.w - m.listW() - 3, bodyH
+	}
 }
 
 type model struct {
@@ -1067,23 +1130,19 @@ func (m *model) footer() string {
 }
 
 func (m *model) relayout() {
-	pw := m.w - m.listW() - 3
-	if m.mode() == modeCollapsed {
-		pw = m.w
-	}
+	m.help.Width = m.w
+	pw, ph := m.previewDims()
 	if pw < 10 {
 		pw = 10
 	}
-	m.help.Width = m.w
-	vh := m.h - lipgloss.Height(m.footer())
-	if vh < 3 {
-		vh = 3
+	if ph < 3 {
+		ph = 3
 	}
 	if !m.rdy {
-		m.vp = viewport.New(pw, vh)
+		m.vp = viewport.New(pw, ph)
 		m.rdy = true
 	} else {
-		m.vp.Width, m.vp.Height = pw, vh
+		m.vp.Width, m.vp.Height = pw, ph
 	}
 	m.syncPreview()
 }
@@ -1124,10 +1183,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.syncPreview()
 		case "p":
-			if m.w >= 62 {
-				m.collapse = !m.collapse // hide/show the side preview
-			} else {
-				m.showResult = !m.showResult // narrow: swap list ↔ result full-screen
+			switch {
+			case m.collapse:
+				m.collapse = false // restore the hidden preview
+			case m.mode() == modeCollapsed:
+				m.showResult = !m.showResult // narrow+short: swap list ↔ result full-screen
+			default:
+				m.collapse = true // split/stacked: hide the preview, list full-screen
 			}
 			m.relayout()
 		case "?":
@@ -1214,11 +1276,11 @@ func (m *model) cycleFacet(dir int) {
 	m.syncPreview()
 }
 
-func (m model) previewPane() string {
+func (m model) previewPane(w, h int) string {
 	return lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder(), false, false, false, true).
 		BorderForeground(lipgloss.Color(cBord)).PaddingLeft(2).
-		Width(m.w - m.listW() - 3).Height(m.vp.Height).
+		Width(w).Height(h).
 		Render(m.vp.View())
 }
 
@@ -1316,25 +1378,29 @@ func scrollbar(total, h, start int) string {
 	return b.String()
 }
 
-func (m model) leftColumn(full bool) string {
-	w := m.listW()
-	if full {
-		w = m.w
-	}
-	var body []string
-	var bcur int
-	if m.view == pickerView {
-		body, bcur = m.pickerLines(true, w)
-	} else {
-		body, bcur = m.genLines(true)
-	}
+// leftColumn renders the pinned section tabs plus the scrolling list body,
+// clipped to bodyH rows and w columns.
+func (m model) leftColumn(w, bodyH int) string {
+	body, bcur := m.bodyLines(w)
 	// the tab switcher + a blank line stay pinned; only the body scrolls.
 	head := m.sectionTabs() + "\n\n"
-	bodyH := m.vp.Height - 2
 	if bodyH < 1 {
 		bodyH = 1
 	}
 	return head + windowList(body, bcur, bodyH, w)
+}
+
+// stackedContent is the narrow-but-tall layout: tabs + list on top, a divider,
+// then the preview stacked below — all full width. The preview keeps its own
+// viewport, so it scrolls (mouse wheel) independently of the list above it.
+func (m model) stackedContent(bodyH int) string {
+	w := m.w
+	body, bcur := m.bodyLines(w)
+	listH, prevH := stackedSplit(bodyH, len(body))
+	list := m.sectionTabs() + "\n\n" + windowList(body, bcur, listH, w)
+	div := stDim.Render(strings.Repeat("─", w))
+	preview := lipgloss.NewStyle().Width(w).Height(prevH).MaxHeight(prevH).Render(m.vp.View())
+	return lipgloss.JoinVertical(lipgloss.Left, list, div, preview)
 }
 
 func (m model) View() string {
@@ -1342,19 +1408,21 @@ func (m model) View() string {
 		return "loading…"
 	}
 	foot := m.footer()
-	bodyH := m.h - lipgloss.Height(foot)
-	if bodyH < 1 {
-		bodyH = 1
-	}
+	bodyH := m.bodyH()
 	var content string
-	if m.mode() == modeCollapsed {
+	switch m.mode() {
+	case modeCollapsed:
 		if m.showResult && m.w < 62 {
 			content = m.vp.View()
 		} else {
-			content = m.leftColumn(true)
+			content = m.leftColumn(m.w, bodyH-2)
 		}
-	} else {
-		content = lipgloss.JoinHorizontal(lipgloss.Top, m.leftColumn(false), m.previewPane())
+	case modeStacked:
+		content = m.stackedContent(bodyH)
+	default: // split
+		content = lipgloss.JoinHorizontal(lipgloss.Top,
+			m.leftColumn(m.listW(), bodyH-2),
+			m.previewPane(m.w-m.listW()-3, bodyH))
 	}
 	// Pin the body into a fixed box (top-left) with lipgloss, then clip: any
 	// stray overflow (e.g. a glyph a terminal renders wider than measured) is

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -740,6 +740,25 @@ const (
 	modeCollapsed
 )
 
+// gut is the left gutter every panel shares, so the whole UI hangs off one
+// consistent margin instead of a ragged mix of flush-left and indented rows.
+// headRows counts the section head (tabs + blank separator) above a list body.
+const (
+	gut      = 2
+	headRows = 2
+)
+
+// padLeft indents every line of s by n spaces. Safe on styled (ANSI) strings —
+// the spaces sit before any escape codes.
+func padLeft(s string, n int) string {
+	pad := strings.Repeat(" ", n)
+	lines := strings.Split(s, "\n")
+	for i := range lines {
+		lines[i] = pad + lines[i]
+	}
+	return strings.Join(lines, "\n")
+}
+
 // genRowWidth is the width needed to render the widest generator facet row (all
 // options) on a single line — the minimum for the left panel.
 func (m model) genRowWidth() int {
@@ -789,12 +808,12 @@ func (m model) bodyLines(w int) ([]string, int) {
 	return m.genLines(true)
 }
 
-// stackedSplit divides the inner body height (minus the 2-line tab head and the
+// stackedSplit divides the inner body height (minus the section head and the
 // 1-line divider) between the list and the preview: the list takes what its
 // content needs, capped at ~60% and floored so the preview keeps ≥ minPrev rows.
 func stackedSplit(bodyH, bodyLen int) (listH, prevH int) {
-	const head, sep, minPrev, minList = 2, 1, 6, 3
-	inner := bodyH - head - sep
+	const sep, minPrev, minList = 1, 6, 3
+	inner := bodyH - headRows - sep
 	listH = bodyLen
 	if c := inner * 3 / 5; listH > c {
 		listH = c
@@ -813,15 +832,17 @@ func stackedSplit(bodyH, bodyLen int) (listH, prevH int) {
 }
 
 // previewDims returns the preview viewport's inner (width, height) for the mode.
+// The full-width modes reserve the shared gutter; split leaves the preview's own
+// border + padding to do the breathing.
 func (m model) previewDims() (int, int) {
 	bodyH := m.bodyH()
 	switch m.mode() {
 	case modeCollapsed:
-		return m.w, bodyH
+		return m.w - gut, bodyH
 	case modeStacked:
-		body, _ := m.bodyLines(m.w)
+		body, _ := m.bodyLines(m.w - gut)
 		_, ph := stackedSplit(bodyH, len(body))
-		return m.w, ph
+		return m.w - gut, ph
 	default: // split
 		return m.w - m.listW() - 3, bodyH
 	}
@@ -1012,7 +1033,7 @@ func (m *model) usagePanel() string {
 			if w.prov == "anthropic" {
 				pcol, pname = "#ff9f52", "Claude"
 			}
-			blocks[w.prov] = []string{lipgloss.NewStyle().Foreground(lipgloss.Color(pcol)).Bold(true).Render(pname)}
+			blocks[w.prov] = []string{padLeft(lipgloss.NewStyle().Foreground(lipgloss.Color(pcol)).Bold(true).Render(pname), gut)}
 		}
 		blocks[w.prov] = append(blocks[w.prov], m.usageRow(w))
 	}
@@ -1027,7 +1048,10 @@ func (m *model) usagePanel() string {
 		return m.refreshLine() + "\n" + lipgloss.JoinHorizontal(lipgloss.Top, cols...)
 	}
 	var lines []string
-	for _, p := range order {
+	for i, p := range order {
+		if i > 0 {
+			lines = append(lines, "") // blank line between provider groups
+		}
 		lines = append(lines, blocks[p]...)
 	}
 	return m.refreshLine() + "\n" + strings.Join(lines, "\n")
@@ -1378,29 +1402,34 @@ func scrollbar(total, h, start int) string {
 	return b.String()
 }
 
-// leftColumn renders the pinned section tabs plus the scrolling list body,
-// clipped to bodyH rows and w columns.
-func (m model) leftColumn(w, bodyH int) string {
-	body, bcur := m.bodyLines(w)
-	// the tab switcher + a blank line stay pinned; only the body scrolls.
-	head := m.sectionTabs() + "\n\n"
-	if bodyH < 1 {
-		bodyH = 1
-	}
-	return head + windowList(body, bcur, bodyH, w)
+// sectionHead is the gutter-inset tab switcher plus a blank separator (headRows
+// tall); it stays pinned above the scrolling list body.
+func (m model) sectionHead() string {
+	return padLeft(m.sectionTabs(), gut) + "\n\n"
 }
 
-// stackedContent is the narrow-but-tall layout: tabs + list on top, a divider,
-// then the preview stacked below — all full width. The preview keeps its own
-// viewport, so it scrolls (mouse wheel) independently of the list above it.
+// leftColumn renders the pinned section head plus the scrolling list body, the
+// whole column inset by the shared gutter, sized to totalH rows and w columns.
+func (m model) leftColumn(w, totalH int) string {
+	iw := w - gut
+	body, bcur := m.bodyLines(iw)
+	listH := totalH - headRows
+	if listH < 1 {
+		listH = 1
+	}
+	return m.sectionHead() + padLeft(windowList(body, bcur, listH, iw), gut)
+}
+
+// stackedContent is the narrow-but-tall layout: head + list on top, a full-width
+// divider, then the preview stacked below. The preview keeps its own viewport, so
+// it scrolls (mouse wheel) independently of the list above it.
 func (m model) stackedContent(bodyH int) string {
-	w := m.w
-	body, bcur := m.bodyLines(w)
+	body, _ := m.bodyLines(m.w - gut)
 	listH, prevH := stackedSplit(bodyH, len(body))
-	list := m.sectionTabs() + "\n\n" + windowList(body, bcur, listH, w)
-	div := stDim.Render(strings.Repeat("─", w))
-	preview := lipgloss.NewStyle().Width(w).Height(prevH).MaxHeight(prevH).Render(m.vp.View())
-	return lipgloss.JoinVertical(lipgloss.Left, list, div, preview)
+	top := m.leftColumn(m.w, headRows+listH)
+	div := stDim.Render(strings.Repeat("─", m.w))
+	preview := lipgloss.NewStyle().MaxHeight(prevH).Render(padLeft(m.vp.View(), gut))
+	return lipgloss.JoinVertical(lipgloss.Left, top, div, preview)
 }
 
 func (m model) View() string {
@@ -1413,15 +1442,15 @@ func (m model) View() string {
 	switch m.mode() {
 	case modeCollapsed:
 		if m.showResult && m.w < 62 {
-			content = m.vp.View()
+			content = padLeft(m.vp.View(), gut)
 		} else {
-			content = m.leftColumn(m.w, bodyH-2)
+			content = m.leftColumn(m.w, bodyH)
 		}
 	case modeStacked:
 		content = m.stackedContent(bodyH)
 	default: // split
 		content = lipgloss.JoinHorizontal(lipgloss.Top,
-			m.leftColumn(m.listW(), bodyH-2),
+			m.leftColumn(m.listW(), bodyH),
 			m.previewPane(m.w-m.listW()-3, bodyH))
 	}
 	// Pin the body into a fixed box (top-left) with lipgloss, then clip: any

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -523,7 +523,7 @@ func facetDefs(glyphs map[string]string) []facet {
 	return []facet{
 		{"lane", []string{"gpt-only", "gpt-led", "mixed", "claude-led", "claude-only"}, glyphs["lane"]},
 		{"model", []string{"fast", "normal", "smart"}, glyphs["model"]},
-		{"thinking", []string{"low", "medium", "high", "xhigh"}, glyphs["thinking"]},
+		{"thinking", []string{"minimal", "low", "medium", "high", "xhigh", "max"}, glyphs["thinking"]},
 		// advisor as a power/cost dial: a quick glance, a proper review, or a
 		// deep (expensive) audit — off spends nothing.
 		{"advisor", []string{"off", "glance", "review", "audit"}, glyphs["advisor"]},

--- a/pkgs/omp-configured/generate-profiles.py
+++ b/pkgs/omp-configured/generate-profiles.py
@@ -39,6 +39,25 @@ for _k, _v in CATALOG.items():
         LADDER[_v["pool"]][_v["tier"]] = _k
 CHEAP = {p: LADDER[p][1] for p in ("O", "A")}
 
+# Per-model thinking range, parsed from the catalog's `thinking: lo→hi` field
+# (mirrors omp's vocabulary: minimal < low < medium < high < xhigh < max). Each
+# model supports a contiguous slice of that scale, so clamping any level into
+# [lo, hi] resolves the extremes per model for free: 'minimal' → the model's floor
+# (minimal for haiku, low for the rest) and 'max' → its ceiling (max for most,
+# xhigh for spark/haiku). It also keeps every emitted level one the model actually
+# offers — e.g. luna has no 'minimal', so luna:minimal clamps to luna:low.
+SCALE = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max']
+SIDX = {lv: i for i, lv in enumerate(SCALE)}
+TH_RANGE = {}
+for _k, _v in CATALOG.items():
+    _lo, _hi = (s.strip() for s in _v["thinking"].split('→'))
+    TH_RANGE[_k] = (SIDX[_lo], SIDX[_hi])
+
+
+def clamp_th(model, level):
+    lo, hi = TH_RANGE[model]
+    return SCALE[max(lo, min(hi, SIDX[level]))]
+
 
 def other(p):
     return 'A' if p == 'O' else 'O'
@@ -131,7 +150,11 @@ TMAP = {'fast': 1, 'normal': 2, 'smart': 3}
 BUMP = {'minimal': 'low', 'low': 'medium', 'medium': 'high', 'high': 'xhigh', 'xhigh': 'xhigh'}
 LANES = ['gpt-only', 'gpt-led', 'mixed', 'claude-led', 'claude-only']
 MTIERS = ['fast', 'normal', 'smart']
-THINKING = ['low', 'medium', 'high', 'xhigh']
+# The middle levels scale per role (deliberation bumps up, utilities stay modest);
+# the two extremes are uniform overrides — 'minimal' floors every role, 'max' tops
+# every role — each clamped to what its model actually supports (see clamp_th).
+THINKING = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max']
+EXTREMES = {'minimal', 'max'}
 
 
 def primary(lane):
@@ -147,6 +170,7 @@ def gen(lane, mtier, thinking, spark, fable):
     P = primary(lane)
     base = TMAP[mtier]
     isp = pure(lane)
+    extreme = thinking in EXTREMES  # 'minimal'/'max' override every role uniformly
 
     def rprov(r):
         if isp:
@@ -161,10 +185,12 @@ def gen(lane, mtier, thinking, spark, fable):
         if r in UTIL:
             rp = rprov(r)
             t = UTIL_MODEL[r][mtier]
-            th = UTIL_THINK[r][thinking]
+            th = thinking if extreme else UTIL_THINK[r][thinking]
             spark_here = spark and (r in ('tiny', 'commit') or (r == 'sonic' and mtier == 'fast'))
             if spark_here:
-                lead, th = 'spark', 'low'      # fast codex tier; keep it snappy
+                lead = 'spark'                 # fast codex tier; keep it snappy
+                if not extreme:
+                    th = 'low'
                 fb = [LADDER[rp][t]]           # fall to the role's normal model
             else:
                 lead = LADDER[rp][t]
@@ -181,12 +207,13 @@ def gen(lane, mtier, thinking, spark, fable):
             # the pure lanes) — the minimum diversity guarantee for any profile.
             AP = P if isp else other(P)
             amod = (LADDER[AP][2] if AP == 'A' else 'terra') if mtier == 'smart' else CHEAP[AP]
-            lvl = 'high' if mtier == 'smart' else 'low'
-            out[r] = (amod, lvl, [(m, 'low') for m in build_chain(amod, isp)])
+            lvl = thinking if extreme else ('high' if mtier == 'smart' else 'low')
+            fbl = thinking if extreme else 'low'
+            out[r] = (amod, lvl, [(m, fbl) for m in build_chain(amod, isp)])
             continue
         rp = rprov(r)
         t = min(3, base + 1) if r in DELIB else base
-        th = BUMP[thinking] if r in DELIB else thinking
+        th = thinking if extreme else (BUMP[thinking] if r in DELIB else thinking)
         lead = 'fable' if (fable and r in DELIB and rp == 'A' and mtier in ('smart', 'normal')) else LADDER[rp][t]
         out[r] = (lead, th, [(m, th) for m in build_chain(lead, isp)])
     return out
@@ -212,10 +239,10 @@ def render(lane, mtier, thinking, spark, fable):
         if lead is None:  # advisor off — no row (matches render-omp-routes skip)
             continue
         marker = '●' if r in AGENT_ROLES else ' '
-        model = f"{ID[lead]}:{lvl}"
+        model = f"{ID[lead]}:{clamp_th(lead, lvl)}"
         row = f"  {marker} {r:<10} {model:<24}"
         for (m, ml) in chain:
-            row += f" → {ID[m]}:{ml}"
+            row += f" → {ID[m]}:{clamp_th(m, ml)}"
         lines.append(row.rstrip())
     lines.append("")
     return "\n".join(lines)
@@ -227,7 +254,7 @@ def render_advisors():
     lines = ["__advisors__  advisor dial (level context → chain)"]
     for ctx in ('gpt', 'claude'):
         for level in ('glance', 'review', 'audit'):
-            chain = ' → '.join(f"{ID[k]}:{lv}" for k, lv in ADVISOR[ctx][level])
+            chain = ' → '.join(f"{ID[k]}:{clamp_th(k, lv)}" for k, lv in ADVISOR[ctx][level])
             lines.append(f"  {level} {ctx} {chain}")
     lines.append("")
     return "\n".join(lines)

--- a/pkgs/omp-configured/generate-profiles.py
+++ b/pkgs/omp-configured/generate-profiles.py
@@ -80,6 +80,13 @@ ROLE_ORDER = ['default', 'task', 'plan', 'slow', 'designer', 'reviewer',
               'librarian', 'sonic', 'advisor', 'smol', 'tiny', 'commit']
 AGENT_ROLES = {'designer', 'librarian', 'reviewer', 'sonic', 'task'}  # ● marker
 DELIB = {'plan', 'slow', 'designer', 'reviewer'}
+# Anti-tunnel-vision (issue: provider diversity). On a *-led lane the default and
+# the bulk of the profile stay on the preferred provider (strong emphasis), but a
+# couple of critique roles cross to the opposite provider so the work always gets
+# a genuinely independent second eye. The advisor always crosses too (handled in
+# its own branch); the reviewer is the other cross role — it audits the output, so
+# a different provider there is where diverse judgement pays off most.
+CROSS_LED = {'reviewer'}
 
 # Utility roles all respond to the sliders, but each to a degree that fits its
 # job — model tier is capped so none can ever become expensive. Provider comes
@@ -143,10 +150,11 @@ def gen(lane, mtier, thinking, spark, fable):
 
     def rprov(r):
         if isp:
-            return P
+            return P                       # pure lane: never cross
         if lane == 'mixed':
             return 'A' if r in DELIB else 'O'
-        return P
+        # *-led: strong primary everywhere, except the cross-provider critique roles
+        return other(P) if r in CROSS_LED else P
 
     out = {}
     for r in ROLE_ORDER:
@@ -168,7 +176,11 @@ def gen(lane, mtier, thinking, spark, fable):
             if mtier == 'fast':
                 out[r] = (None, None, [])  # advisor off
                 continue
-            amod = (LADDER[P][2] if P == 'A' else 'terra') if mtier == 'smart' else CHEAP[P]
+            # The advisor is the independent second opinion, so it leads on the
+            # opposite provider whenever the lane allows crossing (everything but
+            # the pure lanes) — the minimum diversity guarantee for any profile.
+            AP = P if isp else other(P)
+            amod = (LADDER[AP][2] if AP == 'A' else 'terra') if mtier == 'smart' else CHEAP[AP]
             lvl = 'high' if mtier == 'smart' else 'low'
             out[r] = (amod, lvl, [(m, 'low') for m in build_chain(amod, isp)])
             continue


### PR DESCRIPTION
Two improvements to the `code` picker, requested together.

## 1. Cross-provider diversity (anti-tunnel-vision)

On a `*-led` lane the **default** and the bulk of the profile stay on the preferred provider (strong emphasis), but the two dedicated **critique roles cross to the opposite provider** so the work always gets a genuinely independent second eye:

- **advisor** — crosses on *every* non-pure lane (mixed included). The minimum diversity guarantee for any profile.
- **reviewer** — crosses on `*-led` lanes (it audits the output, so a different provider is where diverse judgement pays off most).

Examples (normal/medium):

| lane | default | reviewer | advisor |
|------|---------|----------|---------|
| gpt-led | GPT terra | **Claude opus** | **Claude haiku** |
| claude-led | Claude sonnet | **GPT sol** | **GPT luna** |
| mixed | GPT terra | Claude (DELIB) | **Claude haiku** (was GPT) |

- **Pure lanes never cross** — `gpt-only`/`claude-only` stay 100% their provider (verified: 0 cross-provider models).
- With **fable** on it reads naturally: `claude-led+fable` = "Fable drives Claude deliberation, GPT reviews and advises"; `gpt-led+fable` gives the previously-inert toggle a meaning (Claude-Fable cross reviewer).
- The **interactive advisor dial** had the same blind spot for `claude-led` (it returned a same-provider Claude advisor); it now crosses to GPT to match.
- Grid unchanged in shape (**192 blocks**); the managed static presets (`ompb`/`ompg`/…) are untouched.

## 2. Stacked layout for narrow-but-tall terminals

When the terminal is too thin for the side-by-side preview **but tall enough**, the preview now stacks **below** the list (between it and the usage panel) with a divider, instead of disappearing. It keeps its own viewport, so it scrolls independently (mouse wheel).

- The list takes the height its content needs (capped ~60%); the preview keeps the rest with a floor.
- `p` now hides/restores the preview sensibly across all three modes (split / stacked / collapsed).

## Verification

- `nix build .#code-tui` ✓ · `go vet` ✓
- `nix build .#omp-configured` ✓ (generator + wiki assemble)
- `nix build .#checks.x86_64-linux.omp-stack` ✓
- Generator output inspected: `-led`/`mixed` advisors + reviewers cross-provider; pure lanes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)