### PR TITLE
feat(code): prompt→profile suggestion via the cli-kit PromptBox (closes #116)

### DIFF
--- a/pkgs/cli-kit/README.md
+++ b/pkgs/cli-kit/README.md
@@ -38,7 +38,7 @@ type helpApp struct{ /* your tea.Model */ }
 func (helpApp) Asker() clikit.Asker { return clikit.NewOmpAsker(myDocs) }
 func (helpApp) Docs() clikit.DocCorpus { return myDocs }
 
-func main() { _ = clikit.Run(helpApp{...}, clikit.WithAltScreen()) }
+func main() { _, _ = clikit.Run(helpApp{...}, clikit.WithAltScreen()) }
 ```
 
 `NewOmpAsker` shells out to a headless omp run

--- a/pkgs/cli-kit/ompasker_test.go
+++ b/pkgs/cli-kit/ompasker_test.go
@@ -97,5 +97,8 @@ func TestHelperProcess(t *testing.T) {
 		fmt.Print("first chunk")
 		time.Sleep(30 * time.Second) // killed by the context long before this
 		os.Exit(0)
+	case "json":
+		fmt.Print(`{"model": "fast", "thinking": "high"}`)
+		os.Exit(0)
 	}
 }

--- a/pkgs/cli-kit/ompcommander.go
+++ b/pkgs/cli-kit/ompcommander.go
@@ -1,0 +1,98 @@
+package clikit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sort"
+)
+
+// OmpCommander is the Act backend: it runs a headless omp turn whose system
+// prompt (Docs) instructs the model to reply with a JSON object of the changes to
+// make, then parses that object into a sorted, deterministic Action set. Like
+// OmpAsker it depends only on os/exec and cancels via the context.
+type OmpCommander struct {
+	Bin   string    // omp binary; defaults to "omp"
+	Model string    // evaluator model; defaults to DefaultEvaluatorModel
+	Docs  DocCorpus // system prompt describing the options and demanding a JSON reply
+}
+
+// NewOmpCommander builds an OmpCommander with the default binary and evaluator.
+// Docs must instruct the model to answer with a JSON object (see the host's
+// action schema).
+func NewOmpCommander(docs DocCorpus) OmpCommander {
+	return OmpCommander{Bin: "omp", Model: DefaultEvaluatorModel, Docs: docs}
+}
+
+// execCommandContext is indirected so tests can substitute a stand-in for omp.
+var execCommandContext = exec.CommandContext
+
+// Actions runs omp and parses its JSON reply into proposed changes.
+func (o OmpCommander) Actions(ctx context.Context, prompt string) ([]Action, error) {
+	bin := o.Bin
+	if bin == "" {
+		bin = "omp"
+	}
+	model := o.Model
+	if model == "" {
+		model = DefaultEvaluatorModel
+	}
+	out, err := execCommandContext(ctx, bin, ompArgs(model, o.Docs, prompt)...).Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseActions(out)
+}
+
+// parseActions extracts the JSON object from a model's output (tolerating any
+// surrounding prose) and turns it into a key-sorted Action set — sorted so the
+// proposal is deterministic regardless of JSON/map ordering.
+func parseActions(out []byte) ([]Action, error) {
+	obj := extractJSONObject(out)
+	if obj == "" {
+		return nil, fmt.Errorf("no JSON object in model output")
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(obj), &m); err != nil {
+		return nil, fmt.Errorf("parsing proposal: %w", err)
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	actions := make([]Action, 0, len(keys))
+	for _, k := range keys {
+		actions = append(actions, Action{Key: k, Value: valueToString(m[k])})
+	}
+	return actions, nil
+}
+
+// extractJSONObject returns the substring from the first '{' to the last '}',
+// letting the model wrap its JSON in prose without breaking the parse.
+func extractJSONObject(b []byte) string {
+	i := bytes.IndexByte(b, '{')
+	j := bytes.LastIndexByte(b, '}')
+	if i < 0 || j < i {
+		return ""
+	}
+	return string(b[i : j+1])
+}
+
+// valueToString normalises a JSON value to a facet-style string (booleans become
+// on/off, matching how the toggles are spelled).
+func valueToString(v any) string {
+	switch x := v.(type) {
+	case bool:
+		if x {
+			return "on"
+		}
+		return "off"
+	case string:
+		return x
+	default:
+		return fmt.Sprintf("%v", x)
+	}
+}

--- a/pkgs/cli-kit/ompcommander_test.go
+++ b/pkgs/cli-kit/ompcommander_test.go
@@ -1,0 +1,63 @@
+package clikit
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestParseActions(t *testing.T) {
+	// Clean JSON, sorted deterministically, booleans normalised to on/off.
+	got, err := parseActions([]byte(`{"model":"fast","spark":true,"fable":false}`))
+	if err != nil {
+		t.Fatalf("parseActions: %v", err)
+	}
+	want := []Action{{"fable", "off"}, {"model", "fast"}, {"spark", "on"}}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("action %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseActionsEmbeddedInProse(t *testing.T) {
+	out := []byte("Sure! Here's my suggestion:\n{\"thinking\": \"high\"}\nHope that helps.")
+	got, err := parseActions(out)
+	if err != nil {
+		t.Fatalf("parseActions: %v", err)
+	}
+	if len(got) != 1 || got[0] != (Action{"thinking", "high"}) {
+		t.Errorf("got %v, want [{thinking high}]", got)
+	}
+}
+
+func TestParseActionsNoJSON(t *testing.T) {
+	if _, err := parseActions([]byte("I cannot help with that.")); err == nil {
+		t.Error("expected an error when there is no JSON object")
+	}
+}
+
+func TestOmpCommanderActions(t *testing.T) {
+	o := OmpCommander{Bin: os.Args[0]}
+	// Point Bin at the helper, but Actions builds its own args; the helper ignores
+	// them and prints a fixed JSON object.
+	orig := execCommandContext
+	execCommandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		c := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
+		c.Env = append(os.Environ(), "GO_HELPER=json")
+		return c
+	}
+	defer func() { execCommandContext = orig }()
+
+	got, err := o.Actions(context.Background(), "quick but precise")
+	if err != nil {
+		t.Fatalf("Actions: %v", err)
+	}
+	if len(got) != 2 || got[0] != (Action{"model", "fast"}) || got[1] != (Action{"thinking", "high"}) {
+		t.Errorf("Actions = %v, want [{model fast} {thinking high}]", got)
+	}
+}

--- a/pkgs/cli-kit/promptbox.go
+++ b/pkgs/cli-kit/promptbox.go
@@ -61,8 +61,13 @@ type actionsReady struct {
 type BoxCloseMsg struct{}
 
 // ActionsConfirmedMsg is emitted when the user accepts a Commander's proposal.
-// The host (see Run, which forwards it to the app) applies the actions.
-type ActionsConfirmedMsg struct{ Actions []Action }
+// The host (see Run, which forwards it to the app) applies the actions. Prompt is
+// the text the user submitted, so a host can carry it forward (e.g. as the first
+// message of the session it launches).
+type ActionsConfirmedMsg struct {
+	Actions []Action
+	Prompt  string
+}
 
 // PromptBox is a value type — Update returns an updated copy, matching the
 // bubbles convention.
@@ -76,6 +81,7 @@ type PromptBox struct {
 	w, h     int
 	state    boxState
 	answer   string
+	prompt   string   // the submitted prompt (carried into ActionsConfirmedMsg)
 	proposed []Action // Act mode: the actions awaiting confirmation
 	err      error
 
@@ -151,6 +157,7 @@ func (b *PromptBox) submit() tea.Cmd {
 	}
 	b.state = boxBusy
 	b.answer, b.err, b.proposed = "", nil, nil
+	b.prompt = prompt
 	b.seq++
 	seq := b.seq
 	ctx, cancel := context.WithCancel(context.Background())
@@ -199,9 +206,9 @@ func (b PromptBox) Update(msg tea.Msg) (PromptBox, tea.Cmd) {
 			case boxBusy:
 				return b, nil
 			case boxProposed: // accept the proposal → hand it to the host
-				actions := b.proposed
+				actions, prompt := b.proposed, b.prompt
 				b.proposed, b.state = nil, boxEditing
-				return b, func() tea.Msg { return ActionsConfirmedMsg{Actions: actions} }
+				return b, func() tea.Msg { return ActionsConfirmedMsg{Actions: actions, Prompt: prompt} }
 			default: // enter submits; the box is a single prompt line
 				return b, b.submit()
 			}

--- a/pkgs/cli-kit/promptbox_test.go
+++ b/pkgs/cli-kit/promptbox_test.go
@@ -169,6 +169,9 @@ func TestPromptBoxActProposeThenConfirm(t *testing.T) {
 	if len(msg.Actions) != 2 || msg.Actions[0] != want[0] {
 		t.Errorf("confirmed actions = %v, want %v", msg.Actions, want)
 	}
+	if msg.Prompt != "quick but precise" {
+		t.Errorf("confirmed prompt = %q, want the submitted text", msg.Prompt)
+	}
 }
 
 func TestPromptBoxActEscRejects(t *testing.T) {

--- a/pkgs/cli-kit/run.go
+++ b/pkgs/cli-kit/run.go
@@ -25,11 +25,16 @@ func WithAltScreen() RunOption {
 	return func(h *host) { h.altScreen = true }
 }
 
-// Run starts app under a cli-kit host that auto-mounts capabilities. If app is
-// Askable, a prompt box (Ask mode) is available via the toggle key; if it is also
-// Documented, that grounding is available to the backend; Commandable is detected
-// and reserved for Act mode. An app that implements none simply runs as-is.
-func Run(app App, opts ...RunOption) error {
+// WithMouseCellMotion enables cell-motion mouse reporting (e.g. wheel scroll).
+func WithMouseCellMotion() RunOption {
+	return func(h *host) { h.mouse = true }
+}
+
+// Run starts app under a cli-kit host that auto-mounts capabilities: Askable gets
+// a prompt box in Ask mode, Commandable in Act mode (precedence), Documented
+// grounds the backend; an app implementing none simply runs as-is. It returns the
+// app's final model (unwrapped from the host) so callers can read end state.
+func Run(app App, opts ...RunOption) (tea.Model, error) {
 	h := newHost(app)
 	for _, o := range opts {
 		o(&h)
@@ -38,8 +43,14 @@ func Run(app App, opts ...RunOption) error {
 	if h.altScreen {
 		teaOpts = append(teaOpts, tea.WithAltScreen())
 	}
-	_, err := tea.NewProgram(h, teaOpts...).Run()
-	return err
+	if h.mouse {
+		teaOpts = append(teaOpts, tea.WithMouseCellMotion())
+	}
+	final, err := tea.NewProgram(h, teaOpts...).Run()
+	if fh, ok := final.(host); ok {
+		return fh.app, err
+	}
+	return nil, err
 }
 
 // host wraps a consumer App, overlaying the prompt box when active and routing
@@ -51,6 +62,7 @@ type host struct {
 	active    bool
 	toggleKey string
 	altScreen bool
+	mouse     bool
 	w, h      int
 }
 

--- a/pkgs/code-tui/default.nix
+++ b/pkgs/code-tui/default.nix
@@ -17,7 +17,7 @@ buildGoModule {
   # so any change to pkgs/cli-kit/*.go shifts this hash — bump it on cli-kit edits.
   # A plain build can reuse a cached FOD and hide the change; get the true value
   # from a fake-hash build (set to sha256-AAA…, read the reported `got:`) or CI.
-  vendorHash = "sha256-5ln5X/XTjhuaeUwzKvgFVBk3MXFE2qp4VM0kxmmaO2E=";
+  vendorHash = "sha256-pzJPBXj5rRV4nssiD2NeGUFuCM9brFdNo6x3Zfe7DCE=";
 
   # The launcher picker is invoked as `code`.
   postInstall = ''

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -1098,8 +1098,9 @@ type model struct {
 	fetching    bool      // a usage fetch is in flight (manual or auto)
 	nextRefresh time.Time // when the next auto-refresh fires
 
-	chosen    string
-	genConfig string // generated config YAML to launch omp with (generator Enter)
+	chosen      string
+	genConfig   string // generated config YAML to launch omp with (generator Enter)
+	firstPrompt string // prompt from the suggest box, forwarded as omp's first message
 }
 
 // usage auto-refreshes on this cadence; a 1s tick drives the countdown.
@@ -1481,6 +1482,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.MouseButtonWheelDown:
 			m.vp.LineDown(3)
 		}
+
+	case clikit.ActionsConfirmedMsg:
+		// The suggest box proposed facet changes and the user accepted them:
+		// apply to the generator selection (same as a manual change) and remember
+		// the prompt so the launched session receives it as the first message.
+		m.view = genView
+		m.applyActions(msg.Actions)
+		m.firstPrompt = msg.Prompt
 	}
 	return m, nil
 }
@@ -1769,7 +1778,7 @@ func main() {
 		facets:    facetDefs(glyphs),
 		sel:       defaultSel(),
 	}
-	final, err := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion()).Run()
+	final, err := clikit.Run(m, clikit.WithAltScreen(), clikit.WithMouseCellMotion())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "code:", err)
 		os.Exit(1)
@@ -1783,7 +1792,7 @@ func main() {
 		}
 	}
 	if fm.genConfig != "" {
-		launchGenerated(fm.genConfig)
+		launchGenerated(fm.genConfig, fm.firstPrompt)
 	}
 }
 
@@ -1792,7 +1801,7 @@ func main() {
 // supplies the platform extensions, managed defaults, and policy (and caps the
 // overlay), so we must NOT re-layer defaults/policy here — doing so both
 // double-applies them and breaks when their paths aren't valid from the cwd.
-func launchGenerated(cfg string) {
+func launchGenerated(cfg, prompt string) {
 	tmp, err := os.CreateTemp("", "code-gen-*.yml")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "code:", err)
@@ -1810,6 +1819,9 @@ func launchGenerated(cfg string) {
 		os.Exit(1)
 	}
 	args := append([]string{path, "--config", tmp.Name()}, os.Args[1:]...)
+	if prompt != "" { // forward the suggest-box prompt as omp's first message
+		args = append(args, prompt)
+	}
 	if err := syscall.Exec(path, args, os.Environ()); err != nil {
 		fmt.Fprintln(os.Stderr, "code: exec:", err)
 		os.Exit(1)

--- a/pkgs/code-tui/suggest.go
+++ b/pkgs/code-tui/suggest.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	clikit "cli-kit"
+)
+
+// facetGuide is a one-line hint per facet, grounding the evaluator so it picks
+// sensibly (the facet values themselves come from facetDefs).
+var facetGuide = map[string]string{
+	"lane":     "which model pools to draw from",
+	"model":    "speed/quality tier — fast is cheap, smart is strongest",
+	"thinking": "reasoning depth, minimal→max",
+	"advisor":  "a peer-reviewer each turn: off, a quick glance, a review, or a deep (expensive) audit",
+	"spark":    "use the fast idle-bucket coder for background/execution work",
+	"fable":    "allow the scarce elite Fable lead",
+	"fast":     "force the fast execution model",
+}
+
+// actDocs builds the Act-mode system prompt: the option schema (from the facets)
+// plus a demand for a JSON-only reply of the options to change.
+func actDocs(facets []facet) clikit.DocCorpus {
+	var b strings.Builder
+	b.WriteString("You set up a terminal coding-agent session by choosing options. ")
+	b.WriteString("Given the user's task, choose the best-fitting options.\n\nOptions:\n")
+	for _, f := range facets {
+		b.WriteString(fmt.Sprintf("- %s: one of [%s] — %s\n",
+			f.key, strings.Join(f.values, ", "), facetGuide[f.key]))
+	}
+	b.WriteString("\nReply with ONLY a JSON object mapping the options you want to CHANGE " +
+		"to their chosen values (omit options left at default). No prose, no code fence. " +
+		"Example: {\"model\":\"fast\",\"thinking\":\"high\"}")
+	return clikit.DocCorpus(b.String())
+}
+
+// Commander implements clikit.Commandable: a cheap omp-backed evaluator that
+// proposes facet changes for the user's task. It uses bare omp (CODE_OMP_EVAL)
+// with an explicit lightweight model, not the managed launcher.
+func (m model) Commander() clikit.Commander {
+	c := clikit.NewOmpCommander(actDocs(m.facets))
+	if bin := os.Getenv("CODE_OMP_EVAL"); bin != "" {
+		c.Bin = bin
+	}
+	return c
+}
+
+// validFacetActions keeps only the actions that name a real facet with a value
+// that facet offers — the whitelist that makes an agent proposal no more powerful
+// than a manual change.
+func validFacetActions(facets []facet, actions []clikit.Action) []clikit.Action {
+	valid := map[string]map[string]bool{}
+	for _, f := range facets {
+		vs := map[string]bool{}
+		for _, v := range f.values {
+			vs[v] = true
+		}
+		valid[f.key] = vs
+	}
+	var out []clikit.Action
+	for _, a := range actions {
+		if vs, ok := valid[a.Key]; ok && vs[a.Value] {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// applyActions applies a confirmed proposal: each valid facet=value updates the
+// selection, exactly as a manual change would, then the preview refreshes.
+func (m *model) applyActions(actions []clikit.Action) {
+	for _, a := range validFacetActions(m.facets, actions) {
+		m.sel[a.Key] = a.Value
+	}
+	m.syncPreview()
+}

--- a/pkgs/code-tui/suggest_test.go
+++ b/pkgs/code-tui/suggest_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	clikit "cli-kit"
+)
+
+func TestValidFacetActions(t *testing.T) {
+	facets := facetDefs(map[string]string{})
+	in := []clikit.Action{
+		{"model", "fast"},    // valid
+		{"thinking", "high"}, // valid
+		{"lane", "purple"},   // invalid value → dropped
+		{"nonsense", "x"},    // unknown facet → dropped
+		{"spark", "on"},      // valid
+	}
+	got := validFacetActions(facets, in)
+	want := []clikit.Action{{"model", "fast"}, {"thinking", "high"}, {"spark", "on"}}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("action %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestActDocsSchema(t *testing.T) {
+	docs := string(actDocs(facetDefs(map[string]string{})))
+	// Every facet key and the JSON-only instruction must be present.
+	for _, key := range []string{"lane", "model", "thinking", "advisor", "spark", "fable", "fast"} {
+		if !strings.Contains(docs, key) {
+			t.Errorf("actDocs missing facet %q", key)
+		}
+	}
+	if !strings.Contains(docs, "JSON") {
+		t.Errorf("actDocs must instruct a JSON reply")
+	}
+	// A representative value should be enumerated.
+	if !strings.Contains(docs, "smart") {
+		t.Errorf("actDocs should enumerate facet values (e.g. model=smart)")
+	}
+}

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1485,6 +1485,9 @@ let
       export CODE_GENERATED=${generatedProfiles}/share/omp/generated.plain
       export CODE_OMP=${lib.getExe ompManaged}
       export CODE_USAGE="$omp_bin usage --json"
+      # Bare omp for the picker's prompt→profile evaluator (a cheap one-shot with an
+      # explicit --model): the managed launcher (CODE_OMP) would override the model.
+      export CODE_OMP_EVAL="$omp_bin"
 
       names=( ${lib.escapeShellArgs (map (p: p.cmd) paletteProfiles)} )
       exes=( ${lib.escapeShellArgs (map (p: p.exe) paletteProfiles)} )


### PR DESCRIPTION
The headline feature: press **ctrl+o** in `code`, describe your task, and an omp evaluator proposes the best-fitting generator facets. Accept to apply them onto the generator — and the launched session receives your prompt as its **first message** — or tune further before launching. Closes **#116** (both halves: suggest→apply *and* prompt-forwarding).

## cli-kit (API evolutions validated against this first real consumer)
- `Run` now returns the app's final model (unwrapped from the host) so `code` can read `fm.chosen`/`fm.genConfig`; adds `WithMouseCellMotion`.
- **`OmpCommander`** — the Act backend: runs a headless omp turn, collects the JSON reply, parses it into a key-sorted `Action` set. `parseActions` is pure/tested — tolerates prose around the JSON and normalises bools to `on`/`off`.
- `ActionsConfirmedMsg` now carries the submitted `Prompt`.

## code
- `Commander()` grounds a cheap evaluator (bare omp via `CODE_OMP_EVAL`, `claude-haiku-4-5`) with a schema built from the facets + a JSON-only instruction. On accept, `validFacetActions` whitelists the proposal (unknown keys/values dropped) and applies it to `m.sel` through the **same path as a manual change**; the prompt is forwarded to the launched session.
- Launches via `clikit.Run` so the box mounts — **opt-in on ctrl+o; the normal picker/generator/launch paths are unchanged**.
- `omp-configured` exports `CODE_OMP_EVAL` (bare omp) so the evaluator keeps its explicit `--model` instead of the managed launcher's routing.

## Verification
- **Tests:** cli-kit + code-tui green — `parseActions` (clean/embedded/none), `OmpCommander` via a helper-process omp stand-in, `validFacetActions` (drops bad keys/values), `actDocs` schema.
- **Builds:** `.#cli-kit`, `.#code-tui`, `.#omp-configured` all green; code-tui vendorHash bumped (cli-kit source is vendored in).
- **tmux:** normal `code` unchanged; ctrl+o opens the docked box; typing + submit streams "thinking".

## Needs your auth (the one thing I can't verify)
The sandbox has no omp auth, so I can't see whether the **suggestions are actually good** — the model call errors here. On your authed machine it runs end-to-end. That's the piece to eyeball: does the evaluator pick sensible facets, and is the box's look/placement right for you?

Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)