### PR TITLE
feat(cli-kit): Act mode in the PromptBox + consumer README (closes #120)

### DIFF
--- a/pkgs/cli-kit/README.md
+++ b/pkgs/cli-kit/README.md
@@ -1,0 +1,67 @@
+# cli-kit
+
+The shared visual layer + Bubble Tea components for the dotfiles' custom CLIs, so
+every tool (`code`, `atyrode`, …) looks and feels like it came from the same dev.
+Consumed as a local Go module via `replace cli-kit => ../cli-kit`.
+
+## What's here
+
+- **Palette & styles** (`palette.go`) — colour tokens (`CAcc`, `CBord`, …), the
+  `MeterRamp`, text-presentation glyphs (`GWarn`/`GBroken`/`GReset`), and shared
+  lipgloss styles (`StDim`, `StHead`, …).
+- **Layout helpers** (`layout.go`, `meter.go`) — `PadLeft`/`Pad`, `WindowList`
+  (a clipped, scrollbar'd column), `Scrollbar`, meters.
+- **The smart PromptBox** (`promptbox.go`) + the **consumer contract**
+  (`contract.go`, `run.go`) + an **omp backend** (`ompasker.go`).
+
+## The consumer contract
+
+A CLI built on cli-kit is a Bubble Tea model (`tea.Model`). It launches through
+`clikit.Run`, which mounts capabilities the model **opts into** by implementing
+small interfaces — structural, compile-time, à la carte:
+
+| Implement | Get |
+|---|---|
+| *(nothing extra)* | palette + layout + the footer/help conventions |
+| `Askable` → `Asker() Asker` | the PromptBox in **Ask** mode (read-only Q&A) |
+| `Commandable` → `Commander() Commander` | the PromptBox in **Act** mode (propose → diff → confirm) |
+| `Documented` → `Docs() DocCorpus` | grounding injected into the backend's system prompt |
+
+`clikit.Run(app)` detects what's implemented and mounts the box behind a toggle
+key (default `ctrl+o`). Act mode takes precedence over Ask when both are present.
+
+### Ask mode
+
+```go
+type helpApp struct{ /* your tea.Model */ }
+
+func (helpApp) Asker() clikit.Asker { return clikit.NewOmpAsker(myDocs) }
+func (helpApp) Docs() clikit.DocCorpus { return myDocs }
+
+func main() { _ = clikit.Run(helpApp{...}, clikit.WithAltScreen()) }
+```
+
+`NewOmpAsker` shells out to a headless omp run
+(`omp -p --mode text --no-session --no-tools --model claude-haiku-4-5
+--append-system-prompt <docs> <prompt>`) and streams the answer; cancelling (esc)
+kills the omp subprocess. Override the evaluator via `OmpAsker.Model`.
+
+### Act mode
+
+Implement `Commander`; its `Actions(ctx, prompt)` returns a closed set of
+`Action{Key, Value}` the box shows for confirmation. On accept the host receives a
+`clikit.ActionsConfirmedMsg` (forwarded to your model's `Update`) — apply the
+actions through the **same code path as a manual change**. The closed action set
+*is* your tool's agent-facing API surface.
+
+## Design
+
+The rationale, the runtime-mutation wall, phasing, and open questions live in
+[`DESIGN-promptbox.md`](./DESIGN-promptbox.md). `code` is the reference consumer.
+
+## Building / testing
+
+`cli-kit` is a checked flake package: `nix build .#cli-kit` runs the unit tests in
+`checkPhase`. Note the vendoring coupling — `code-tui` includes `../cli-kit` in
+its build source, so a change to any `cli-kit/*.go` shifts `code-tui`'s
+`vendorHash` (bump it; see the comment in `pkgs/code-tui/default.nix`).

--- a/pkgs/cli-kit/promptbox.go
+++ b/pkgs/cli-kit/promptbox.go
@@ -2,6 +2,7 @@ package clikit
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -10,6 +11,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
+
+// errNoChanges is shown when a Commander returns an empty proposal.
+var errNoChanges = errors.New("no changes proposed")
 
 // PromptBox is the shared "smart prompt box": type a prompt, watch the agent
 // think, and read a streamed answer. It is a self-contained Bubble Tea component
@@ -22,9 +26,10 @@ import (
 type boxState int
 
 const (
-	boxEditing boxState = iota // composing a prompt
-	boxBusy                    // request in flight / streaming
-	boxDone                    // answer complete (or errored)
+	boxEditing  boxState = iota // composing a prompt
+	boxBusy                     // request in flight / streaming
+	boxDone                     // answer complete (or errored)
+	boxProposed                 // Act mode: showing proposed actions, awaiting confirm
 )
 
 // streamStarted carries the channel back from the (possibly slow) Ask call so the
@@ -44,9 +49,20 @@ type promptToken struct {
 	ok  bool
 }
 
+// actionsReady carries a Commander's proposal back to the UI thread (Act mode).
+type actionsReady struct {
+	seq     int
+	actions []Action
+	err     error
+}
+
 // BoxCloseMsg is emitted when the user dismisses an idle box (esc while editing).
 // A host (see Run) listens for it to hide the box.
 type BoxCloseMsg struct{}
+
+// ActionsConfirmedMsg is emitted when the user accepts a Commander's proposal.
+// The host (see Run, which forwards it to the app) applies the actions.
+type ActionsConfirmedMsg struct{ Actions []Action }
 
 // PromptBox is a value type — Update returns an updated copy, matching the
 // bubbles convention.
@@ -55,11 +71,13 @@ type PromptBox struct {
 	vp    viewport.Model
 	spin  spinner.Model
 	asker Asker
+	cmd   Commander
 
-	w, h   int
-	state  boxState
-	answer string
-	err    error
+	w, h     int
+	state    boxState
+	answer   string
+	proposed []Action // Act mode: the actions awaiting confirmation
+	err      error
 
 	seq    int // identifies the current request; stale async msgs are dropped
 	cancel context.CancelFunc
@@ -84,6 +102,11 @@ func NewPromptBox() PromptBox {
 
 // SetAsker wires the read-only backend. Without one, submitting is a no-op.
 func (b *PromptBox) SetAsker(a Asker) { b.asker = a }
+
+// SetCommander wires the Act-mode backend. When set, submitting asks the
+// Commander for a proposal (shown for confirmation) instead of streaming an
+// answer; it takes precedence over an Asker.
+func (b *PromptBox) SetCommander(c Commander) { b.cmd = c }
 
 // SetSize lays the box out within w×h (outer cells). A border + one column of
 // padding sit inside, so the inner widgets get w-4.
@@ -118,26 +141,39 @@ func readToken(seq int, ch <-chan string) tea.Cmd {
 	}
 }
 
-// submit fires the current prompt at the Asker. It returns quickly: the Ask call
-// runs inside a Cmd so a slow backend start never blocks the UI.
+// submit fires the current prompt at the backend. It returns quickly: the
+// backend call runs inside a Cmd so a slow start never blocks the UI. Act mode
+// (a Commander) takes precedence over Ask (an Asker).
 func (b *PromptBox) submit() tea.Cmd {
 	prompt := strings.TrimSpace(b.ta.Value())
-	if prompt == "" || b.asker == nil {
+	if prompt == "" {
 		return nil
 	}
 	b.state = boxBusy
-	b.answer, b.err = "", nil
+	b.answer, b.err, b.proposed = "", nil, nil
 	b.seq++
 	seq := b.seq
 	ctx, cancel := context.WithCancel(context.Background())
 	b.cancel = cancel
-	asker := b.asker
 	b.vp.SetContent("")
 	// The spinner keeps ticking on its own (see the TickMsg case); submit only
-	// needs to kick off the backend, in a Cmd so a slow start never blocks the UI.
-	return func() tea.Msg {
-		ch, err := asker.Ask(ctx, prompt)
-		return streamStarted{seq: seq, ch: ch, err: err}
+	// kicks off the backend, in a Cmd so a slow start never blocks the UI.
+	switch {
+	case b.cmd != nil: // Act mode
+		cmder := b.cmd
+		return func() tea.Msg {
+			actions, err := cmder.Actions(ctx, prompt)
+			return actionsReady{seq: seq, actions: actions, err: err}
+		}
+	case b.asker != nil: // Ask mode
+		asker := b.asker
+		return func() tea.Msg {
+			ch, err := asker.Ask(ctx, prompt)
+			return streamStarted{seq: seq, ch: ch, err: err}
+		}
+	default:
+		b.state = boxEditing
+		return nil
 	}
 }
 
@@ -159,18 +195,29 @@ func (b PromptBox) Update(msg tea.Msg) (PromptBox, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "enter":
-			if b.state != boxBusy { // enter submits; the box is a single prompt line
+			switch b.state {
+			case boxBusy:
+				return b, nil
+			case boxProposed: // accept the proposal → hand it to the host
+				actions := b.proposed
+				b.proposed, b.state = nil, boxEditing
+				return b, func() tea.Msg { return ActionsConfirmedMsg{Actions: actions} }
+			default: // enter submits; the box is a single prompt line
 				return b, b.submit()
 			}
-			return b, nil
 		case "esc":
-			if b.state == boxBusy {
+			switch b.state {
+			case boxBusy:
 				b.stop()
 				return b, nil
+			case boxProposed: // reject the proposal, back to editing
+				b.proposed, b.state = nil, boxEditing
+				return b, nil
+			default:
+				return b, func() tea.Msg { return BoxCloseMsg{} }
 			}
-			return b, func() tea.Msg { return BoxCloseMsg{} }
 		}
-		if b.state == boxBusy { // ignore edits mid-stream
+		if b.state == boxBusy || b.state == boxProposed { // ignore edits mid-flow
 			return b, nil
 		}
 		var cmd tea.Cmd
@@ -206,6 +253,20 @@ func (b PromptBox) Update(msg tea.Msg) (PromptBox, tea.Cmd) {
 		b.vp.SetContent(b.wrapAnswer())
 		b.vp.GotoBottom()
 		return b, readToken(msg.seq, msg.ch)
+
+	case actionsReady:
+		if msg.seq != b.seq {
+			return b, nil // stale
+		}
+		switch {
+		case msg.err != nil:
+			b.state, b.err = boxDone, msg.err
+		case len(msg.actions) == 0:
+			b.state, b.err = boxDone, errNoChanges
+		default:
+			b.proposed, b.state = msg.actions, boxProposed
+		}
+		return b, nil
 	}
 
 	// Everything else (mouse, etc.) goes to whichever pane is live.
@@ -245,6 +306,13 @@ func (b PromptBox) View() string {
 		} else {
 			parts = append(parts, b.vp.View())
 		}
+	case boxProposed:
+		lines := []string{StHead.Render("proposed changes")}
+		for _, a := range b.proposed {
+			lines = append(lines, "  "+a.Key+" → "+StWarn.Render(a.Value))
+		}
+		lines = append(lines, StDim.Render("enter apply · esc cancel"))
+		parts = append(parts, strings.Join(lines, "\n"))
 	}
 
 	body := lipgloss.JoinVertical(lipgloss.Left, parts...)

--- a/pkgs/cli-kit/promptbox_test.go
+++ b/pkgs/cli-kit/promptbox_test.go
@@ -119,3 +119,71 @@ func TestHostMountsBoxForAskable(t *testing.T) {
 		t.Error("bare app should not get a prompt box")
 	}
 }
+
+// stubCommander proposes a fixed action set.
+type stubCommander struct{ actions []Action }
+
+func (s stubCommander) Actions(ctx context.Context, prompt string) ([]Action, error) {
+	return s.actions, nil
+}
+
+type commandableApp struct{ tea.Model }
+
+func (commandableApp) Commander() Commander { return stubCommander{} }
+
+func TestHostMountsBoxForCommandable(t *testing.T) {
+	if h := newHost(commandableApp{}); !h.hasBox {
+		t.Error("Commandable app should get a prompt box")
+	}
+}
+
+func TestPromptBoxActProposeThenConfirm(t *testing.T) {
+	want := []Action{{"model", "fast"}, {"thinking", "high"}}
+	b := NewPromptBox()
+	b.SetCommander(stubCommander{actions: want})
+	b.SetSize(60, 20)
+	b.ta.SetValue("quick but precise")
+
+	// Submit → the Commander proposes → box enters the proposed state.
+	b, cmd := b.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	b = follow(b, cmd)
+	if b.state != boxProposed {
+		t.Fatalf("expected boxProposed after Commander returns, got %d", b.state)
+	}
+	if !strings.Contains(b.View(), "proposed changes") || !strings.Contains(b.View(), "fast") {
+		t.Errorf("proposed view should list the actions, got:\n%s", b.View())
+	}
+
+	// Enter accepts → emits ActionsConfirmedMsg with the proposal, box back to editing.
+	b, cmd = b.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if b.state != boxEditing {
+		t.Errorf("after accept, expected boxEditing, got %d", b.state)
+	}
+	if cmd == nil {
+		t.Fatal("accept should emit a Cmd")
+	}
+	msg, ok := cmd().(ActionsConfirmedMsg)
+	if !ok {
+		t.Fatalf("accept should emit ActionsConfirmedMsg, got %T", cmd())
+	}
+	if len(msg.Actions) != 2 || msg.Actions[0] != want[0] {
+		t.Errorf("confirmed actions = %v, want %v", msg.Actions, want)
+	}
+}
+
+func TestPromptBoxActEscRejects(t *testing.T) {
+	b := NewPromptBox()
+	b.SetCommander(stubCommander{actions: []Action{{"model", "fast"}}})
+	b.SetSize(60, 20)
+	b.ta.SetValue("x")
+
+	b, cmd := b.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	b = follow(b, cmd)
+	if b.state != boxProposed {
+		t.Fatalf("expected boxProposed, got %d", b.state)
+	}
+	b, _ = b.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if b.state != boxEditing || b.proposed != nil {
+		t.Errorf("esc should reject the proposal and clear it; state=%d proposed=%v", b.state, b.proposed)
+	}
+}

--- a/pkgs/cli-kit/run.go
+++ b/pkgs/cli-kit/run.go
@@ -56,10 +56,17 @@ type host struct {
 
 func newHost(app App) host {
 	h := host{app: app, toggleKey: "ctrl+o"}
-	if a, ok := app.(Askable); ok {
+	askable, isAsk := app.(Askable)
+	commandable, isCmd := app.(Commandable)
+	if isAsk || isCmd {
 		h.box = NewPromptBox()
-		h.box.SetAsker(a.Asker())
 		h.hasBox = true
+		if isAsk {
+			h.box.SetAsker(askable.Asker())
+		}
+		if isCmd { // Act mode takes precedence when both are present
+			h.box.SetCommander(commandable.Commander())
+		}
 	}
 	return h
 }
@@ -86,6 +93,14 @@ func (h host) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case BoxCloseMsg:
 		h.active = false
 		return h, nil
+
+	case ActionsConfirmedMsg:
+		// The user accepted an Act-mode proposal; hide the box and let the app
+		// apply the actions (it owns the state the actions mutate).
+		h.active = false
+		var cmd tea.Cmd
+		h.app, cmd = h.app.Update(msg)
+		return h, cmd
 
 	case tea.KeyMsg:
 		if h.hasBox && !h.active && msg.String() == h.toggleKey {

--- a/pkgs/code-tui/default.nix
+++ b/pkgs/code-tui/default.nix
@@ -15,7 +15,9 @@ buildGoModule {
   modRoot = "code-tui";
   # cli-kit is a local `replace` whose source lives in this build's src (above),
   # so any change to pkgs/cli-kit/*.go shifts this hash — bump it on cli-kit edits.
-  vendorHash = "sha256-Kw9KeayOAbWlOQxVszD5W/qzaI0qbF6L+h4zVjONbOg=";
+  # A plain build can reuse a cached FOD and hide the change; get the true value
+  # from a fake-hash build (set to sha256-AAA…, read the reported `got:`) or CI.
+  vendorHash = "sha256-5ln5X/XTjhuaeUwzKvgFVBk3MXFE2qp4VM0kxmmaO2E=";
 
   # The launcher picker is invoked as `code`.
   postInstall = ''


### PR DESCRIPTION
Adds **Act mode** to the PromptBox and documents the consumer contract, closing **#120**. This is the cli-kit half of the headline feature (#116, code prompt→profile).

## Act mode
- A `Commandable` host's `Commander.Actions(ctx, prompt)` is called on submit; the proposed `Action{Key,Value}` set is shown for confirmation (`proposed changes / enter apply · esc cancel`).
- **enter** accepts → the box emits `ActionsConfirmedMsg`, which `Run` forwards to the app's `Update` so it applies the actions through **its own code path** (for `code`: onto `m.sel`, exactly as a manual facet change). **esc** rejects.
- `Run` detects `Commandable` and mounts the box in Act mode (takes precedence over Ask when both are implemented).

## Contract README
`pkgs/cli-kit/README.md` — the capability-interface table, `clikit.Run`, Ask/Act flows, and the `OmpAsker` backend, with a minimal consumer example. The reference guide a new tool follows (closes #120).

## Tests
- Commandable capability detection; propose→confirm emits the exact actions and returns to editing; esc rejects and clears the proposal. Full cli-kit suite green in `nix build .#cli-kit` checkPhase; gofmt-clean.

## Note
Bumps `code-tui`'s `vendorHash` (cli-kit source is vendored into code-tui's build). Added a comment there documenting the coupling + how to get the value (a plain build can reuse a cached FOD and hide the change).

Refs #115, #116. Closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)