### PR TITLE
build(code): gofmt code-tui and enforce gofmt via a flake check

### DIFF
--- a/checks/go-fmt.nix
+++ b/checks/go-fmt.nix
@@ -1,0 +1,26 @@
+{ lib, pkgs }:
+
+let
+  # buildGoModule does not gofmt-check, so drift in the Go packages (code-tui,
+  # cli-kit) builds green. Scope this guard to the .go sources alone so edits to
+  # default.nix / go.mod don't invalidate it, and so it grows to cover any future
+  # Go package under pkgs/ automatically.
+  goSources = lib.fileset.toSource {
+    root = ../pkgs;
+    fileset = lib.fileset.fileFilter (file: file.hasExt "go") ../pkgs;
+  };
+in
+pkgs.runCommand "check-go-fmt"
+  {
+    nativeBuildInputs = [ pkgs.go ];
+  }
+  ''
+    unformatted="$(cd ${goSources} && gofmt -l .)"
+    if [ -n "$unformatted" ]; then
+      echo 'These Go files are not gofmt-clean:' >&2
+      echo "$unformatted" >&2
+      echo 'Run `gofmt -w pkgs` to fix them.' >&2
+      exit 1
+    fi
+    mkdir "$out"
+  ''

--- a/flake.nix
+++ b/flake.nix
@@ -596,6 +596,7 @@
             baseConfig = baseOnlyConfig;
           };
           get-entrypoint = import ./checks/get-sh.nix { inherit pkgs; };
+          go-fmt = import ./checks/go-fmt.nix { inherit lib pkgs; };
           omp-seed = import ./checks/omp-seed.nix { inherit lib pkgs; };
           production-facts = import ./checks/production-facts.nix { inherit pkgs; };
           home-evaluation = homeEvaluation;

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -1022,7 +1022,7 @@ func (m model) launchFooter() []string {
 	cs, ss := m.costScore(), m.speedScore()
 	return []string{
 		"",
-		m.meter("cost", "$", meterRamp[cs], cs),    // dear → red, cheap → green
+		m.meter("cost", "$", meterRamp[cs], cs), // dear → red, cheap → green
 		m.meter("speed", "»", meterRamp[6-ss], ss), // fast → green, slow → red
 		lipgloss.NewStyle().Foreground(lipgloss.Color(m.accent())).Bold(true).Render("  ⏎ launch this profile"),
 	}


### PR DESCRIPTION
## Problem

`pkgs/code-tui/main.go` was not gofmt-clean (`gofmt -l` listed it) yet CI stayed green — `buildGoModule` doesn't gofmt-check. A misaligned trailing comment in `launchFooter` slipped through unnoticed.

## Change

- **Reformat** `pkgs/code-tui/main.go` with `gofmt -w` (one-line comment alignment fix).
- **Add** a `go-fmt` flake check (`checks/go-fmt.nix`) that runs `gofmt -l` over every `.go` file under `pkgs/`. It's scoped via a fileset to `.go` sources only, so it covers code-tui, cli-kit, and any future Go package automatically, and edits to `default.nix`/`go.mod` don't invalidate it.

## Verification

- `nix build .#checks.x86_64-linux.go-fmt` passes on the clean tree.
- Negative test: reintroducing the misalignment makes the check fail with
  `These Go files are not gofmt-clean: code-tui/main.go … Run \`gofmt -w pkgs\``.

Pre-existing drift on `main`, unrelated to any in-flight feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)