### PR TITLE
fix(code): legible message when the evaluator returns no proposal

### DIFF
--- a/pkgs/cli-kit/promptbox.go
+++ b/pkgs/cli-kit/promptbox.go
@@ -12,8 +12,10 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// errNoChanges is shown when a Commander returns an empty proposal.
-var errNoChanges = errors.New("no changes proposed")
+// errNoProposal is shown when the backend didn't return a usable proposal —
+// whether it errored, answered in prose, or proposed nothing. The raw output is
+// displayed above it (see View), which carries the actual reason.
+var errNoProposal = errors.New("no settings proposal in the output above")
 
 // PromptBox is the shared "smart prompt box": type a prompt, watch the agent
 // think, and read a streamed answer. It is a self-contained Bubble Tea component
@@ -263,10 +265,11 @@ func (b PromptBox) Update(msg tea.Msg) (PromptBox, tea.Cmd) {
 			if b.acting && b.cmd != nil { // Act: parse the streamed output
 				actions, err := b.cmd.Parse(b.answer)
 				switch {
-				case err != nil:
-					b.state, b.err = boxDone, err
-				case len(actions) == 0:
-					b.state, b.err = boxDone, errNoChanges
+				case err != nil || len(actions) == 0:
+					// The output (shown above) wasn't a usable proposal — an omp
+					// error, a prose answer, or nothing. Don't surface the JSON
+					// parser's cryptic message; point at the output instead.
+					b.state, b.err = boxDone, errNoProposal
 				default:
 					// Apply the proposal live (host previews it) and await keep/revert.
 					b.proposed, b.state = actions, boxProposed

--- a/pkgs/code-tui/default.nix
+++ b/pkgs/code-tui/default.nix
@@ -17,7 +17,7 @@ buildGoModule {
   # so any change to pkgs/cli-kit/*.go shifts this hash — bump it on cli-kit edits.
   # A plain build can reuse a cached FOD and hide the change; get the true value
   # from a fake-hash build (set to sha256-AAA…, read the reported `got:`) or CI.
-  vendorHash = "sha256-BF7az6vKgB6ejOAcEKAeV4RPmhSR8EfPSz52Z5qFOrU=";
+  vendorHash = "sha256-/XKH5dXqQCWBHUEZjaDwlBFpdm8U0gEbnE+iTcURA9k=";
 
   # The launcher picker is invoked as `code`.
   postInstall = ''


### PR DESCRIPTION
Follow-up to the confusing `parsing proposal: invalid character 'x'` you hit when trying `CODE_EVAL_MODEL=gpt-5.6-luna` (omp fuzzy-resolved that bare name to the **github-copilot** provider, which isn't authed).

The box was trying to JSON-parse omp's *error text* (a Bun stack trace with `{` in it). Now any Act-mode failure — omp error, a prose answer, or an empty proposal — shows one plain line, **"no settings proposal in the output above"**, with omp's actual output rendered above it (the real reason).

Verified in tmux with a stubbed erroring evaluator: the box shows the raw `No API key found for…` output + the clean message, instead of a cryptic parser error. Test green; vendorHash bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)