### PR TITLE
feat(code): add a 1–5 $ cost meter to the generator

### DIFF
--- a/.github/workflows/model-facts-freshness.yml
+++ b/.github/workflows/model-facts-freshness.yml
@@ -1,0 +1,58 @@
+name: Model facts freshness
+
+# omp is the authority for the factual model data (cost/speed/ttft) cached in
+# omp/models.yml, refreshed by `nix run .#refresh-model-facts`. That refresh
+# needs omp's creds + `omp bench` (real API calls), so CI can't run it — but it
+# can watch the `refreshed:` stamp and nudge when the cache goes stale, so the
+# data gets recomputed *sometime* even though it changes rarely.
+
+on:
+  schedule:
+    - cron: "0 9 1 * *" # 09:00 UTC on the 1st of each month
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: model-facts-freshness
+  cancel-in-progress: false
+
+env:
+  MAX_AGE_DAYS: 90
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Nudge if the model-facts cache is stale
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          refreshed="$(grep -m1 '^refreshed:' omp/models.yml | sed -E "s/^refreshed:[[:space:]]*'?([0-9-]+)'?.*/\1/")"
+          if [ -z "$refreshed" ]; then
+            echo "no 'refreshed:' stamp in omp/models.yml" >&2
+            exit 1
+          fi
+          age=$(( ( $(date +%s) - $(date -d "$refreshed" +%s) ) / 86400 ))
+          echo "model facts last refreshed $refreshed ($age days ago; threshold ${MAX_AGE_DAYS})"
+          if [ "$age" -le "${MAX_AGE_DAYS}" ]; then
+            echo "fresh enough — nothing to do."
+            exit 0
+          fi
+          title="Refresh model facts (omp/models.yml is ${age} days old)"
+          body=$(printf 'omp/models.yml was last refreshed **%s** (%s days ago).\n\nRun `nix run .#refresh-model-facts` on a machine with omp auth to re-pull cost/speed/ttft, then open a PR. (CI can'\''t do it — `omp bench` needs creds + real API calls.)' "$refreshed" "$age")
+          existing="$(gh issue list --state open --search "in:title Refresh model facts" --json number --jq '.[0].number' || true)"
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --title "$title" --body "$body"
+            echo "updated existing reminder issue #$existing"
+          else
+            gh issue create --title "$title" --body "$body" --label "" >/dev/null || gh issue create --title "$title" --body "$body" >/dev/null
+            echo "opened a reminder issue"
+          fi

--- a/flake.nix
+++ b/flake.nix
@@ -641,10 +641,28 @@
 
       apps = forAllSystems (
         system:
+        let
+          pkgs = pkgsFor system;
+          # Re-pull the factual fields in omp/models.yml from omp (cost/context via
+          # `omp models`, speed/ttft via `omp bench`). Run from the repo root:
+          #   nix run .#refresh-model-facts [-- --skip-bench | --runs 3 | …]
+          refreshModelFacts = pkgs.writeShellApplication {
+            name = "refresh-model-facts";
+            runtimeInputs = [
+              (pkgs.python3.withPackages (ps: [ ps.ruamel-yaml ]))
+              pkgs.omp
+            ];
+            text = ''python3 ${./omp/refresh-model-facts.py} "$@"'';
+          };
+        in
         {
           home-manager = {
             type = "app";
             program = "${home-manager.packages.${system}.home-manager}/bin/home-manager";
+          };
+          refresh-model-facts = {
+            type = "app";
+            program = "${refreshModelFacts}/bin/refresh-model-facts";
           };
         }
         // lib.optionalAttrs (lib.hasSuffix "-darwin" system) {

--- a/omp/models.yml
+++ b/omp/models.yml
@@ -19,6 +19,7 @@
 #
 # Consumed by generate-profiles.py (the facet grid) and generate-wiki.py (the
 # browsable profiles wiki).
+refreshed: '2026-07-13'
 models:
   luna:
     id: gpt-5.6-luna
@@ -123,10 +124,12 @@ models:
     bucket: claude-fable
     cost_in: 10
     cost_out: 50
-    # speed/ttft: ESTIMATE — its bucket was maxed at refresh time so `omp bench`
-    # couldn't measure it; re-run the refresh once the Fable quota resets.
-    speed: 30
-    ttft: 4.0
+    # speed/ttft: from `omp stats` history (what `/model` shows), NOT `omp bench` —
+    # Fable's bucket was maxed so it couldn't be benched live. Stats are thinking-
+    # blended so not perfectly bench-comparable; re-run the refresh once the Fable
+    # quota resets to replace these with a clean benchmark.
+    speed: 54
+    ttft: 6.9
     context: 1000000
     thinking: low→max
     role: >-

--- a/omp/models.yml
+++ b/omp/models.yml
@@ -1,12 +1,15 @@
-# Curated model catalog — the single source of truth for the routing tooling:
-# which models we use, their short keys, pool, tier, quota bucket, a role note,
-# and the cost/context/thinking facts.
+# Model catalog for the routing tooling: the curated fields (short key, pool,
+# tier, quota bucket, role note) plus a cache of the factual fields omp measures.
 #
-# The factual fields (cost_in, cost_out — $ per 1M tokens; context; thinking)
-# mirror `omp models --json`, which is the AUTHORITY. omp fetches its catalog
-# into ~/.omp/models.db (network + provider-gated), so it can't be read in the
-# Nix build sandbox — hence the numbers live here, copied from omp. Keep them in
-# sync when pricing changes: `omp models <key> --json` prints the current values.
+# The factual fields are NOT hand-maintained — omp is the authority for all of
+# them, and `omp/refresh-model-facts.py` (run: `nix run .#refresh-model-facts`)
+# re-pulls them, rewriting only these fields in place:
+#   cost_in / cost_out ($ per 1M tokens), context, thinking  <- `omp models --json`
+#   speed (output tok/s), ttft (time-to-first-token, seconds) <- `omp bench --json`
+# They live here only because the Nix build sandbox has no network, creds, or
+# ~/.omp and so cannot reach omp itself; this file is that committed cache. Do not
+# edit the factual fields by hand — re-run the refresh instead. (speed/ttft are a
+# live benchmark, so they drift with load; re-run when you want fresh figures.)
 #
 #   pool:   O = openai-codex   ·   A = anthropic
 #   tier:   0 trivial/fast · 1 speed · 2 regular · 3 smart · 4 elite
@@ -24,7 +27,9 @@ models:
     bucket: codex-main
     cost_in: 1
     cost_out: 6
-    context: 372000
+    speed: 52.3
+    ttft: 1.18
+    context: 272000
     thinking: low→max
     role: >-
       Fast, high-volume — the cheapest supported Codex tier. Leads the speed GPT
@@ -36,7 +41,9 @@ models:
     bucket: codex-main
     cost_in: 2.5
     cost_out: 15
-    context: 372000
+    speed: 51.8
+    ttft: 1.74
+    context: 272000
     thinking: low→max
     role: >-
       Balanced workhorse. Leads the regular GPT tier (ompb) and the mixed
@@ -48,7 +55,9 @@ models:
     bucket: codex-main
     cost_in: 5
     cost_out: 30
-    context: 372000
+    speed: 31.5
+    ttft: 4.59
+    context: 272000
     thinking: low→max
     role: Flagship. Leads the smart GPT tier (ompg, ompm, ompo).
   spark:
@@ -58,6 +67,8 @@ models:
     bucket: codex-spark
     cost_in: 1.75
     cost_out: 14
+    speed: 286.7
+    ttft: 5.56
     context: 128000
     thinking: low→xhigh
     role: >-
@@ -70,6 +81,8 @@ models:
     bucket: claude-main
     cost_in: 1
     cost_out: 5
+    speed: 48.9
+    ttft: 1.7
     context: 200000
     thinking: minimal→xhigh
     role: >-
@@ -82,6 +95,8 @@ models:
     bucket: claude-main
     cost_in: 2
     cost_out: 10
+    speed: 35.2
+    ttft: 3.84
     context: 1000000
     thinking: low→max
     role: >-
@@ -94,6 +109,8 @@ models:
     bucket: claude-main
     cost_in: 5
     cost_out: 25
+    speed: 46.6
+    ttft: 1.77
     context: 1000000
     thinking: low→max
     role: >-
@@ -106,6 +123,10 @@ models:
     bucket: claude-fable
     cost_in: 10
     cost_out: 50
+    # speed/ttft: ESTIMATE — its bucket was maxed at refresh time so `omp bench`
+    # couldn't measure it; re-run the refresh once the Fable quota resets.
+    speed: 30
+    ttft: 4.0
     context: 1000000
     thinking: low→max
     role: >-

--- a/omp/refresh-model-facts.py
+++ b/omp/refresh-model-facts.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Refresh the factual fields in omp/models.yml from omp — the source of truth.
+
+omp is the authority for what a model costs and how fast it runs; models.yml is
+only a committed cache the sandboxed Nix build can read (the build has no network,
+creds, or ~/.omp). This script re-pulls the facts so we never hand-maintain them:
+
+  cost_in / cost_out / context / thinking   <- `omp models --json`
+  speed (tok/s) / ttft (s)                   <- `omp bench --json`  (live, costs API $)
+
+Only those fields are rewritten; the curated fields (pool, tier, bucket, role) and
+every comment are preserved. Run it from the repo root:
+
+  nix run .#refresh-model-facts                 # cost + speed (benches every model)
+  nix run .#refresh-model-facts -- --skip-bench # cost/context/thinking only (free)
+  nix run .#refresh-model-facts -- --runs 3     # average speed over 3 bench runs
+
+A model whose bench fails (e.g. its quota is maxed) keeps its existing speed/ttft
+and prints a warning — re-run once the bucket resets.
+"""
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+POOL_PROVIDER = {"O": "openai-codex", "A": "anthropic"}
+
+
+def omp_models():
+    out = subprocess.run(["omp", "models", "--json"], capture_output=True, text=True, check=True).stdout
+    idx = {}
+    for m in json.loads(out)["models"]:
+        idx[(m["provider"], m["id"])] = m
+    return idx
+
+
+def bench_from(models_data):
+    """Index a bench --json payload by selector, keeping only successful runs."""
+    out = {}
+    for m in models_data:
+        avg = m.get("average") or {}
+        r0 = (m.get("results") or [{}])[0]
+        if r0.get("ok") and avg.get("tokensPerSecond"):
+            out[m["model"]] = avg
+    return out
+
+
+def omp_bench(selectors, runs, max_tokens):
+    cmd = ["omp", "bench", *selectors, "--json", "--runs", str(runs), "--max-tokens", str(max_tokens)]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+    return bench_from(json.loads(out)["models"])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--file", default="omp/models.yml", help="path to models.yml (default: omp/models.yml under CWD)")
+    ap.add_argument("--runs", type=int, default=2, help="bench requests per model, averaged")
+    ap.add_argument("--max-tokens", type=int, default=256)
+    ap.add_argument("--skip-bench", action="store_true", help="only refresh cost/context/thinking (no API calls)")
+    ap.add_argument("--bench-json", help="reuse a saved `omp bench --json` payload instead of running it")
+    args = ap.parse_args()
+
+    path = Path(args.file)
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    doc = yaml.load(path.read_text())
+    models = doc["models"]
+
+    mi = omp_models()
+    for key, m in models.items():
+        prov = POOL_PROVIDER[m["pool"]]
+        om4 = mi.get((prov, m["id"]))
+        if not om4:
+            print(f"warn: {key} ({prov}/{m['id']}) not found in `omp models`", file=sys.stderr)
+            continue
+        m["cost_in"] = om4["cost"]["input"]
+        m["cost_out"] = om4["cost"]["output"]
+        m["context"] = om4["contextWindow"]
+        th = om4.get("thinking") or []
+        if th:
+            m["thinking"] = f"{th[0]}→{th[-1]}"
+
+    if not args.skip_bench:
+        if args.bench_json:
+            bench = bench_from(json.loads(Path(args.bench_json).read_text())["models"])
+        else:
+            selectors = [f"{POOL_PROVIDER[m['pool']]}/{m['id']}" for m in models.values()]
+            bench = omp_bench(selectors, args.runs, args.max_tokens)
+        for key, m in models.items():
+            sel = f"{POOL_PROVIDER[m['pool']]}/{m['id']}"
+            avg = bench.get(sel)
+            if not avg:
+                print(f"warn: no bench result for {key} ({sel}); keeping existing speed/ttft", file=sys.stderr)
+                continue
+            m["speed"] = round(avg["tokensPerSecond"], 1)
+            ttft = round(avg["ttftMs"] / 1000.0, 2)
+            if "ttft" in m:
+                m["ttft"] = ttft
+            else:  # keep ttft next to speed, not appended at the end
+                ks = list(m.keys())
+                m.insert(ks.index("speed") + 1, "ttft", ttft)
+
+    yaml.dump(doc, path.open("w"))
+    print(f"refreshed {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/omp/refresh-model-facts.py
+++ b/omp/refresh-model-facts.py
@@ -19,6 +19,7 @@ A model whose bench fails (e.g. its quota is maxed) keeps its existing speed/ttf
 and prints a warning — re-run once the bucket resets.
 """
 import argparse
+import datetime
 import json
 import subprocess
 import sys
@@ -52,6 +53,20 @@ def omp_bench(selectors, runs, max_tokens):
     cmd = ["omp", "bench", *selectors, "--json", "--runs", str(runs), "--max-tokens", str(max_tokens)]
     out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
     return bench_from(json.loads(out)["models"])
+
+
+def omp_stats():
+    """Per-model historical aggregate (what `/model` shows) — the fallback for a
+    model `omp bench` can't reach live (e.g. a maxed quota). Keyed by provider/id.
+    Note: stats are thinking-blended real usage, not a clean benchmark."""
+    out = subprocess.run(["omp", "stats", "--json"], capture_output=True, text=True, check=True).stdout
+    out = out[out.index("{"):]  # skip the "Syncing…" preamble
+    res = {}
+    for m in json.loads(out).get("byModel", []):
+        tps, ttft = m.get("avgTokensPerSecond"), m.get("avgTtft")
+        if tps and ttft:
+            res[f"{m['provider']}/{m['model']}"] = {"tokensPerSecond": tps, "ttftMs": ttft}
+    return res
 
 
 def main():
@@ -89,11 +104,15 @@ def main():
         else:
             selectors = [f"{POOL_PROVIDER[m['pool']]}/{m['id']}" for m in models.values()]
             bench = omp_bench(selectors, args.runs, args.max_tokens)
+        stats = omp_stats()  # fallback for models bench couldn't reach
         for key, m in models.items():
             sel = f"{POOL_PROVIDER[m['pool']]}/{m['id']}"
             avg = bench.get(sel)
+            if not avg and sel in stats:
+                avg = stats[sel]
+                print(f"note: {key} benched from `omp stats` history (bench unavailable)", file=sys.stderr)
             if not avg:
-                print(f"warn: no bench result for {key} ({sel}); keeping existing speed/ttft", file=sys.stderr)
+                print(f"warn: no bench or stats for {key} ({sel}); keeping existing speed/ttft", file=sys.stderr)
                 continue
             m["speed"] = round(avg["tokensPerSecond"], 1)
             ttft = round(avg["ttftMs"] / 1000.0, 2)
@@ -103,8 +122,16 @@ def main():
                 ks = list(m.keys())
                 m.insert(ks.index("speed") + 1, "ttft", ttft)
 
+    # stamp the refresh date (top-level; consumers read only `models`) so a CI
+    # freshness check can nudge a re-run when the cache goes stale.
+    today = datetime.date.today().isoformat()
+    if "refreshed" in doc:
+        doc["refreshed"] = today
+    else:
+        doc.insert(0, "refreshed", today)
+
     yaml.dump(doc, path.open("w"))
-    print(f"refreshed {path}")
+    print(f"refreshed {path} ({today})")
 
 
 if __name__ == "__main__":

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -12,10 +12,12 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -556,6 +558,104 @@ func parseAdvisors(rows []string) map[string][]string {
 	return out
 }
 
+// parseCosts reads the __costs__ block (rows: "<id> <in> <out>") into a model-id
+// → {cost_in, cost_out} table ($ per 1M tokens), sourced from the catalog so the
+// $ meter and the routing share one price list.
+func parseCosts(rows []string) map[string][2]float64 {
+	out := map[string][2]float64{}
+	for _, r := range rows {
+		f := strings.Fields(r)
+		if len(f) < 3 {
+			continue
+		}
+		in, e1 := strconv.ParseFloat(f[1], 64)
+		outc, e2 := strconv.ParseFloat(f[2], 64)
+		if e1 == nil && e2 == nil {
+			out[f[0]] = [2]float64{in, outc}
+		}
+	}
+	return out
+}
+
+// ── cost meter ───────────────────────────────────────────────────────────────
+// A profile's price is dominated by the models on its heaviest roles, so each
+// role is weighted by the token volume it drives over a session: the default
+// agent and its task sub-agents move the needle; commit/tiny barely register — so
+// Fable-as-commit stays cheap while Fable-as-default is dear. Per role the cost
+// blends input+output pricing, scales with thinking effort, and takes OpenAI's
+// priority multiplier under fast mode. The weighted average maps onto a 1..5 log
+// scale (cost is perceived multiplicatively), calibrated across the whole grid.
+var roleWeight = map[string]float64{
+	"default": 10, "task": 6, "reviewer": 3, "sonic": 3, "plan": 3, "advisor": 4,
+	"slow": 2, "designer": 2, "librarian": 2, "smol": 1, "tiny": 0.5, "commit": 0.5,
+}
+var thinkMult = map[string]float64{
+	"minimal": 0.6, "low": 0.8, "medium": 1.0, "high": 1.3, "xhigh": 1.6, "max": 2.0,
+}
+
+const priorityMult = 1.9 // OpenAI priority service tier, charged under fast mode
+
+// costLnLo/Hi are ln of the grid-wide min/max weighted-cost index (calibrated
+// over every valid facet × advisor × fast combination).
+const costLnLo, costLnHi = 1.27, 4.42
+
+// costScore rates the current generator config from 1 (cheap) to 5 (dear).
+func (m model) costScore() int {
+	rows := m.applyAdvisor(m.generated[comboID(m.sel)], m.sel["advisor"], m.sel["lane"])
+	fast := m.sel["fast"] == "on" && m.sel["lane"] != "claude-only"
+	var num, den float64
+	for _, r := range rows {
+		f := strings.Fields(strings.ReplaceAll(r, "→", " "))
+		i := 0
+		if len(f) > 0 && f[0] == "●" {
+			i = 1
+		}
+		if i >= len(f) {
+			continue
+		}
+		w, ok := roleWeight[f[i]]
+		if !ok {
+			continue
+		}
+		var lead string
+		for _, t := range f[i+1:] {
+			if modelRe.MatchString(t) {
+				lead = t
+				break
+			}
+		}
+		id, lvl, _ := strings.Cut(lead, ":")
+		c, ok := m.costs[id]
+		if !ok {
+			continue
+		}
+		mult, ok := thinkMult[lvl]
+		if !ok {
+			mult = 1
+		}
+		cost := (0.25*c[0] + 0.75*c[1]) * mult
+		if fast && strings.HasPrefix(id, "gpt-") {
+			cost *= priorityMult
+		}
+		num += w * cost
+		den += w
+	}
+	if den == 0 {
+		return 1
+	}
+	s := 1 + 4*(math.Log(num/den)-costLnLo)/(costLnHi-costLnLo)
+	return int(math.Round(math.Max(1, math.Min(5, s))))
+}
+
+// costMeter renders the 1..5 $ scale — the estimate in the accent colour, the
+// rest dim — always five glyphs so the fill reads at a glance.
+func (m model) costMeter() string {
+	n := m.costScore()
+	acc := lipgloss.NewStyle().Foreground(lipgloss.Color(m.accent())).Bold(true).Render(strings.Repeat("$", n))
+	rest := stDim.Render(strings.Repeat("$", 5-n))
+	return "  " + stDim.Render("cost ") + acc + rest
+}
+
 // advisorChain returns the advisor role's model chain for an intensity + lane,
 // sourced from the baked __advisors__ table. The advisor is the independent
 // second opinion, so it uses the opposite provider to the lane's preference — GPT
@@ -852,7 +952,8 @@ type model struct {
 	profiles  []profile
 	routes    map[string][]string
 	generated map[string][]string
-	advisors  map[string][]string // "level/ctx" → advisor model chain
+	advisors  map[string][]string   // "level/ctx" → advisor model chain
+	costs     map[string][2]float64 // model id → {cost_in, cost_out} $/1M tokens
 	avail     availability
 	glyphs    map[string]string
 
@@ -1561,7 +1662,8 @@ func (m model) genLines(focused bool) ([]string, int) {
 	// launch call-to-action under the facets — the "configure → launch" flow
 	// lives with the generator; the routing detail stays on the right.
 	if focused {
-		lines = append(lines, "", lipgloss.NewStyle().Foreground(lipgloss.Color(acc)).Bold(true).Render("  ⏎ launch this profile"))
+		lines = append(lines, "", m.costMeter(),
+			lipgloss.NewStyle().Foreground(lipgloss.Color(acc)).Bold(true).Render("  ⏎ launch this profile"))
 	}
 	return lines, cursor
 }
@@ -1599,6 +1701,7 @@ func main() {
 		routes:    loadBlocks(os.Getenv("CODE_ROUTES")),
 		generated: generated,
 		advisors:  parseAdvisors(generated["__advisors__"]),
+		costs:     parseCosts(generated["__costs__"]),
 		avail:     availability{bucket: map[string]string{}, reset: map[string]int64{}},
 		usageCmd:  os.Getenv("CODE_USAGE"),
 		spin:      sp,

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -842,9 +842,11 @@ const (
 
 // gut is the left gutter every panel shares, so the whole UI hangs off one
 // consistent margin instead of a ragged mix of flush-left and indented rows.
+// topGap is the matching vertical breathing room above the section tabs.
 // headRows counts the section head (tabs + blank separator) above a list body.
 const (
 	gut      = 2
+	topGap   = 1
 	headRows = 2
 )
 
@@ -899,6 +901,15 @@ func (m model) bodyH() int {
 	return h
 }
 
+// contentH is the height the panels actually fill — bodyH minus the top gap.
+func (m model) contentH() int {
+	h := m.bodyH() - topGap
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
 // bodyLines renders the active section's scrolling list (the generator facets or
 // the profile palette) and reports the cursor's line index within it.
 func (m model) bodyLines(w int) ([]string, int) {
@@ -935,7 +946,7 @@ func stackedSplit(bodyH, bodyLen int) (listH, prevH int) {
 // The full-width modes reserve the shared gutter; split leaves the preview's own
 // border + padding to do the breathing.
 func (m model) previewDims() (int, int) {
-	bodyH := m.bodyH()
+	bodyH := m.contentH()
 	switch m.mode() {
 	case modeCollapsed:
 		return m.w - gut, bodyH
@@ -1539,26 +1550,29 @@ func (m model) View() string {
 	}
 	foot := m.footer()
 	bodyH := m.bodyH()
+	ch := m.contentH()
 	var content string
 	switch m.mode() {
 	case modeCollapsed:
 		if m.showResult && m.w < 62 {
 			content = padLeft(m.vp.View(), gut)
 		} else {
-			content = m.leftColumn(m.w, bodyH)
+			content = m.leftColumn(m.w, ch)
 		}
 	case modeStacked:
-		content = m.stackedContent(bodyH)
+		content = m.stackedContent(ch)
 	default: // split
 		content = lipgloss.JoinHorizontal(lipgloss.Top,
-			m.leftColumn(m.listW(), bodyH),
-			m.previewPane(m.w-m.listW()-3, bodyH))
+			m.leftColumn(m.listW(), ch),
+			m.previewPane(m.w-m.listW()-3, ch))
 	}
 	// Pin the body into a fixed box (top-left) with lipgloss, then clip: any
 	// stray overflow (e.g. a glyph a terminal renders wider than measured) is
-	// absorbed here, never pushing the pinned footer off-screen.
+	// absorbed here, never pushing the pinned footer off-screen. A top gap above
+	// the content gives the section tabs vertical breathing room.
 	body := lipgloss.NewStyle().MaxHeight(bodyH).Render(
-		lipgloss.Place(m.w, bodyH, lipgloss.Left, lipgloss.Top, content))
+		strings.Repeat("\n", topGap) +
+			lipgloss.Place(m.w, ch, lipgloss.Left, lipgloss.Top, content))
 	return lipgloss.NewStyle().MaxWidth(m.w).MaxHeight(m.h).Render(
 		lipgloss.JoinVertical(lipgloss.Left, body, foot))
 }

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -558,52 +558,82 @@ func parseAdvisors(rows []string) map[string][]string {
 	return out
 }
 
-// parseCosts reads the __costs__ block (rows: "<id> <in> <out>") into a model-id
-// → {cost_in, cost_out} table ($ per 1M tokens), sourced from the catalog so the
-// $ meter and the routing share one price list.
-func parseCosts(rows []string) map[string][2]float64 {
-	out := map[string][2]float64{}
+// modelFact is a model's measured facts from omp (via the catalog): pricing
+// ($/1M tokens), output throughput (tok/s), and time-to-first-token (seconds).
+type modelFact struct {
+	in, out, speed, ttft float64
+}
+
+// effTPS folds ttft into throughput — the effective tok/s for a representative
+// reply of effTokens: total time = ttft (startup) + tokens/speed (streaming), so
+// a blazing-but-slow-to-start model (spark: 287 t/s, 5.6s ttft) reads honestly.
+const effTokens = 300.0
+
+func (f modelFact) effTPS() float64 {
+	if f.speed <= 0 {
+		return 0
+	}
+	return effTokens / (f.ttft + effTokens/f.speed)
+}
+
+// parseFacts reads the __models__ block (rows: "<id> <in> <out> <speed> <ttft>")
+// into a per-model table, sourced from the catalog so meters and routing agree.
+func parseFacts(rows []string) map[string]modelFact {
+	out := map[string]modelFact{}
 	for _, r := range rows {
 		f := strings.Fields(r)
-		if len(f) < 3 {
+		if len(f) < 5 {
 			continue
 		}
 		in, e1 := strconv.ParseFloat(f[1], 64)
 		outc, e2 := strconv.ParseFloat(f[2], 64)
-		if e1 == nil && e2 == nil {
-			out[f[0]] = [2]float64{in, outc}
+		sp, e3 := strconv.ParseFloat(f[3], 64)
+		tt, e4 := strconv.ParseFloat(f[4], 64)
+		if e1 == nil && e2 == nil && e3 == nil && e4 == nil {
+			out[f[0]] = modelFact{in, outc, sp, tt}
 		}
 	}
 	return out
 }
 
-// ── cost meter ───────────────────────────────────────────────────────────────
-// A profile's price is dominated by the models on its heaviest roles, so each
-// role is weighted by the token volume it drives over a session: the default
-// agent and its task sub-agents move the needle; commit/tiny barely register — so
-// Fable-as-commit stays cheap while Fable-as-default is dear. Per role the cost
-// blends input+output pricing, scales with thinking effort, and takes OpenAI's
-// priority multiplier under fast mode. The weighted average maps onto a 1..5 log
-// scale (cost is perceived multiplicatively), calibrated across the whole grid.
+// ── cost + speed meters ──────────────────────────────────────────────────────
+// A profile's price and pace are dominated by the models on its heaviest roles,
+// so each role is weighted by the token volume it drives over a session: the
+// default agent and its task sub-agents move the needle; commit/tiny barely
+// register — so Fable-as-commit stays cheap while Fable-as-default is dear (and
+// slow). Per role, cost blends input+output pricing while speed reads the model's
+// effective throughput (tok/s folded with time-to-first-token — see effTPS); both
+// scale with thinking effort (more reasoning = pricier + slower) and take OpenAI's
+// priority tier under fast mode (pricier but quicker). The weighted averages map
+// onto 1..5 log scales (both perceived multiplicatively), calibrated across every
+// valid facet × advisor × fast combination.
 var roleWeight = map[string]float64{
 	"default": 10, "task": 6, "reviewer": 3, "sonic": 3, "plan": 3, "advisor": 4,
 	"slow": 2, "designer": 2, "librarian": 2, "smol": 1, "tiny": 0.5, "commit": 0.5,
 }
-var thinkMult = map[string]float64{
+var thinkMult = map[string]float64{ // reasoning tokens grow with effort → pricier
 	"minimal": 0.6, "low": 0.8, "medium": 1.0, "high": 1.3, "xhigh": 1.6, "max": 2.0,
 }
+var thinkSpeed = map[string]float64{ // more reasoning before the answer → slower
+	"minimal": 1.4, "low": 1.2, "medium": 1.0, "high": 0.8, "xhigh": 0.65, "max": 0.5,
+}
 
-const priorityMult = 1.9 // OpenAI priority service tier, charged under fast mode
+const (
+	priorityMult = 1.9 // OpenAI priority tier costs more under fast mode …
+	fastSpeed    = 1.3 // … but responds quicker
+)
 
-// costLnLo/Hi are ln of the grid-wide min/max weighted-cost index (calibrated
-// over every valid facet × advisor × fast combination).
-const costLnLo, costLnHi = 1.27, 4.42
+// Ln endpoints of the grid-wide min/max weighted indices, calibrated over every
+// valid facet × advisor × fast combination (cost dear→ high, speed fast→ high).
+const (
+	costLnLo, costLnHi   = 1.27, 4.42
+	speedLnLo, speedLnHi = 2.49, 4.20
+)
 
-// costScore rates the current generator config from 1 (cheap) to 5 (dear).
-func (m model) costScore() int {
+// weightedModels walks the current config's rows and calls fn(weight, id, level)
+// for each role's lead model — the shared basis for both meters.
+func (m model) weightedModels(fn func(w float64, id, lvl string)) {
 	rows := m.applyAdvisor(m.generated[comboID(m.sel)], m.sel["advisor"], m.sel["lane"])
-	fast := m.sel["fast"] == "on" && m.sel["lane"] != "claude-only"
-	var num, den float64
 	for _, r := range rows {
 		f := strings.Fields(strings.ReplaceAll(r, "→", " "))
 		i := 0
@@ -625,35 +655,75 @@ func (m model) costScore() int {
 			}
 		}
 		id, lvl, _ := strings.Cut(lead, ":")
-		c, ok := m.costs[id]
+		if id != "" {
+			fn(w, id, lvl)
+		}
+	}
+}
+
+func logScore(idx, lnLo, lnHi float64) int {
+	s := 1 + 4*(math.Log(idx)-lnLo)/(lnHi-lnLo)
+	return int(math.Round(math.Max(1, math.Min(5, s))))
+}
+
+// costScore rates the current config from 1 (cheap) to 5 (dear).
+func (m model) costScore() int {
+	fast := m.sel["fast"] == "on" && m.sel["lane"] != "claude-only"
+	var num, den float64
+	m.weightedModels(func(w float64, id, lvl string) {
+		c, ok := m.facts[id]
 		if !ok {
-			continue
+			return
 		}
 		mult, ok := thinkMult[lvl]
 		if !ok {
 			mult = 1
 		}
-		cost := (0.25*c[0] + 0.75*c[1]) * mult
+		cost := (0.25*c.in + 0.75*c.out) * mult
 		if fast && strings.HasPrefix(id, "gpt-") {
 			cost *= priorityMult
 		}
 		num += w * cost
 		den += w
-	}
+	})
 	if den == 0 {
 		return 1
 	}
-	s := 1 + 4*(math.Log(num/den)-costLnLo)/(costLnHi-costLnLo)
-	return int(math.Round(math.Max(1, math.Min(5, s))))
+	return logScore(num/den, costLnLo, costLnHi)
 }
 
-// costMeter renders the 1..5 $ scale — the estimate in the accent colour, the
-// rest dim — always five glyphs so the fill reads at a glance.
-func (m model) costMeter() string {
-	n := m.costScore()
-	acc := lipgloss.NewStyle().Foreground(lipgloss.Color(m.accent())).Bold(true).Render(strings.Repeat("$", n))
-	rest := stDim.Render(strings.Repeat("$", 5-n))
-	return "  " + stDim.Render("cost ") + acc + rest
+// speedScore rates the current config from 1 (slow) to 5 (fast).
+func (m model) speedScore() int {
+	fast := m.sel["fast"] == "on" && m.sel["lane"] != "claude-only"
+	var num, den float64
+	m.weightedModels(func(w float64, id, lvl string) {
+		c, ok := m.facts[id]
+		if !ok || c.speed == 0 {
+			return
+		}
+		mult, ok := thinkSpeed[lvl]
+		if !ok {
+			mult = 1
+		}
+		sp := c.effTPS() * mult
+		if fast && strings.HasPrefix(id, "gpt-") {
+			sp *= fastSpeed
+		}
+		num += w * sp
+		den += w
+	})
+	if den == 0 {
+		return 3
+	}
+	return logScore(num/den, speedLnLo, speedLnHi)
+}
+
+// meter renders a labelled 1..5 scale — the score in the accent colour, the rest
+// dim — always five glyphs so the fill reads at a glance.
+func (m model) meter(label, glyph string, n int) string {
+	acc := lipgloss.NewStyle().Foreground(lipgloss.Color(m.accent())).Bold(true).Render(strings.Repeat(glyph, n))
+	rest := stDim.Render(strings.Repeat(glyph, 5-n))
+	return "  " + stDim.Render(pad(label, 6)) + acc + rest
 }
 
 // advisorChain returns the advisor role's model chain for an intensity + lane,
@@ -963,8 +1033,8 @@ type model struct {
 	profiles  []profile
 	routes    map[string][]string
 	generated map[string][]string
-	advisors  map[string][]string   // "level/ctx" → advisor model chain
-	costs     map[string][2]float64 // model id → {cost_in, cost_out} $/1M tokens
+	advisors  map[string][]string  // "level/ctx" → advisor model chain
+	facts     map[string]modelFact // model id → cost ($/1M) + curated speed (tok/s)
 	avail     availability
 	glyphs    map[string]string
 
@@ -1676,7 +1746,9 @@ func (m model) genLines(focused bool) ([]string, int) {
 	// launch call-to-action under the facets — the "configure → launch" flow
 	// lives with the generator; the routing detail stays on the right.
 	if focused {
-		lines = append(lines, "", m.costMeter(),
+		lines = append(lines, "",
+			m.meter("cost", "$", m.costScore()),
+			m.meter("speed", "»", m.speedScore()),
 			lipgloss.NewStyle().Foreground(lipgloss.Color(acc)).Bold(true).Render("  ⏎ launch this profile"))
 	}
 	return lines, cursor
@@ -1715,7 +1787,7 @@ func main() {
 		routes:    loadBlocks(os.Getenv("CODE_ROUTES")),
 		generated: generated,
 		advisors:  parseAdvisors(generated["__advisors__"]),
-		costs:     parseCosts(generated["__costs__"]),
+		facts:     parseFacts(generated["__models__"]),
 		avail:     availability{bucket: map[string]string{}, reset: map[string]int64{}},
 		usageCmd:  os.Getenv("CODE_USAGE"),
 		spin:      sp,

--- a/pkgs/omp-configured/generate-profiles.py
+++ b/pkgs/omp-configured/generate-profiles.py
@@ -248,6 +248,17 @@ def render(lane, mtier, thinking, spark, fable):
     return "\n".join(lines)
 
 
+def render_costs():
+    """Emit the per-model cost table as a pseudo-block the picker parses, so the
+    generator's $ meter reads pricing from the catalog (not a second copy). Cost
+    is $ per 1M tokens, mirrored from `omp models` (see models.yml)."""
+    lines = ["__costs__  model cost table (id in out — $ per 1M tokens)"]
+    for k, v in CATALOG.items():
+        lines.append(f"  {ID[k]} {v['cost_in']} {v['cost_out']}")
+    lines.append("")
+    return "\n".join(lines)
+
+
 def render_advisors():
     """Emit the advisor dial as a pseudo-block the picker parses (level context
     → chain), so the advisor model names live here, not duplicated in the TUI."""
@@ -272,6 +283,7 @@ def main():
     print("OMP generated routing — first-principles facet grid")
     print("bundled agents: designer librarian reviewer sonic task — ● marks an agent-backed role\n")
     print(render_advisors())
+    print(render_costs())
     for lane in LANES:
         for mtier in MTIERS:
             for thinking in THINKING:

--- a/pkgs/omp-configured/generate-profiles.py
+++ b/pkgs/omp-configured/generate-profiles.py
@@ -248,13 +248,14 @@ def render(lane, mtier, thinking, spark, fable):
     return "\n".join(lines)
 
 
-def render_costs():
-    """Emit the per-model cost table as a pseudo-block the picker parses, so the
-    generator's $ meter reads pricing from the catalog (not a second copy). Cost
-    is $ per 1M tokens, mirrored from `omp models` (see models.yml)."""
-    lines = ["__costs__  model cost table (id in out — $ per 1M tokens)"]
+def render_model_facts():
+    """Emit the per-model cost + speed table as a pseudo-block the picker parses,
+    so the generator's $ / speed meters read from the catalog (not a second copy):
+    cost is $ per 1M tokens (from omp), speed is our curated tok/s (see models.yml
+    — omp exposes no throughput)."""
+    lines = ["__models__  model facts (id in out speed ttft — $/1M in·out, tok/s, s)"]
     for k, v in CATALOG.items():
-        lines.append(f"  {ID[k]} {v['cost_in']} {v['cost_out']}")
+        lines.append(f"  {ID[k]} {v['cost_in']} {v['cost_out']} {v['speed']} {v['ttft']}")
     lines.append("")
     return "\n".join(lines)
 
@@ -283,7 +284,7 @@ def main():
     print("OMP generated routing — first-principles facet grid")
     print("bundled agents: designer librarian reviewer sonic task — ● marks an agent-backed role\n")
     print(render_advisors())
-    print(render_costs())
+    print(render_model_facts())
     for lane in LANES:
         for mtier in MTIERS:
             for thinking in THINKING:

--- a/pkgs/omp-configured/generate-wiki.py
+++ b/pkgs/omp-configured/generate-wiki.py
@@ -195,6 +195,9 @@ def main():
         ctx_disp = f"{ctx // 1000}K" if ctx else "—"
         think_disp = v.get("thinking") or "—"
         ci, co = v.get("cost_in"), v.get("cost_out")
+        sp, tt = v.get("speed"), v.get("ttft")
+        sp_disp = f"{sp:g} t/s" if sp else "—"
+        tt_disp = f"{tt:g}s" if tt is not None else "—"
         cat_rows.append(
             f'<tr class="{model_class(v["id"])}">'
             f'<td class="key">{esc(key)}</td>'
@@ -204,6 +207,8 @@ def main():
             f'<td data-sort="{ci if ci is not None else -1}" class="num">{fmt_cost(ci)}</td>'
             f'<td data-sort="{co if co is not None else -1}" class="num">{fmt_cost(co)}</td>'
             f'<td data-sort="{ctx or 0}" class="num">{ctx_disp}</td>'
+            f'<td data-sort="{sp or 0}" class="num">{sp_disp}</td>'
+            f'<td data-sort="{tt if tt is not None else 999}" class="num">{tt_disp}</td>'
             f'<td>{esc(think_disp)}</td>'
             f'<td>{esc(v["bucket"])}</td>'
             f'<td class="role-note">{esc(v.get("role", ""))}</td>'
@@ -326,13 +331,15 @@ footer { margin-top:40px; color:var(--dim); font-size:12.5px; }
   <p class="intro">__INTRO__</p>
 
   <h2>Model catalog</h2>
-  <p class="intro">Cost ($ per 1M tokens in / out), context, and thinking range come live from
-    <span class="mono">omp models</span>; the short key, tier, bucket, and role come from
+  <p class="intro">Cost ($ per 1M tokens in / out) and context come from
+    <span class="mono">omp models</span>; speed (output tok/s) and ttft (time-to-first-token)
+    from <span class="mono">omp bench</span>; the short key, tier, bucket, and role from
     <span class="mono">models.yml</span>. Click a header to sort.</p>
   <div class="scroll"><table id="models">
     <thead><tr>
       <th>key</th><th>model</th><th>pool</th><th>tier</th>
       <th class="num">$ in</th><th class="num">$ out</th><th class="num">context</th>
+      <th class="num">speed</th><th class="num">ttft</th>
       <th>thinking</th><th>bucket</th><th>role</th>
     </tr></thead>
     <tbody>__CAT_ROWS__</tbody>


### PR DESCRIPTION
Adds a **cost meter** to the `code` generator — five `$` glyphs above "launch this profile", the estimate in the accent colour and the rest dim, so you can see how expensive a profile is before launching it.

## How the score works

A profile's price is dominated by the models on its **heaviest roles**, so each role is weighted by the token volume it drives over a session:

| role | weight | | role | weight |
|------|-------|-|------|-------|
| default | 10 | | librarian | 2 |
| task | 6 | | slow / designer | 2 |
| advisor | 4 | | smol | 1 |
| reviewer / sonic / plan | 3 | | tiny / commit | 0.5 |

So a pricey model on `default` moves the needle, while the same model on `commit` barely registers — **Fable-as-default is dear, Fable-as-commit is not**, exactly as requested.

Per role the cost:
- blends input+output pricing (mirrored from `omp models` via models.yml),
- scales with thinking effort (`minimal` 0.6 … `max` 2.0),
- applies OpenAI's **priority multiplier** (×1.9) under fast mode,
- includes the advisor's dial choice (and its `off` state).

The weighted average maps onto a **log 1–5 scale** (cost is perceived multiplicatively), calibrated across all **2160** valid facet × advisor × fast combinations — which gives a natural spread (histogram `{1:48, 2:467, 3:867, 4:700, 5:78}`).

## Plumbing

Pricing reaches the picker through a new `__costs__` pseudo-block in the generated grid (same mechanism as `__advisors__`), so cost data still lives in **models.yml alone**.

## Verification

- `nix build .#code-tui`, `.#omp-configured`, `.#checks.x86_64-linux.omp-stack` all pass.
- Rendered live under tmux — Go scores match the Python calibration exactly: `claude-only/fast/minimal` → **1**, the `mixed/normal/medium` default → **3**, `mixed/normal/max/audit/fast/fable` → **4**, `smart/max/fable/fast` → **5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)