### PR TITLE
fix(code): make the suggest box show what the model/omp actually returns

### DIFF
--- a/pkgs/cli-kit/ompasker.go
+++ b/pkgs/cli-kit/ompasker.go
@@ -2,6 +2,7 @@ package clikit
 
 import (
 	"context"
+	"os"
 	"os/exec"
 )
 
@@ -66,35 +67,43 @@ func (o OmpAsker) Ask(ctx context.Context, prompt string) (<-chan string, error)
 	return streamCmd(ctx, cmd)
 }
 
-// streamCmd starts cmd and streams its stdout in chunks. It is separate from Ask
-// so the streaming/cancellation machinery can be tested with any command.
+// streamCmd starts cmd and streams its combined stdout+stderr in chunks. Merging
+// stderr matters: omp reports failures (bad model, auth, rejected flags) there,
+// so without it a failed run streams nothing and the box can't show what went
+// wrong. It is separate from Ask so the streaming/cancellation machinery can be
+// tested with any command.
 func streamCmd(ctx context.Context, cmd *exec.Cmd) (<-chan string, error) {
-	stdout, err := cmd.StdoutPipe()
+	r, w, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
+	cmd.Stdout = w
+	cmd.Stderr = w
 	if err := cmd.Start(); err != nil {
+		w.Close()
+		r.Close()
 		return nil, err
 	}
+	w.Close() // the child holds its own dup of the write end
 	ch := make(chan string)
 	go func() {
 		defer close(ch)
+		defer r.Close()
+		defer func() { _ = cmd.Wait() }()
 		buf := make([]byte, 512)
 		for {
-			n, rerr := stdout.Read(buf)
+			n, rerr := r.Read(buf)
 			if n > 0 {
 				select {
 				case ch <- string(buf[:n]):
-				case <-ctx.Done():
-					_ = cmd.Wait() // process already being killed by the context
+				case <-ctx.Done(): // process already being killed by the context
 					return
 				}
 			}
 			if rerr != nil {
-				break
+				return
 			}
 		}
-		_ = cmd.Wait()
 	}()
 	return ch, nil
 }

--- a/pkgs/cli-kit/promptbox.go
+++ b/pkgs/cli-kit/promptbox.go
@@ -310,10 +310,13 @@ func (b PromptBox) View() string {
 			parts = append(parts, b.vp.View())
 		}
 	case boxDone:
+		// Always keep the raw output visible — on an Act parse-failure it's the
+		// diagnostic (what the model/omp actually said), not just the terse error.
+		if b.answer != "" {
+			parts = append(parts, b.vp.View())
+		}
 		if b.err != nil {
 			parts = append(parts, StBrk.Render(GBroken+" "+b.err.Error()))
-		} else {
-			parts = append(parts, b.vp.View())
 		}
 	case boxProposed:
 		lines := []string{StHead.Render("proposed changes")}

--- a/pkgs/code-tui/default.nix
+++ b/pkgs/code-tui/default.nix
@@ -17,7 +17,7 @@ buildGoModule {
   # so any change to pkgs/cli-kit/*.go shifts this hash — bump it on cli-kit edits.
   # A plain build can reuse a cached FOD and hide the change; get the true value
   # from a fake-hash build (set to sha256-AAA…, read the reported `got:`) or CI.
-  vendorHash = "sha256-hd2ETLUwygR3SRwfypxOuiG/O4DO/e6HkBz3hN2VCl8=";
+  vendorHash = "sha256-VPItyMn5FvX9W+BBTyJQ0o8CZ3o0B7lQLQbKqZxJBnU=";
 
   # The launcher picker is invoked as `code`.
   postInstall = ''

--- a/pkgs/code-tui/suggest.go
+++ b/pkgs/code-tui/suggest.go
@@ -39,10 +39,11 @@ func actDocs(facets []facet) clikit.DocCorpus {
 	return clikit.DocCorpus(b.String())
 }
 
-// defaultEvalModel is a fast, cheap evaluator (leads the speed GPT tier, lowest
-// ttft). Override with CODE_EVAL_MODEL; thinking is off by default (a quick
-// classification) and tunable via CODE_EVAL_THINKING.
-const defaultEvalModel = "gpt-5.6-luna"
+// defaultEvalModel is a fast, cheap evaluator — Anthropic's cheapest tier, which
+// is reliably authed and strong at instruction-following/JSON. With thinking off
+// (below) it's quick. Override with CODE_EVAL_MODEL (e.g. gpt-5.6-luna if your
+// Codex is authed); thinking is tunable via CODE_EVAL_THINKING.
+const defaultEvalModel = "claude-haiku-4-5"
 
 func evalModel() string {
 	if v := os.Getenv("CODE_EVAL_MODEL"); v != "" {


### PR DESCRIPTION
Follow-up to your test: **"still no JSON, and no streamed text so nothing to paste."**

## Root cause (found it)
Running the exact box invocation revealed omp reports failures on **stderr** and exits non-zero with **empty stdout**:
```
error: No API key found for anthropic.  (sandbox — you're authed)
```
The box only streamed **stdout**, and on an Act parse-failure it **replaced** the streamed output with a terse "no JSON object" error — so the real reason was invisible. That's why you had nothing to paste.

## Fixes
- **`streamCmd` merges stderr** into the stream (via `os.Pipe`) — omp's errors and output are now captured.
- **The box keeps the raw output visible** in the done state (shows the streamed text *and* the error together) instead of hiding it behind the parse error.
- **Default evaluator reverted to `claude-haiku-4-5`** — reliably authed and strong at JSON. The earlier `gpt-5.6-luna` default silently produced nothing when Codex wasn't authed (likely your 2nd test). Still overridable via `CODE_EVAL_MODEL`.

## Verified
Rebuilt + tmux: the box now displays omp's actual error (the auth message) instead of a bare "no JSON". cli-kit + code-tui tests green; gofmt clean; builds green; vendorHash bumped.

## Your next test
`git pull && atyrode apply`, then ctrl+o. With haiku (authed) + the replace-system-prompt + thinking-off fixes from #131, it should now return clean JSON → a proposal. **If it still doesn't, you'll now see exactly what came back** — paste that and I'll fix it in one round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)