### PR TITLE
fix(darwin): install Godot as a Homebrew cask, not a from-source build

### DIFF
--- a/darwin/casks.nix
+++ b/darwin/casks.nix
@@ -5,6 +5,7 @@
   "codex-app"
   "display-pilot"
   "discord"
+  "godot"
   "parsec"
   "plugdata"
   "sonos"

--- a/home/profiles/desktop.nix
+++ b/home/profiles/desktop.nix
@@ -15,7 +15,6 @@ in
   home.packages = lib.optionals pkgs.stdenv.isDarwin (
     (with pkgs; [
       chatgpt
-      godot
       obsidian
       postman
       prismlauncher

--- a/inventory/packages.json
+++ b/inventory/packages.json
@@ -37,7 +37,7 @@
     "versionOwner": "pinned nixpkgs",
     "mutableState": "application-owned user data and caches",
     "closureClass": "very-large",
-    "packages": ["arduino-ide", "chatgpt", "ghostty-bin", "godot", "lichess", "obsidian", "parsec-bin", "plugdata", "postman", "prismlauncher", "reaper", "signal-desktop", "spotify", "steam", "steamcmd", "vital", "vlc", "vlc-bin", "whatsapp-for-mac"]
+    "packages": ["arduino-ide", "chatgpt", "ghostty-bin", "lichess", "obsidian", "parsec-bin", "plugdata", "postman", "prismlauncher", "reaper", "signal-desktop", "spotify", "steam", "steamcmd", "vital", "vlc", "vlc-bin", "whatsapp-for-mac"]
   },
   {
     "owner": "mobile",
@@ -97,7 +97,7 @@
     "versionOwner": "immutable Homebrew taps pinned by the flake",
     "mutableState": "application-owned user data; Homebrew state outside Nix derivations",
     "closureClass": "outside-nix-store",
-    "packages": ["bitwarden", "claude", "codex-app", "display-pilot", "discord", "parsec", "sonos", "zen"]
+    "packages": ["bitwarden", "claude", "codex-app", "display-pilot", "discord", "godot", "parsec", "sonos", "zen"]
   },
   {
     "owner": "experimental",


### PR DESCRIPTION
## What happened
Your `atyrode apply` on macOS failed building **`godot-4.7-stable`**. Godot was the one desktop app sourced from **nixpkgs** on macOS, and nixpkgs' godot on `aarch64-darwin` is a full **from-source scons build**. With no binary-cache hit, your Mac compiled the entire editor (~22 min) and then died at the final link:

```
clang++: error: linker command failed with exit code 133
scons: *** [bin/godot.macos.editor.arm64] Error 1
```

Exit 133 is a linker crash (a nixpkgs/darwin toolchain issue), and it failed the whole darwin activation. **Not your config's fault** — and *not* reliably one-time: as long as godot comes from nixpkgs on macOS, every version bump risks another slow uncached rebuild + breakage.

## Fix
Deliver the **official prebuilt Godot** via the Homebrew **cask** — no source build, no cache dependency — the same way your other cask-only macOS apps (bitwarden/discord/sonos/zen) work:

- remove `godot` from the darwin `home.packages` (`home/profiles/desktop.nix`);
- add `"godot"` to `darwin/casks.nix`;
- move `godot` in `inventory/packages.json` from the *desktop* (home-manager) record to the *system* (nix-darwin cask) record.

Godot stays macOS-only (its current scope). `system-boundary` + `package-ownership` pass locally; CI covers the darwin `atyrode-cli`.

After this merges, `atyrode apply` installs Godot from the cask (a quick download) instead of compiling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)