### PR TITLE
test(code): unit-test the routing renderer, facets, and defaults

### DIFF
--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// A realistic full-name routing row: renderRoute shortens the names for display.
+const sampleRow = "  default    gpt-5.6-terra:medium → gpt-5.6-luna:medium → claude-sonnet-5:medium → claude-haiku-4-5:medium"
+
+// labelWidth mirrors how renderRoute derives the role label (everything before
+// the first model match) so tests assert against the real alignment column.
+func labelWidth(row string) int {
+	loc := modelRe.FindStringIndex(row)
+	if loc == nil {
+		return 0
+	}
+	return lipgloss.Width(row[:loc[0]])
+}
+
+// routeLines splits renderRoute output into physical lines, dropping the trailing
+// newline the function appends.
+func routeLines(out string) []string {
+	return strings.Split(strings.TrimRight(out, "\n"), "\n")
+}
+
+// TestRenderRouteHangingIndent locks the bug fixed in #118: when a chain wraps,
+// every continuation line must be indented to align under the first model (a
+// hanging block), never flush-left.
+func TestRenderRouteHangingIndent(t *testing.T) {
+	lw := labelWidth(sampleRow)
+	indent := strings.Repeat(" ", lw)
+	// The sample chain is ~70 cols on one line; these widths force it to wrap.
+	for _, width := range []int{40, 52, 64} {
+		out := renderRoute([]string{sampleRow}, 1, availability{}, width)
+		lines := routeLines(out)
+		if len(lines) < 2 {
+			t.Fatalf("width=%d: expected the chain to wrap onto multiple lines, got %d", width, len(lines))
+		}
+		for i, ln := range lines[1:] {
+			// Continuation lines start with exactly the label-width of spaces,
+			// then a (non-space) model — i.e. aligned under the first model.
+			if !strings.HasPrefix(ln, indent) {
+				t.Errorf("width=%d line %d not aligned under first model: %q", width, i+1, ln)
+			}
+			if lw < len(ln) && ln[lw] == ' ' {
+				t.Errorf("width=%d line %d over-indented past the model column: %q", width, i+1, ln)
+			}
+		}
+	}
+}
+
+// TestRenderRouteWidthInvariant: no rendered line exceeds the target width — the
+// 2-col reserve for the trailing arrow must keep even break lines in bounds.
+func TestRenderRouteWidthInvariant(t *testing.T) {
+	for _, width := range []int{40, 56, 72, 100} {
+		out := renderRoute([]string{sampleRow}, 1, availability{}, width)
+		for i, ln := range routeLines(out) {
+			if w := lipgloss.Width(ln); w > width {
+				t.Errorf("width=%d: line %d overflows (%d cols): %q", width, i, w, ln)
+			}
+		}
+	}
+}
+
+// TestRenderRouteLeadDepth: at depth 0 only the primary (first live) model shows.
+func TestRenderRouteLeadDepth(t *testing.T) {
+	out := renderRoute([]string{sampleRow}, 0, availability{}, 120)
+	if lines := routeLines(out); len(lines) != 1 {
+		t.Fatalf("lead depth should be a single line, got %d:\n%s", len(lines), out)
+	}
+	if !strings.Contains(out, "terra:medium") {
+		t.Errorf("lead should show the primary model terra:medium: %q", out)
+	}
+	if strings.Contains(out, "luna:medium") {
+		t.Errorf("lead depth must not show fallback models: %q", out)
+	}
+}
+
+// TestRenderRoutePassThrough: a line with no models is emitted unchanged (modulo
+// colourisation), not dropped.
+func TestRenderRoutePassThrough(t *testing.T) {
+	out := renderRoute([]string{"  advisor    (disabled)"}, 1, availability{}, 80)
+	if !strings.Contains(out, "advisor") || !strings.Contains(out, "(disabled)") {
+		t.Errorf("note line should pass through, got: %q", out)
+	}
+}
+
+func TestShortModel(t *testing.T) {
+	cases := map[string]string{
+		"gpt-5.6-terra":       "terra",
+		"gpt-5.6-luna":        "luna",
+		"gpt-5.6-sol":         "sol",
+		"gpt-5.3-codex-spark": "spark",
+		"claude-opus-4-8":     "opus",
+		"claude-sonnet-5":     "sonnet",
+		"claude-haiku-4-5":    "haiku",
+		"claude-fable-5":      "fable",
+		"gpt-5.4":             "gpt-5.4", // special-cased whole name
+	}
+	for in, want := range cases {
+		if got := shortModel(in); got != want {
+			t.Errorf("shortModel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestLvl(t *testing.T) {
+	cases := map[string]int{
+		"minimal": 0, "low": 1, "medium": 2, "high": 3, "xhigh": 4, "max": 5,
+		"": 5, "bogus": 5,
+	}
+	for in, want := range cases {
+		if got := lvl(in); got != want {
+			t.Errorf("lvl(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+// TestComboID covers the lane-driven suppression: gpt-only forces fable off,
+// claude-only forces spark off, regardless of the toggles.
+func TestComboID(t *testing.T) {
+	cases := []struct {
+		sel  map[string]string
+		want string
+	}{
+		{map[string]string{"lane": "mixed", "model": "normal", "thinking": "medium", "spark": "on", "fable": "off"}, "mixed_normal_medium_sp_nofa"},
+		{map[string]string{"lane": "mixed", "model": "normal", "thinking": "medium", "spark": "off", "fable": "on"}, "mixed_normal_medium_nosp_fa"},
+		{map[string]string{"lane": "gpt-only", "model": "fast", "thinking": "high", "spark": "on", "fable": "on"}, "gpt-only_fast_high_sp_nofa"},
+		{map[string]string{"lane": "claude-only", "model": "smart", "thinking": "low", "spark": "on", "fable": "on"}, "claude-only_smart_low_nosp_fa"},
+	}
+	for _, c := range cases {
+		if got := comboID(c.sel); got != c.want {
+			t.Errorf("comboID(%v) = %q, want %q", c.sel, got, c.want)
+		}
+	}
+}
+
+// TestDefaultSelValid guards the reset-to-defaults key (#119) against facet
+// drift: every default must name a real facet and a value that facet offers, and
+// every facet must be seeded exactly once.
+func TestDefaultSelValid(t *testing.T) {
+	facets := facetDefs(map[string]string{})
+	byKey := map[string][]string{}
+	for _, f := range facets {
+		byKey[f.key] = f.values
+	}
+	def := defaultSel()
+	if len(def) != len(facets) {
+		t.Errorf("defaultSel has %d keys, facetDefs has %d — every facet must be seeded", len(def), len(facets))
+	}
+	for k, v := range def {
+		values, ok := byKey[k]
+		if !ok {
+			t.Errorf("defaultSel key %q is not a known facet", k)
+			continue
+		}
+		found := false
+		for _, allowed := range values {
+			if allowed == v {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("defaultSel[%q]=%q is not a valid value (allowed: %v)", k, v, values)
+		}
+	}
+}


### PR DESCRIPTION
## What

`code-tui` had **zero test coverage** despite intricate layout logic — the fallback-chain wrap bug (#118) was exactly the kind of subtle geometry regression a test locks down. This adds a focused white-box suite.

It runs in `buildGoModule`'s `checkPhase` (`doCheck` is on), so **`nix flake check` gates it in CI** — no workflow changes needed.

## Coverage

- **`renderRoute`** — the regression-prone part:
  - hanging-indent alignment when a chain wraps (guards #118: continuations align under the first model, never flush-left),
  - the width invariant (no rendered line exceeds the target width, incl. the 2-col trailing-arrow reserve),
  - lead depth shows only the primary model,
  - note lines with no models pass through unchanged.
- **`shortModel` / `lvl`** — display-name and level mappings, incl. the `gpt-5.4` special case.
- **`comboID`** — the lane-driven suppression (`gpt-only` forces fable off → `nofa`; `claude-only` forces spark off → `nosp`).
- **`defaultSel`** — every default names a real facet with a valid value and every facet is seeded exactly once; guards the reset-to-defaults key (#119) against facet drift.

## Verification

`go test ./...` → all 8 pass locally; `nix build .#code-tui` runs them in `checkPhase` and passes in the sandbox (vendored deps; the suite adds no new dependency — stdlib `testing` + the already-vendored lipgloss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)