### PR TITLE
feat(cli-kit,code): show the full applied diff in the suggest box (#141)

### DIFF
--- a/pkgs/cli-kit/promptbox.go
+++ b/pkgs/cli-kit/promptbox.go
@@ -95,6 +95,12 @@ type ActionsConfirmedMsg struct{ Prompt string }
 // host restores the state it saved on ActionsProposedMsg.
 type ActionsRevertedMsg struct{}
 
+// AppliedActionsMsg lets the host replace what the box lists as "applied" with
+// the authoritative set it actually applied — which may differ from the parsed
+// proposal (e.g. the host derives extra changes, or repairs/validates some).
+// Optional: a host that applies actions verbatim need never send it.
+type AppliedActionsMsg struct{ Actions []Action }
+
 // PromptBox is a value type — Update returns an updated copy, matching the
 // bubbles convention.
 type PromptBox struct {
@@ -338,6 +344,14 @@ func (b PromptBox) Update(msg tea.Msg) (PromptBox, tea.Cmd) {
 		b.ta, cmd = b.ta.Update(msg)
 		b.syncInputHeight() // grow/shrink the box with the typed text
 		return b, cmd
+
+	case AppliedActionsMsg:
+		// The host telling us what it really applied (see the type doc); reflect it
+		// in the proposal list so "applied" is truthful.
+		if b.state == boxProposed {
+			b.proposed = msg.Actions
+		}
+		return b, nil
 
 	case modelResidencyMsg:
 		b.loading = false

--- a/pkgs/cli-kit/run.go
+++ b/pkgs/cli-kit/run.go
@@ -115,6 +115,10 @@ func (h host) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// actions mutate); the box stays open showing keep/revert.
 		h.app, cmd = h.app.Update(msg)
 
+	case AppliedActionsMsg:
+		// The app reporting the authoritative applied set — hand it to the box.
+		h.box, cmd = h.box.Update(msg)
+
 	case ActionsConfirmedMsg, ActionsRevertedMsg:
 		// Keep or revert the previewed proposal; either way the box closes and the
 		// app handles it (commit, or restore the saved state).

--- a/pkgs/code-tui/default.nix
+++ b/pkgs/code-tui/default.nix
@@ -17,7 +17,7 @@ buildGoModule {
   # so any change to pkgs/cli-kit/*.go shifts this hash — bump it on cli-kit edits.
   # A plain build can reuse a cached FOD and hide the change; get the true value
   # from a fake-hash build (set to sha256-AAA…, read the reported `got:`) or CI.
-  vendorHash = "sha256-lZRqRWLe13I3HAEZOv8YtMJWETLuRWn8MvbHkatFyZ0=";
+  vendorHash = "sha256-8oozQvEVjnOLNK5RTn3iaWQBju+QPsghiyIW500jX94=";
 
   # The launcher picker is invoked as `code`.
   postInstall = ''

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -1483,13 +1483,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case clikit.ActionsProposedMsg:
 		// Live preview: snapshot the current selection, then apply the proposal to
-		// the generator so the user sees the change while deciding.
+		// the generator so the user sees the change while deciding. Report the FULL
+		// applied diff back to the box (the model's picks plus the derived toggles),
+		// so its "applied" list reflects everything that changed, not just the three
+		// facets the model named directly.
 		m.view = genView
 		m.savedSel = map[string]string{}
 		for k, v := range m.sel {
 			m.savedSel[k] = v
 		}
 		m.applyActions(msg.Actions)
+		return m, func() tea.Msg { return clikit.AppliedActionsMsg{Actions: m.appliedDiff()} }
 
 	case clikit.ActionsConfirmedMsg:
 		// Kept: the preview stays; remember the prompt for the launched session.

--- a/pkgs/code-tui/suggest.go
+++ b/pkgs/code-tui/suggest.go
@@ -154,6 +154,20 @@ func (m *model) applyActions(actions []clikit.Action) {
 	m.syncPreview()
 }
 
+// appliedDiff returns the facets that changed from the pre-suggestion snapshot
+// (m.savedSel) to the current selection, in facet order — the complete set the
+// suggestion applied: the model's direct picks plus the derived spark/fable/fast
+// toggles and any repair. The box shows this so its "applied" list is truthful.
+func (m model) appliedDiff() []clikit.Action {
+	var out []clikit.Action
+	for _, f := range m.facets {
+		if m.savedSel[f.key] != m.sel[f.key] {
+			out = append(out, clikit.Action{Key: f.key, Value: m.sel[f.key]})
+		}
+	}
+	return out
+}
+
 // deriveToggles sets the spark/fable/fast toggles from the suggested sizing plus
 // live quota — encoding what each model is for, which the classifier itself isn't
 // reliable enough to weigh:

--- a/pkgs/code-tui/suggest_test.go
+++ b/pkgs/code-tui/suggest_test.go
@@ -77,6 +77,24 @@ func TestTruncateForClassify(t *testing.T) {
 	}
 }
 
+func TestAppliedDiff(t *testing.T) {
+	// The diff must include every changed facet (model's picks + derived toggles),
+	// in facet order, and skip unchanged ones.
+	m := model{facets: facetDefs(map[string]string{}),
+		savedSel: map[string]string{"model": "normal", "thinking": "medium", "spark": "on", "fable": "off"},
+		sel:      map[string]string{"model": "smart", "thinking": "xhigh", "spark": "on", "fable": "on"}}
+	got := m.appliedDiff()
+	want := []clikit.Action{{"model", "smart"}, {"thinking", "xhigh"}, {"fable", "on"}}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("action %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
 func TestDeriveToggles(t *testing.T) {
 	avail := func() availability { return availability{bucket: map[string]string{}} }
 	// critical-tier sizing, Claude-capable lane, fable free → fable on, fast off.


### PR DESCRIPTION
The box's "applied" list showed only the model's three direct picks; the derived spark/fable/fast toggles (and any repair) applied but weren't listed, reading as "those didn't change".

- **cli-kit**: `AppliedActionsMsg` lets a host replace what the box lists as applied with the authoritative set it actually applied; the host routes it to the box.
- **code**: after `applyActions`, emit the full changed-facet diff (`savedSel` → `sel`, in facet order) so the list reflects the model's picks plus derived toggles.

Tested: unit tests for `appliedDiff` + cli-kit; both packages build; omp-configured builds.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)