### PR TITLE
chore(code-tui): drop accidentally-committed build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 *.pyd
 .Python
 
+# Go — `go build` in a package dir drops a binary named after the dir
+/pkgs/code-tui/code-tui
+
 # Nix
 result
 result-*


### PR DESCRIPTION
The previous PR (#96) accidentally swept in a 5.3MB compiled Go binary — `pkgs/code-tui/code-tui`, left behind by a stray `go build` in the package directory during local verification.

Nix builds the picker from source (`main.go` + `go.mod`/`go.sum`), so the binary is pure repo bloat and never used. This removes it and gitignores the path (`/pkgs/code-tui/code-tui`) so it can't recur.

Verified `nix build .#code-tui` still builds cleanly from source without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)