### PR TITLE
feat(code): serve `code --wiki` over localhost (VPS-friendly)

### DIFF
--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1543,7 +1543,7 @@ let
           '  code <profile>          run that launcher (name, number, or letter)' \
           '  code <profile> [args]   run it, forwarding all extra args' \
           '  code -l, --list         print the launcher palette and exit' \
-          '  code -w, --wiki         open the browsable profiles wiki' \
+          '  code -w, --wiki         serve the profiles wiki on localhost' \
           '  code -U, --no-usage     open without fetching the usage panel' \
           '  code -h, --help         this help' \
           "" \
@@ -1552,15 +1552,26 @@ let
           'profile opens the picker and forwards all args to your choice.'
       }
 
+      # Serve the wiki over HTTP on localhost rather than handing back a file
+      # path — so it also works on a headless VPS (forward the port over SSH).
+      # Bound to 127.0.0.1 only; set CODE_WIKI_PORT to change the port.
       open_wiki() {
         local wiki=${profilesWiki}/share/omp/routes.html
+        local port="''${CODE_WIKI_PORT:-8765}"
+        local dir
+        dir="$(mktemp -d)"
+        cp "$wiki" "$dir/index.html"
+        trap 'rm -rf "$dir"' EXIT
+        local url="http://127.0.0.1:$port/"
+        printf 'code: serving the profiles wiki at %s\n' "$url"
+        printf 'code: from another machine, forward it:  ssh -L %s:127.0.0.1:%s <this-host>\n' "$port" "$port"
+        printf 'code: Ctrl-C to stop.\n'
         if command -v xdg-open >/dev/null 2>&1; then
-          xdg-open "$wiki" >/dev/null 2>&1 &
+          xdg-open "$url" >/dev/null 2>&1 &
         elif command -v open >/dev/null 2>&1; then
-          open "$wiki"
-        else
-          printf '%s\n' "$wiki"
+          open "$url" >/dev/null 2>&1 &
         fi
+        ${python3}/bin/python3 -m http.server "$port" --bind 127.0.0.1 --directory "$dir" || true
       }
 
       case "''${1:-}" in


### PR DESCRIPTION
`code --wiki` opened a `file://` path, which only works on a desktop with a browser — on a headless VPS it just printed a Nix store path.

Now it serves the self-contained wiki over HTTP on **127.0.0.1** (default port `8765`, override with `CODE_WIKI_PORT`), so it's reachable over SSH:

```
code: serving the profiles wiki at http://127.0.0.1:8765/
code: from another machine, forward it:  ssh -L 8765:127.0.0.1:8765 <this-host>
code: Ctrl-C to stop.
```

Bound to loopback only (no `0.0.0.0` exposure); opens a local browser when there is one; cleans up its temp dir on exit. Verified: builds (shellcheck clean via `writeShellApplication`), serves the rendered HTML to `curl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)