### PR TITLE
feat(code): faster, streamed, labelled prompt→profile suggestions

### DIFF
--- a/pkgs/cli-kit/contract.go
+++ b/pkgs/cli-kit/contract.go
@@ -26,11 +26,13 @@ type Action struct {
 	Value string
 }
 
-// Commander turns a prompt into a closed set of typed actions the host validates
-// and applies (through the same code path as a manual change), then previews as a
-// diff before confirming. Cancelling ctx stops the work.
+// Commander proposes changes for a prompt in two parts so the box can show the
+// model working: Propose streams the model's raw output (rationale + result) for
+// live display, and Parse turns the completed output into a closed set of typed
+// actions the host validates and applies. Cancelling ctx stops the work.
 type Commander interface {
-	Actions(ctx context.Context, prompt string) ([]Action, error)
+	Propose(ctx context.Context, prompt string) (<-chan string, error)
+	Parse(output string) ([]Action, error)
 }
 
 // DocCorpus is grounding text a Documented host exposes; a real Asker backend

--- a/pkgs/cli-kit/ompasker.go
+++ b/pkgs/cli-kit/ompasker.go
@@ -27,16 +27,26 @@ func NewOmpAsker(docs DocCorpus) OmpAsker {
 	return OmpAsker{Bin: "omp", Model: DefaultEvaluatorModel, Docs: docs}
 }
 
-// ompArgs assembles the headless, read-only invocation: process one prompt and
-// exit (-p), plain streamed text, no session, no tools, grounded by the docs.
-// Kept pure so the exact command line is unit-testable.
-func ompArgs(model string, docs DocCorpus, prompt string) []string {
+// ompArgs assembles the headless invocation: process one prompt and exit (-p),
+// plain streamed text, no session, no tools. thinking (if set) pins the reasoning
+// level. When replaceSystem is true the docs REPLACE omp's default coding-agent
+// system prompt (--system-prompt) — the right choice for a classifier/evaluator,
+// which should follow the instructions verbatim rather than act like a coder;
+// otherwise they are appended. Kept pure so the command line is unit-testable.
+func ompArgs(model, thinking string, replaceSystem bool, docs DocCorpus, prompt string) []string {
 	args := []string{"-p", "--mode", "text", "--no-session", "--no-tools"}
 	if model != "" {
 		args = append(args, "--model", model)
 	}
+	if thinking != "" {
+		args = append(args, "--thinking", thinking)
+	}
 	if docs != "" {
-		args = append(args, "--append-system-prompt", string(docs))
+		flag := "--append-system-prompt"
+		if replaceSystem {
+			flag = "--system-prompt"
+		}
+		args = append(args, flag, string(docs))
 	}
 	return append(args, prompt)
 }
@@ -52,7 +62,7 @@ func (o OmpAsker) Ask(ctx context.Context, prompt string) (<-chan string, error)
 	if model == "" {
 		model = DefaultEvaluatorModel
 	}
-	cmd := exec.CommandContext(ctx, bin, ompArgs(model, o.Docs, prompt)...)
+	cmd := exec.CommandContext(ctx, bin, ompArgs(model, "", false, o.Docs, prompt)...)
 	return streamCmd(ctx, cmd)
 }
 

--- a/pkgs/cli-kit/ompasker_test.go
+++ b/pkgs/cli-kit/ompasker_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestOmpArgs(t *testing.T) {
-	got := ompArgs("claude-haiku-4-5", "grounding docs", "why is the sky blue?")
+	// Ask style: append the docs, no thinking override.
+	got := ompArgs("claude-haiku-4-5", "", false, "grounding docs", "why is the sky blue?")
 	want := []string{
 		"-p", "--mode", "text", "--no-session", "--no-tools",
 		"--model", "claude-haiku-4-5",
@@ -19,14 +20,25 @@ func TestOmpArgs(t *testing.T) {
 		"why is the sky blue?",
 	}
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
-		t.Errorf("ompArgs = %v\nwant %v", got, want)
+		t.Errorf("ompArgs(ask) = %v\nwant %v", got, want)
 	}
 
-	// No model and no docs: those flags are omitted, prompt still last.
-	got = ompArgs("", "", "hi")
+	// Commander style: replace the system prompt and pin thinking.
+	got = ompArgs("gpt-5.6-luna", "off", true, "schema", "do a thing")
+	want = []string{
+		"-p", "--mode", "text", "--no-session", "--no-tools",
+		"--model", "gpt-5.6-luna", "--thinking", "off",
+		"--system-prompt", "schema", "do a thing",
+	}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Errorf("ompArgs(commander) = %v\nwant %v", got, want)
+	}
+
+	// No model/thinking/docs: those flags are omitted, prompt still last.
+	got = ompArgs("", "", false, "", "hi")
 	want = []string{"-p", "--mode", "text", "--no-session", "--no-tools", "hi"}
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
-		t.Errorf("ompArgs(no model/docs) = %v\nwant %v", got, want)
+		t.Errorf("ompArgs(bare) = %v\nwant %v", got, want)
 	}
 }
 

--- a/pkgs/cli-kit/ompcommander.go
+++ b/pkgs/cli-kit/ompcommander.go
@@ -10,27 +10,29 @@ import (
 )
 
 // OmpCommander is the Act backend: it runs a headless omp turn whose system
-// prompt (Docs) instructs the model to reply with a JSON object of the changes to
-// make, then parses that object into a sorted, deterministic Action set. Like
-// OmpAsker it depends only on os/exec and cancels via the context.
+// prompt (Docs) REPLACES omp's default agent prompt and instructs the model to
+// reply with a JSON object of the changes to make. Propose streams that output so
+// the box shows the model working; Parse turns it into a sorted, deterministic
+// Action set. Thinking defaults off — this is a fast classification, not deep
+// reasoning. Depends only on os/exec and cancels via the context.
 type OmpCommander struct {
-	Bin   string    // omp binary; defaults to "omp"
-	Model string    // evaluator model; defaults to DefaultEvaluatorModel
-	Docs  DocCorpus // system prompt describing the options and demanding a JSON reply
+	Bin      string    // omp binary; defaults to "omp"
+	Model    string    // evaluator model; defaults to DefaultEvaluatorModel
+	Thinking string    // reasoning level; defaults to "off" for speed
+	Docs     DocCorpus // system prompt: describes the options, demands a JSON reply
 }
 
-// NewOmpCommander builds an OmpCommander with the default binary and evaluator.
-// Docs must instruct the model to answer with a JSON object (see the host's
-// action schema).
+// NewOmpCommander builds an OmpCommander with the default binary, evaluator, and
+// thinking off. Docs must instruct the model to answer with a JSON object.
 func NewOmpCommander(docs DocCorpus) OmpCommander {
-	return OmpCommander{Bin: "omp", Model: DefaultEvaluatorModel, Docs: docs}
+	return OmpCommander{Bin: "omp", Model: DefaultEvaluatorModel, Thinking: "off", Docs: docs}
 }
 
 // execCommandContext is indirected so tests can substitute a stand-in for omp.
 var execCommandContext = exec.CommandContext
 
-// Actions runs omp and parses its JSON reply into proposed changes.
-func (o OmpCommander) Actions(ctx context.Context, prompt string) ([]Action, error) {
+// Propose runs omp and streams its output for live display.
+func (o OmpCommander) Propose(ctx context.Context, prompt string) (<-chan string, error) {
 	bin := o.Bin
 	if bin == "" {
 		bin = "omp"
@@ -39,11 +41,13 @@ func (o OmpCommander) Actions(ctx context.Context, prompt string) ([]Action, err
 	if model == "" {
 		model = DefaultEvaluatorModel
 	}
-	out, err := execCommandContext(ctx, bin, ompArgs(model, o.Docs, prompt)...).Output()
-	if err != nil {
-		return nil, err
-	}
-	return parseActions(out)
+	cmd := execCommandContext(ctx, bin, ompArgs(model, o.Thinking, true, o.Docs, prompt)...)
+	return streamCmd(ctx, cmd)
+}
+
+// Parse turns the model's completed output into proposed changes.
+func (o OmpCommander) Parse(output string) ([]Action, error) {
+	return parseActions([]byte(output))
 }
 
 // parseActions extracts the JSON object from a model's output (tolerating any

--- a/pkgs/cli-kit/ompcommander_test.go
+++ b/pkgs/cli-kit/ompcommander_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -41,10 +42,10 @@ func TestParseActionsNoJSON(t *testing.T) {
 	}
 }
 
-func TestOmpCommanderActions(t *testing.T) {
-	o := OmpCommander{Bin: os.Args[0]}
-	// Point Bin at the helper, but Actions builds its own args; the helper ignores
-	// them and prints a fixed JSON object.
+func TestOmpCommanderProposeParse(t *testing.T) {
+	o := OmpCommander{Bin: "x", Model: "m"}
+	// Substitute a stand-in for omp that streams a fixed JSON object; Propose
+	// builds its own args, which the helper ignores.
 	orig := execCommandContext
 	execCommandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 		c := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
@@ -53,11 +54,19 @@ func TestOmpCommanderActions(t *testing.T) {
 	}
 	defer func() { execCommandContext = orig }()
 
-	got, err := o.Actions(context.Background(), "quick but precise")
+	ch, err := o.Propose(context.Background(), "quick but precise")
 	if err != nil {
-		t.Fatalf("Actions: %v", err)
+		t.Fatalf("Propose: %v", err)
+	}
+	var out strings.Builder
+	for s := range ch {
+		out.WriteString(s)
+	}
+	got, err := o.Parse(out.String())
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
 	}
 	if len(got) != 2 || got[0] != (Action{"model", "fast"}) || got[1] != (Action{"thinking", "high"}) {
-		t.Errorf("Actions = %v, want [{model fast} {thinking high}]", got)
+		t.Errorf("proposal = %v, want [{model fast} {thinking high}]", got)
 	}
 }

--- a/pkgs/cli-kit/promptbox.go
+++ b/pkgs/cli-kit/promptbox.go
@@ -49,13 +49,6 @@ type promptToken struct {
 	ok  bool
 }
 
-// actionsReady carries a Commander's proposal back to the UI thread (Act mode).
-type actionsReady struct {
-	seq     int
-	actions []Action
-	err     error
-}
-
 // BoxCloseMsg is emitted when the user dismisses an idle box (esc while editing).
 // A host (see Run) listens for it to hide the box.
 type BoxCloseMsg struct{}
@@ -79,7 +72,9 @@ type PromptBox struct {
 	cmd   Commander
 
 	w, h     int
+	title    string // optional header (e.g. the evaluator model in use)
 	state    boxState
+	acting   bool // the current stream is an Act proposal (parse on close)
 	answer   string
 	prompt   string   // the submitted prompt (carried into ActionsConfirmedMsg)
 	proposed []Action // Act mode: the actions awaiting confirmation
@@ -110,9 +105,13 @@ func NewPromptBox() PromptBox {
 func (b *PromptBox) SetAsker(a Asker) { b.asker = a }
 
 // SetCommander wires the Act-mode backend. When set, submitting asks the
-// Commander for a proposal (shown for confirmation) instead of streaming an
-// answer; it takes precedence over an Asker.
+// Commander for a proposal (streamed live, then shown for confirmation) instead
+// of streaming a plain answer; it takes precedence over an Asker.
 func (b *PromptBox) SetCommander(c Commander) { b.cmd = c }
+
+// SetTitle sets an optional header line (e.g. "prompt → profile · gpt-5.6-luna")
+// so the user can see what the box is doing / which model it uses.
+func (b *PromptBox) SetTitle(s string) { b.title = s }
 
 // SetSize lays the box out within w×h (outer cells). A border + one column of
 // padding sit inside, so the inner widgets get w-4.
@@ -166,13 +165,15 @@ func (b *PromptBox) submit() tea.Cmd {
 	// The spinner keeps ticking on its own (see the TickMsg case); submit only
 	// kicks off the backend, in a Cmd so a slow start never blocks the UI.
 	switch {
-	case b.cmd != nil: // Act mode
+	case b.cmd != nil: // Act mode — stream the proposal, parse on close
+		b.acting = true
 		cmder := b.cmd
 		return func() tea.Msg {
-			actions, err := cmder.Actions(ctx, prompt)
-			return actionsReady{seq: seq, actions: actions, err: err}
+			ch, err := cmder.Propose(ctx, prompt)
+			return streamStarted{seq: seq, ch: ch, err: err}
 		}
 	case b.asker != nil: // Ask mode
+		b.acting = false
 		asker := b.asker
 		return func() tea.Msg {
 			ch, err := asker.Ask(ctx, prompt)
@@ -252,28 +253,26 @@ func (b PromptBox) Update(msg tea.Msg) (PromptBox, tea.Cmd) {
 		if msg.seq != b.seq {
 			return b, nil // stale (cancelled or superseded)
 		}
-		if !msg.ok {
-			b.state = boxDone
+		if !msg.ok { // stream closed
+			if b.acting && b.cmd != nil { // Act: parse the streamed output
+				actions, err := b.cmd.Parse(b.answer)
+				switch {
+				case err != nil:
+					b.state, b.err = boxDone, err
+				case len(actions) == 0:
+					b.state, b.err = boxDone, errNoChanges
+				default:
+					b.proposed, b.state = actions, boxProposed
+				}
+			} else {
+				b.state = boxDone
+			}
 			return b, nil
 		}
 		b.answer += msg.tok
 		b.vp.SetContent(b.wrapAnswer())
 		b.vp.GotoBottom()
 		return b, readToken(msg.seq, msg.ch)
-
-	case actionsReady:
-		if msg.seq != b.seq {
-			return b, nil // stale
-		}
-		switch {
-		case msg.err != nil:
-			b.state, b.err = boxDone, msg.err
-		case len(msg.actions) == 0:
-			b.state, b.err = boxDone, errNoChanges
-		default:
-			b.proposed, b.state = msg.actions, boxProposed
-		}
-		return b, nil
 	}
 
 	// Everything else (mouse, etc.) goes to whichever pane is live.
@@ -298,6 +297,9 @@ func (b PromptBox) wrapAnswer() string {
 // streamed answer, or an error.
 func (b PromptBox) View() string {
 	var parts []string
+	if b.title != "" {
+		parts = append(parts, StHead.Render(b.title))
+	}
 	parts = append(parts, b.ta.View())
 
 	switch b.state {

--- a/pkgs/cli-kit/promptbox_test.go
+++ b/pkgs/cli-kit/promptbox_test.go
@@ -120,12 +120,27 @@ func TestHostMountsBoxForAskable(t *testing.T) {
 	}
 }
 
-// stubCommander proposes a fixed action set.
-type stubCommander struct{ actions []Action }
-
-func (s stubCommander) Actions(ctx context.Context, prompt string) ([]Action, error) {
-	return s.actions, nil
+// stubCommander streams optional output and parses to a fixed action set.
+type stubCommander struct {
+	actions []Action
+	output  string
 }
+
+func (s stubCommander) Propose(ctx context.Context, prompt string) (<-chan string, error) {
+	ch := make(chan string)
+	go func() {
+		defer close(ch)
+		if s.output != "" {
+			select {
+			case ch <- s.output:
+			case <-ctx.Done():
+			}
+		}
+	}()
+	return ch, nil
+}
+
+func (s stubCommander) Parse(output string) ([]Action, error) { return s.actions, nil }
 
 type commandableApp struct{ tea.Model }
 

--- a/pkgs/cli-kit/run.go
+++ b/pkgs/cli-kit/run.go
@@ -79,6 +79,10 @@ func newHost(app App) host {
 		if isCmd { // Act mode takes precedence when both are present
 			h.box.SetCommander(commandable.Commander())
 		}
+		// Optional: let the app title the box (e.g. show the evaluator model).
+		if t, ok := app.(interface{ BoxTitle() string }); ok {
+			h.box.SetTitle(t.BoxTitle())
+		}
 	}
 	return h
 }

--- a/pkgs/code-tui/default.nix
+++ b/pkgs/code-tui/default.nix
@@ -17,7 +17,7 @@ buildGoModule {
   # so any change to pkgs/cli-kit/*.go shifts this hash — bump it on cli-kit edits.
   # A plain build can reuse a cached FOD and hide the change; get the true value
   # from a fake-hash build (set to sha256-AAA…, read the reported `got:`) or CI.
-  vendorHash = "sha256-pzJPBXj5rRV4nssiD2NeGUFuCM9brFdNo6x3Zfe7DCE=";
+  vendorHash = "sha256-hd2ETLUwygR3SRwfypxOuiG/O4DO/e6HkBz3hN2VCl8=";
 
   # The launcher picker is invoked as `code`.
   postInstall = ''

--- a/pkgs/code-tui/suggest.go
+++ b/pkgs/code-tui/suggest.go
@@ -30,10 +30,25 @@ func actDocs(facets []facet) clikit.DocCorpus {
 		b.WriteString(fmt.Sprintf("- %s: one of [%s] — %s\n",
 			f.key, strings.Join(f.values, ", "), facetGuide[f.key]))
 	}
-	b.WriteString("\nReply with ONLY a JSON object mapping the options you want to CHANGE " +
-		"to their chosen values (omit options left at default). No prose, no code fence. " +
-		"Example: {\"model\":\"fast\",\"thinking\":\"high\"}")
+	b.WriteString("\nRespond with one short sentence explaining your pick, then a JSON " +
+		"object (on its own line) mapping ONLY the options you want to CHANGE to their " +
+		"chosen values — omit options left at default, and use exactly the option names " +
+		"and values listed above. Example:\n" +
+		"Quick but precise task, so a fast model with more thinking.\n" +
+		"{\"model\":\"fast\",\"thinking\":\"high\"}")
 	return clikit.DocCorpus(b.String())
+}
+
+// defaultEvalModel is a fast, cheap evaluator (leads the speed GPT tier, lowest
+// ttft). Override with CODE_EVAL_MODEL; thinking is off by default (a quick
+// classification) and tunable via CODE_EVAL_THINKING.
+const defaultEvalModel = "gpt-5.6-luna"
+
+func evalModel() string {
+	if v := os.Getenv("CODE_EVAL_MODEL"); v != "" {
+		return v
+	}
+	return defaultEvalModel
 }
 
 // Commander implements clikit.Commandable: a cheap omp-backed evaluator that
@@ -44,8 +59,16 @@ func (m model) Commander() clikit.Commander {
 	if bin := os.Getenv("CODE_OMP_EVAL"); bin != "" {
 		c.Bin = bin
 	}
+	c.Model = evalModel()
+	if v := os.Getenv("CODE_EVAL_THINKING"); v != "" {
+		c.Thinking = v
+	}
 	return c
 }
+
+// BoxTitle labels the suggest box with its purpose and the model in use, so the
+// user knows what they're invoking.
+func (m model) BoxTitle() string { return "prompt → profile · " + evalModel() }
 
 // validFacetActions keeps only the actions that name a real facet with a value
 // that facet offers — the whitelist that makes an agent proposal no more powerful


### PR DESCRIPTION
Addresses all three points from your first test of the suggest box.

## 1. "no JSON object in model output" + it thought too long
Root cause: the evaluator used `--append-system-prompt`, so its schema was tacked onto omp's **default coding-agent** system prompt — the model behaved like a conversational agent (prose, no clean JSON) and ran with **default thinking** (slow).

Fix: the Commander now **replaces** the system prompt (`--system-prompt`) and runs with **`--thinking off`** — a fast, literal classification. Default model switched to **`gpt-5.6-luna`** (fastest ttft, cheapest Codex tier). Both tunable at runtime via `CODE_EVAL_MODEL` / `CODE_EVAL_THINKING` — no rebuild needed to experiment.

## 2. Show what model it's using
The box now has a title: **`prompt → profile · gpt-5.6-luna`** (via an optional `BoxTitle()` the host implements, wired by `Run`). Verified in tmux.

## 3. See the agent working
`Commander` is reworked from a blocking `Actions()` into **`Propose()` (streams the model's output live) + `Parse()` (turns the finished output into actions)**. The box now streams a one-line rationale + the JSON as it generates, then shows the proposal — no more silent spinner. **Bonus: a parse failure now shows you the raw output**, so if it still misbehaves you'll see exactly what the model said.

## Notes
- cli-kit: `Commander` interface changed; `ompArgs` gains thinking + system-prompt-replace; `OmpCommander` streams (thinking off); `PromptBox` streams Act output and parses on close; `SetTitle`/`BoxTitle`.
- Tests updated (arg builder for both styles, Propose/Parse via the omp stand-in, streamed Act propose→confirm); cli-kit + code-tui suites green; gofmt clean; builds green; vendorHash bumped.
- **The actual suggestion quality still needs your omp auth to judge** — I can't run the model here. But with streaming you'll now *see* what it produces; if JSON parsing still fails, paste me the raw output and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)