### PR TITLE
feat(atyrode): show progress during clean's garbage collection

### DIFF
--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -411,5 +411,24 @@ pkgs.runCommand "check-atyrode-cli"
     grep -F '"$test_hooks" == 1 && -n "''${ATYRODE_NH:-}"' \
       ${../pkgs/atyrode/atyrode} >/dev/null
 
+    # clean splits the GC out of nh (--no-gc) and runs it itself so the slow
+    # phase can show progress; a stub stands in for the real collector.
+    cat > "$TMPDIR/bin/fake-gc" <<'EOF'
+    #!${pkgs.runtimeShell}
+    printf '%s\n' "$*" > "$TMPDIR/gc-args"
+    EOF
+    chmod +x "$TMPDIR/bin/fake-gc"
+    export ATYRODE_NIX_STORE="$TMPDIR/bin/fake-gc"
+    atyrode clean --keep 3 >/dev/null 2>&1
+    grep -F -- '--no-gc' "$TMPDIR/nh-args" >/dev/null \
+      || { echo 'clean must pass --no-gc to nh' >&2; exit 1; }
+    grep -F -- '--gc' "$TMPDIR/gc-args" >/dev/null \
+      || { echo 'clean must run the garbage collector' >&2; exit 1; }
+    rm -f "$TMPDIR/gc-args"
+    atyrode clean -n >/dev/null 2>&1
+    test ! -e "$TMPDIR/gc-args" \
+      || { echo 'dry-run clean must not collect garbage' >&2; exit 1; }
+    unset ATYRODE_NIX_STORE
+
     mkdir "$out"
   ''

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -875,6 +875,45 @@ clean_macos_residue() {
   printf '  app-owned, not Nix-managed, so a dropped app leaves it behind; remove by hand.\n' >&2
 }
 
+# collect_garbage runs the store GC that `nh clean --no-gc` deliberately skips.
+# nh runs it silently, so the last step of a clean looks frozen for however long
+# the daemon takes (often minutes). Here we own that phase: a spinner on a
+# terminal shows it is alive, and non-interactively the collector's native output
+# streams through. In test builds it is a no-op unless ATYRODE_NIX_STORE provides
+# a stand-in, so the suite never touches the real store.
+collect_garbage() {
+  local -a gc=(nix-store --gc)
+  if [[ "$test_hooks" == 1 ]]; then
+    [[ -n "${ATYRODE_NIX_STORE:-}" ]] || return 0
+    gc=("$ATYRODE_NIX_STORE" --gc)
+  fi
+
+  if [[ ! -t 2 ]]; then # non-interactive: stream the collector's own output
+    printf 'atyrode: collecting garbage…\n' >&2
+    "${gc[@]}" >&2 || printf 'atyrode: garbage collection reported an error\n' >&2
+    return 0
+  fi
+
+  local out pid rc=0 i=0
+  local -a frames=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)
+  out="$(mktemp)"
+  "${gc[@]}" >"$out" 2>&1 &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    printf '\r  %s collecting garbage…' "${frames[$((i++ % ${#frames[@]}))]}" >&2
+    sleep 0.1
+  done
+  wait "$pid" || rc=$?
+  printf '\r\033[K' >&2
+  if [[ "$rc" == 0 ]]; then
+    printf 'atyrode: %s\n' "$(grep -iE 'freed|deleted' "$out" | tail -n1 || echo 'store collected')" >&2
+  else
+    cat "$out" >&2
+    printf 'atyrode: garbage collection failed\n' >&2
+  fi
+  rm -f "$out"
+}
+
 # clean — reclaim disk from generations the config no longer references, always
 # keeping the current generation and a rollback window (never an auto-wipe of the
 # safety net). Also sweeps stale macOS app aliases (see clean_macos_residue).
@@ -897,9 +936,14 @@ cmd_clean() {
   [[ "$test_hooks" != 1 || -z "${ATYRODE_NH:-}" ]] || nh_command="$ATYRODE_NH"
 
   printf 'atyrode: reclaiming the Nix store (keeping %s generation(s) + everything newer than %s)\n' "$keep" "$keep_since" >&2
-  local nh_args=("$nh_command" clean "$scope" --keep "$keep" --keep-since "$keep_since")
+  # Let nh remove the stale generations and gcroots, but skip its garbage
+  # collection (--no-gc) — nh runs it silently. We collect below instead, with a
+  # progress indicator, so the slow final step isn't an unexplained freeze.
+  local nh_args=("$nh_command" clean "$scope" --keep "$keep" --keep-since "$keep_since" --no-gc)
   [[ "$dry" == 0 ]] || nh_args+=(--dry)
   "${nh_args[@]}" || die "$EX_SOFTWARE" "nh clean failed"
+
+  [[ "$dry" == 1 ]] || collect_garbage
 
   if [[ "$(uname -s)" == Darwin ]]; then
     clean_macos_residue "$dry" "$assume_yes"


### PR DESCRIPTION
## The problem (you reported it)
`atyrode clean`'s last step — "Performing garbage collection on the nix store" — hands off to the nix daemon and goes **silent** for however long the collection takes (often minutes), with a frozen cursor. No way to tell "working" from "crashed."

That line and the silence are **nh's** — `atyrode clean` shelled out to `nh clean`, and nh swallows nix's native GC progress.

## The fix
Take ownership of that phase. `nh clean user --help` has a **`--no-gc`** flag, so:
- Pass `--no-gc` to nh — it still does the fast part (removing stale generations + gcroots, with its normal output), just skips the silent GC.
- Run the collection ourselves via `nix-store --gc`, wrapped in a **spinner** on a terminal (`⠋ collecting garbage…`), or streaming the collector's native output when not interactive. Either way the final `freed/deleted` summary is surfaced.

So the slow step now visibly shows it's alive.

## Safety + tests
- The GC is gated on `test_hooks` — in test builds it's a **no-op unless `ATYRODE_NIX_STORE`** provides a stand-in, so the suite never touches the real store.
- New coverage in `checks/atyrode-cli.nix`: `atyrode clean` passes `--no-gc` to nh **and** runs the collector; a dry-run does **neither**. The `atyrode-cli` check passes.
- Verified `--no-gc` is valid for both `user` and `all` scopes; the spinner branch's logic (braille array, `wait || rc`, summary extraction) is clean under `set -euo pipefail`; shellcheck passes.

## Note (separate from this PR)
The earlier `Permission denied` flood on `/nix/var/nix/gcroots/auto/*` is a *different*, cosmetic thing (user-mode nh can't unlink root-owned auto gcroots — several of which were my build litter, now cleared). This PR is purely about the silent-GC UX. Happy to tackle the gcroot noise separately if it bugs you (e.g. demote those lines to a one-line "N root-owned roots skipped").

🤖 Generated with [Claude Code](https://claude.com/claude-code)