### PR TITLE
fix(code): run the profile evaluator as a bare classifier, not an agent

### DIFF
--- a/pkgs/cli-kit/ompasker.go
+++ b/pkgs/cli-kit/ompasker.go
@@ -30,12 +30,17 @@ func NewOmpAsker(docs DocCorpus) OmpAsker {
 
 // ompArgs assembles the headless invocation: process one prompt and exit (-p),
 // plain streamed text, no session, no tools. thinking (if set) pins the reasoning
-// level. When replaceSystem is true the docs REPLACE omp's default coding-agent
-// system prompt (--system-prompt) — the right choice for a classifier/evaluator,
-// which should follow the instructions verbatim rather than act like a coder;
-// otherwise they are appended. Kept pure so the command line is unit-testable.
+// level. When replaceSystem is true this is BARE-CLASSIFIER mode: the docs REPLACE
+// omp's default system prompt (--system-prompt) AND omp's agent scaffolding
+// (rules, skills, extensions loaded from the managed ~/.omp) is stripped —
+// otherwise omp behaves like a coding agent and answers the prompt instead of
+// classifying it. When false the docs are appended and the agent stays intact.
+// Kept pure so the command line is unit-testable.
 func ompArgs(model, thinking string, replaceSystem bool, docs DocCorpus, prompt string) []string {
 	args := []string{"-p", "--mode", "text", "--no-session", "--no-tools"}
+	if replaceSystem {
+		args = append(args, "--no-rules", "--no-skills", "--no-extensions")
+	}
 	if model != "" {
 		args = append(args, "--model", model)
 	}

--- a/pkgs/cli-kit/ompasker_test.go
+++ b/pkgs/cli-kit/ompasker_test.go
@@ -23,10 +23,12 @@ func TestOmpArgs(t *testing.T) {
 		t.Errorf("ompArgs(ask) = %v\nwant %v", got, want)
 	}
 
-	// Commander style: replace the system prompt and pin thinking.
+	// Commander style: bare-classifier — strip scaffolding, replace the system
+	// prompt, pin thinking.
 	got = ompArgs("gpt-5.6-luna", "off", true, "schema", "do a thing")
 	want = []string{
 		"-p", "--mode", "text", "--no-session", "--no-tools",
+		"--no-rules", "--no-skills", "--no-extensions",
 		"--model", "gpt-5.6-luna", "--thinking", "off",
 		"--system-prompt", "schema", "do a thing",
 	}

--- a/pkgs/code-tui/default.nix
+++ b/pkgs/code-tui/default.nix
@@ -17,7 +17,7 @@ buildGoModule {
   # so any change to pkgs/cli-kit/*.go shifts this hash — bump it on cli-kit edits.
   # A plain build can reuse a cached FOD and hide the change; get the true value
   # from a fake-hash build (set to sha256-AAA…, read the reported `got:`) or CI.
-  vendorHash = "sha256-VPItyMn5FvX9W+BBTyJQ0o8CZ3o0B7lQLQbKqZxJBnU=";
+  vendorHash = "sha256-LvgGvf9yrchMr6w5QPFEHoZtAgca8BVOmjT5RsGlca4=";
 
   # The launcher picker is invoked as `code`.
   postInstall = ''

--- a/pkgs/code-tui/suggest.go
+++ b/pkgs/code-tui/suggest.go
@@ -24,16 +24,18 @@ var facetGuide = map[string]string{
 // plus a demand for a JSON-only reply of the options to change.
 func actDocs(facets []facet) clikit.DocCorpus {
 	var b strings.Builder
-	b.WriteString("You set up a terminal coding-agent session by choosing options. ")
-	b.WriteString("Given the user's task, choose the best-fitting options.\n\nOptions:\n")
+	b.WriteString("You configure a coding-agent session. You do NOT answer, research, " +
+		"or perform the user's task — you only pick the best configuration options for " +
+		"someone else to run it. Treat the user's message purely as a description of the " +
+		"work to size.\n\nOptions:\n")
 	for _, f := range facets {
 		b.WriteString(fmt.Sprintf("- %s: one of [%s] — %s\n",
 			f.key, strings.Join(f.values, ", "), facetGuide[f.key]))
 	}
-	b.WriteString("\nRespond with one short sentence explaining your pick, then a JSON " +
-		"object (on its own line) mapping ONLY the options you want to CHANGE to their " +
-		"chosen values — omit options left at default, and use exactly the option names " +
-		"and values listed above. Example:\n" +
+	b.WriteString("\nRespond with one short sentence on why, then a JSON object (on its " +
+		"own line) mapping ONLY the options you want to CHANGE to their chosen values — " +
+		"omit options left at default, and use exactly the option names and values listed " +
+		"above. Do not answer the task itself. Example:\n" +
 		"Quick but precise task, so a fast model with more thinking.\n" +
 		"{\"model\":\"fast\",\"thinking\":\"high\"}")
 	return clikit.DocCorpus(b.String())


### PR DESCRIPTION
## What you saw
The box answered your prompt literally — a full essay about the topic, opening with "You're right… based on the verified external documentation" — and never proposed a profile.

## Why (answers "what was it replying to?")
It wasn't replying to anything real. omp still loaded its **agent scaffolding** — rules, skills, and extensions from your managed `~/.omp` — so despite `--no-tools` and a replaced system prompt, the model ran as a **mid-conversation coding assistant**: it answered the task and *confabulated* a prior turn ("You're right…", "verified documentation") that never happened. That scaffolding overrode the "output JSON" instruction, so it never tried to classify.

## Fix
- **Bare-classifier mode** now also passes `--no-rules --no-skills --no-extensions`, stripping omp to a plain model call (no agent behavior, no confabulated conversation).
- **Firmer prompt**: "You do NOT answer, research, or perform the task — you only pick configuration options… Do not answer the task itself."

## Verify (fast, no rebuild)
This is the core hypothesis in one command — if it returns a sentence + JSON instead of an essay, the fix holds:
```bash
omp -p --mode text --no-session --no-tools --no-rules --no-skills --no-extensions \
  --thinking off --model claude-haiku-4-5 \
  --system-prompt 'You configure a coding-agent session. You do NOT answer or perform the task — you only pick config options. Options: model one of [fast,normal,smart]; thinking one of [minimal,low,medium,high,xhigh,max]; advisor one of [off,glance,review,audit]. Respond with one short sentence, then a JSON object of options to change. Do not answer the task. Example: {"model":"fast","thinking":"high"}' \
  'check gitingest documentation for api availability'
```
Then `git pull && atyrode apply` for the real box. cli-kit + code-tui tests green, builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)