### PR TITLE
fix(code): align wrapped fallback chains in the split preview

### DIFF
--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -500,7 +500,14 @@ func renderRoute(rows []string, depth int, a availability, width int) string {
 		line, lineW := label+s0, labelW+w0
 		for i := 1; i <= last; i++ {
 			si, wi := render(toks[i])
-			if lineW+3+wi > width { // won't fit — break after a trailing arrow
+			// Reserve 2 cols for a trailing " →" whenever more models follow, so a
+			// break line's continuation arrow always fits within width instead of
+			// being clipped at the edge; the final model needs no such reserve.
+			budget := width
+			if i < last {
+				budget -= 2
+			}
+			if lineW+3+wi > budget { // won't fit — break after a trailing arrow
 				out = append(out, line+stDim.Render(" →"))
 				line, lineW = indent+si, labelW+wi
 			} else {
@@ -1049,8 +1056,9 @@ func (m model) previewDims() (int, int) {
 		body, _ := m.bodyLines(m.w - gut)
 		_, ph := stackedSplit(bodyH, len(body))
 		return m.w - gut, ph
-	default: // split
-		return m.w - m.listW() - 3, bodyH
+	default: // split — the pane draws a border + prevPadL inside its width, so the
+		// viewport (what renderRoute wraps to) gets the inner text area, not the box.
+		return m.w - m.listW() - 3 - prevPadL, bodyH
 	}
 }
 
@@ -1507,10 +1515,16 @@ func (m *model) cycleFacet(dir int) {
 	m.syncPreview()
 }
 
+// prevPadL is the split preview pane's left padding. Width() counts it, so the
+// viewport's usable text width is the box width minus this — the viewport must
+// be sized to that inner area (see previewDims), else lines wrap 1:1 with the
+// box and their tail overflows to the pane's left edge.
+const prevPadL = 2
+
 func (m model) previewPane(w, h int) string {
 	return lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder(), false, false, false, true).
-		BorderForeground(lipgloss.Color(cBord)).PaddingLeft(2).
+		BorderForeground(lipgloss.Color(cBord)).PaddingLeft(prevPadL).
 		Width(w).Height(h).
 		Render(m.vp.View())
 }


### PR DESCRIPTION
## What

The hanging-indent continuation of wrapped routing chains in `code`'s split preview rendered **flush-left for some rows** (the `:high` chains) instead of aligned under the first model — exactly the "works for the first two, fails for the next four, works again for the following two" behavior reported.

## Root cause

The split preview pane sets `Width(w)` with a left border + `PaddingLeft(2)`, so its drawable text area is `w − 2`. But the viewport — which is what `renderRoute` wraps its chains to — was sized to the **full `w`**. Every preview line was 2 columns too wide, and the terminal soft-wrapped the overflow (the trailing ` →`) to the pane's left edge. It only surfaced on the short-named `:high` chains because they pack an extra token onto line 1 before `renderRoute`'s own wrap fires.

## Fix

- Size the viewport to the pane's **inner text area** (`- prevPadL`) in `previewDims`, so `renderRoute` wraps to what actually fits. `prevPadL` is now a named const shared by `previewPane` and `previewDims`.
- Reserve 2 columns for the trailing continuation arrow in `renderRoute`, so ` →` always fits at the edge instead of being clipped — consistent across rows.

## Verification

`nix build .#omp-configured` + tmux capture across widths **96, 104, 112, 120, 128, 140**: all fallback chains hang-indent uniformly under the first model, no soft-wrap overflow, trailing arrow consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)