### PR TITLE
feat(darwin): enable Touch ID for sudo

### DIFF
--- a/checks/system-boundary.nix
+++ b/checks/system-boundary.nix
@@ -112,12 +112,16 @@ let
     let
       activation = config.system.activationScripts.postActivation.text;
       shellPaths = map toString config.environment.shells;
+      sudoPam = config.security.pam.services.${boundary.sudo.darwinService};
       configuredCasks = map (
         cask: if builtins.isString cask then cask else cask.name
       ) config.homebrew.casks;
     in
     config.programs.zsh.enable
     && builtins.elem boundary.loginShell.darwinPath shellPaths
+    && sudoPam.enable
+    && sudoPam.touchIdAuth
+    && sudoPam.reattach
     && config.users.users.${config.system.primaryUser}.shell == null
     && !(builtins.elem config.system.primaryUser config.users.knownUsers)
     && config.nix.settings.trusted-users == [ "root" ]
@@ -150,6 +154,9 @@ assert lib.assertMsg (
   && boundary.loginShell.darwinPath == "/run/current-system/sw/bin/zsh"
   && boundary.loginShell.nixosPath == "/run/current-system/sw/bin/zsh"
 ) "login-shell ownership paths differ from the reviewed boundary";
+assert lib.assertMsg (
+  boundary.sudo.darwinService == "sudo_local" && boundary.sudo.touchIdAuth && boundary.sudo.reattach
+) "Darwin sudo authentication differs from the reviewed boundary";
 assert lib.assertMsg (
   boundary.nix.store == "daemon"
   && boundary.nix.trustedUsers == [ "root" ]

--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -23,6 +23,12 @@ in
 
   programs.zsh.enable = true;
 
+  security.pam.services.sudo_local = {
+    touchIdAuth = true;
+    # Keep biometric sudo available inside the managed tmux sessions.
+    reattach = true;
+  };
+
   users.users.${username} = {
     home = homeDirectory;
   };

--- a/docs/system-boundary.md
+++ b/docs/system-boundary.md
@@ -14,6 +14,7 @@ layer and are checked separately.
 | Zsh startup, Git, CLI and agent configuration | Home Manager | Home Manager | Home Manager |
 | Home Manager generations | Home Manager | Home Manager inside the Darwin generation | Home Manager inside the NixOS generation |
 | Account and login-shell selection | Bootstrap registers `$HOME/.nix-profile/bin/zsh` in `/etc/shells` and selects it with `chsh` using explicit privilege | nix-darwin registers Zsh and sets the existing primary user's `UserShell` to `/run/current-system/sw/bin/zsh` during activation | The consuming infrastructure enables Zsh and sets `users.users.<name>.shell` |
+| `sudo` authentication | Operating system/operator | nix-darwin manages `/etc/pam.d/sudo_local`, enabling Touch ID with password fallback and reattachment for tmux sessions | The consuming infrastructure |
 | Nix daemon, store and service lifecycle | The system-wide Nix installation | nix-darwin | The consuming NixOS infrastructure |
 | Nix trust, cache and optimisation policy | System Nix configuration; never a Home Manager `nix.conf` override | nix-darwin | The consuming NixOS infrastructure |
 | Container engine and privileged access | System/operator, using a rootless per-user engine | OrbStack runtime state, outside Home Manager | The consuming infrastructure |

--- a/inventory/system-boundary.json
+++ b/inventory/system-boundary.json
@@ -15,6 +15,11 @@
     "darwinPath": "/run/current-system/sw/bin/zsh",
     "nixosPath": "/run/current-system/sw/bin/zsh"
   },
+  "sudo": {
+    "darwinService": "sudo_local",
+    "touchIdAuth": true,
+    "reattach": true
+  },
   "nix": {
     "store": "daemon",
     "trustedUsers": ["root"],


### PR DESCRIPTION
## Summary

- enable nix-darwin's declarative `sudo_local` Touch ID authentication
- enable PAM reattachment so Touch ID continues to work in managed tmux sessions
- record and enforce the setting in the system-boundary policy and documentation

Password authentication remains available as PAM's fallback.

## Validation

- `nix fmt -- darwin/default.nix checks/system-boundary.nix`
- `nix flake check --all-systems --no-build --show-trace`
- `nix build .#checks.aarch64-darwin.system-boundary .#checks.aarch64-darwin.darwin-evaluation --no-link`
- evaluated the generated `security.pam.services.sudo_local.text` and confirmed `pam_reattach` precedes `pam_tid`
- `git diff --check`
