### PR TITLE
feat(home): add Clever Tools CLI to the development profile (#129)

### DIFF
--- a/home/profiles/development.nix
+++ b/home/profiles/development.nix
@@ -1,11 +1,14 @@
 { pkgs, ... }:
 {
-  # Cross-repository quality tools that interactive agents may assume. Project
-  # language versions and compilers belong to dev shells or mise manifests.
+  # Cross-repository tooling the operator and interactive agents may assume:
+  # quality tools (linters, formatters, Nix editing) and operator deployment
+  # CLIs. Project language versions and compilers belong to dev shells or mise
+  # manifests.
   home.packages = with pkgs; [
     nixd
     nixfmt
     shellcheck
     shfmt
+    clever-tools # Clever Cloud deployment CLI
   ];
 }

--- a/inventory/packages.json
+++ b/inventory/packages.json
@@ -13,11 +13,11 @@
     "owner": "development",
     "deliveryLayer": "home-manager",
     "selectedBy": ["development"],
-    "consumer": "cross-repository agent linting and Nix editing",
+    "consumer": "cross-repository agent linting, Nix editing, and operator deployment CLIs",
     "versionOwner": "pinned nixpkgs",
     "mutableState": "language-server caches",
     "closureClass": "medium",
-    "packages": ["nixd", "nixfmt", "shellcheck", "shfmt"]
+    "packages": ["clever-tools", "nixd", "nixfmt", "shellcheck", "shfmt"]
   },
   {
     "owner": "agent-tools",


### PR DESCRIPTION
Adds the Clever Cloud deployment CLI (`clever-tools`, nixpkgs 4.11.0) to the `development` profile — present on every real machine — and registers it in `inventory/packages.json`. Broadened the profile's consumer description to cover operator deployment CLIs alongside linters/Nix editing.

Verified: home activation builds; the `package-ownership` inventory check passes.

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)