### PR TITLE
chore(inventory): drop stale vscode entries — it isn't managed here

### DIFF
--- a/inventory/packages.json
+++ b/inventory/packages.json
@@ -37,7 +37,7 @@
     "versionOwner": "pinned nixpkgs",
     "mutableState": "application-owned user data and caches",
     "closureClass": "very-large",
-    "packages": ["arduino-ide", "chatgpt", "ghostty-bin", "godot", "lichess", "obsidian", "parsec-bin", "plugdata", "postman", "prismlauncher", "reaper", "signal-desktop", "spotify", "steam", "steamcmd", "vital", "vlc", "vlc-bin", "vscode", "whatsapp-for-mac"]
+    "packages": ["arduino-ide", "chatgpt", "ghostty-bin", "godot", "lichess", "obsidian", "parsec-bin", "plugdata", "postman", "prismlauncher", "reaper", "signal-desktop", "spotify", "steam", "steamcmd", "vital", "vlc", "vlc-bin", "whatsapp-for-mac"]
   },
   {
     "owner": "mobile",

--- a/inventory/server-profile.json
+++ b/inventory/server-profile.json
@@ -88,7 +88,6 @@
     "vital",
     "vlc",
     "vlc-bin",
-    "vscode",
     "whatsapp-for-mac",
     "zed",
     "zen"


### PR DESCRIPTION
**Answer to "is my VS Code coming from the dotfiles?": no.**

`grep -rn 'vscode' --include='*.nix'` across the whole repo finds nothing — VS Code is in no `home.packages` list, no Homebrew cask, and there's no `programs.vscode`. It appeared *only* as a stale token in two inventory manifests (`inventory/packages.json` under the desktop set, and `inventory/server-profile.json`), so the manifest claimed a package the dotfiles never actually deliver.

This removes those two stale entries so the inventory reflects reality. Any VS Code on a machine is a manual / Homebrew-GUI install and is unaffected by this change (it was never Nix-managed).

`system-boundary` and `package-ownership` checks pass without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)