### PR TITLE
build(nix): enforce nixfmt via a flake check (#13)

### DIFF
--- a/checks/fixtures/nixos-server.nix
+++ b/checks/fixtures/nixos-server.nix
@@ -41,37 +41,40 @@ in
 
     modules = [
       dotfiles.nixosModules.dotfiles-home
-      ({ pkgs, ... }: {
-        boot.isContainer = true;
-        nixpkgs.hostPlatform = system;
-        system.stateVersion = "26.05";
+      (
+        { pkgs, ... }:
+        {
+          boot.isContainer = true;
+          nixpkgs.hostPlatform = system;
+          system.stateVersion = "26.05";
 
-        programs.zsh.enable = true;
+          programs.zsh.enable = true;
 
-        atyrode.dotfiles.hostRegistry = registry;
+          atyrode.dotfiles.hostRegistry = registry;
 
-        users.users.${username} = {
-          home = homeDirectory;
-          isNormalUser = true;
-          shell = pkgs.zsh;
-        };
-
-        home-manager.users.${username} = {
-          imports = [
-            profiles.base
-            profiles.server
-            profiles.agent-tools
-            (dotfiles.lib.mkHostIdentityModule {
-              inherit host;
-              name = hostId;
-            })
-          ];
-
-          home = {
-            inherit homeDirectory username;
+          users.users.${username} = {
+            home = homeDirectory;
+            isNormalUser = true;
+            shell = pkgs.zsh;
           };
-        };
-      })
+
+          home-manager.users.${username} = {
+            imports = [
+              profiles.base
+              profiles.server
+              profiles.agent-tools
+              (dotfiles.lib.mkHostIdentityModule {
+                inherit host;
+                name = hostId;
+              })
+            ];
+
+            home = {
+              inherit homeDirectory username;
+            };
+          };
+        }
+      )
     ];
   };
 }

--- a/checks/nixfmt.nix
+++ b/checks/nixfmt.nix
@@ -1,0 +1,22 @@
+{ lib, pkgs }:
+
+let
+  # Every .nix source in the tree (fileFilter keeps only .nix, so edits to other
+  # files don't invalidate the check and new .nix files are covered automatically).
+  nixSources = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.fileFilter (file: file.hasExt "nix") ../.;
+  };
+in
+pkgs.runCommand "check-nixfmt"
+  {
+    nativeBuildInputs = [ pkgs.nixfmt ];
+  }
+  ''
+    cd ${nixSources}
+    if ! find . -name '*.nix' -exec nixfmt --check {} +; then
+      echo 'These Nix files are not nixfmt-clean (see above). Run `nix fmt` to fix them.' >&2
+      exit 1
+    fi
+    mkdir "$out"
+  ''

--- a/flake.nix
+++ b/flake.nix
@@ -599,6 +599,7 @@
           };
           get-entrypoint = import ./checks/get-sh.nix { inherit pkgs; };
           go-fmt = import ./checks/go-fmt.nix { inherit lib pkgs; };
+          nixfmt = import ./checks/nixfmt.nix { inherit lib pkgs; };
           omp-seed = import ./checks/omp-seed.nix { inherit lib pkgs; };
           production-facts = import ./checks/production-facts.nix { inherit pkgs; };
           home-evaluation = homeEvaluation;

--- a/home/git.nix
+++ b/home/git.nix
@@ -3,17 +3,17 @@
 {
   programs.git = {
     enable = true;
-    
+
     settings = {
       user.name = "Alex TYRODE";
       user.email = "alex@tyrode.dev";
       user.signingKey = "${config.home.homeDirectory}/.ssh/id_ed25519_git_signing.pub";
-      
+
       # Never persist Git credentials in plaintext; use SSH remotes/agents or
       # a platform credential manager instead.
       gpg.format = "ssh";
       gpg.ssh.allowedSignersFile = "${config.home.homeDirectory}/.config/git/allowed_signers";
-      
+
       # Useful defaults
       init.defaultBranch = "main";
       pull.rebase = false;
@@ -21,11 +21,11 @@
       commit.gpgsign = true;
 
       includeIf."gitdir/i:**/gitlab.alouette.dev/**".path = "~/.gitconfigs/.alouette.config";
-      
+
       # Better diff/merge tools
       diff.colorMoved = "default";
       merge.conflictstyle = "diff3";
-      
+
       # Git aliases
       alias.st = "status";
       alias.co = "checkout";

--- a/home/pkgs/lichess.nix
+++ b/home/pkgs/lichess.nix
@@ -7,69 +7,71 @@ pkgs.stdenvNoCC.mkDerivation {
   dontUnpack = true;
 
   installPhase = ''
-    runHook preInstall
+        runHook preInstall
 
-    mkdir -p "$out/bin" "$out/share/applications"
+        mkdir -p "$out/bin" "$out/share/applications"
 
-    cat > "$out/bin/lichess" <<'EOF'
-#!/usr/bin/env sh
-url="https://lichess.org"
+        cat > "$out/bin/lichess" <<'EOF'
+    #!/usr/bin/env sh
+    url="https://lichess.org"
 
-if command -v open >/dev/null 2>&1; then
-  exec open "$url"
-fi
+    if command -v open >/dev/null 2>&1; then
+      exec open "$url"
+    fi
 
-${lib.optionalString pkgs.stdenv.isLinux ''
-if [ -x "${pkgs.xdg-utils}/bin/xdg-open" ]; then
-  exec "${pkgs.xdg-utils}/bin/xdg-open" "$url"
-fi
-''}
+    ${lib.optionalString pkgs.stdenv.isLinux ''
+      if [ -x "${pkgs.xdg-utils}/bin/xdg-open" ]; then
+        exec "${pkgs.xdg-utils}/bin/xdg-open" "$url"
+      fi
+    ''}
 
-if command -v xdg-open >/dev/null 2>&1; then
-  exec xdg-open "$url"
-fi
+    if command -v xdg-open >/dev/null 2>&1; then
+      exec xdg-open "$url"
+    fi
 
-printf '%s\n' "$url"
-EOF
-    chmod +x "$out/bin/lichess"
+    printf '%s\n' "$url"
+    EOF
+        chmod +x "$out/bin/lichess"
 
-    cat > "$out/share/applications/lichess.desktop" <<EOF
-[Desktop Entry]
-Type=Application
-Name=Lichess
-Comment=Open lichess.org
-Exec=$out/bin/lichess
-Terminal=false
-Categories=Game;BoardGame;
-EOF
-  '' + lib.optionalString pkgs.stdenv.isDarwin ''
-    mkdir -p "$out/Applications/Lichess.app/Contents/MacOS"
+        cat > "$out/share/applications/lichess.desktop" <<EOF
+    [Desktop Entry]
+    Type=Application
+    Name=Lichess
+    Comment=Open lichess.org
+    Exec=$out/bin/lichess
+    Terminal=false
+    Categories=Game;BoardGame;
+    EOF
+  ''
+  + lib.optionalString pkgs.stdenv.isDarwin ''
+        mkdir -p "$out/Applications/Lichess.app/Contents/MacOS"
 
-    cat > "$out/Applications/Lichess.app/Contents/Info.plist" <<'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>CFBundleExecutable</key>
-  <string>Lichess</string>
-  <key>CFBundleIdentifier</key>
-  <string>org.lichess.webapp</string>
-  <key>CFBundleName</key>
-  <string>Lichess</string>
-  <key>CFBundlePackageType</key>
-  <string>APPL</string>
-  <key>LSApplicationCategoryType</key>
-  <string>public.app-category.games</string>
-</dict>
-</plist>
-EOF
+        cat > "$out/Applications/Lichess.app/Contents/Info.plist" <<'EOF'
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>CFBundleExecutable</key>
+      <string>Lichess</string>
+      <key>CFBundleIdentifier</key>
+      <string>org.lichess.webapp</string>
+      <key>CFBundleName</key>
+      <string>Lichess</string>
+      <key>CFBundlePackageType</key>
+      <string>APPL</string>
+      <key>LSApplicationCategoryType</key>
+      <string>public.app-category.games</string>
+    </dict>
+    </plist>
+    EOF
 
-    cat > "$out/Applications/Lichess.app/Contents/MacOS/Lichess" <<'EOF'
-#!/bin/sh
-exec /usr/bin/open "https://lichess.org"
-EOF
-    chmod +x "$out/Applications/Lichess.app/Contents/MacOS/Lichess"
-  '' + ''
+        cat > "$out/Applications/Lichess.app/Contents/MacOS/Lichess" <<'EOF'
+    #!/bin/sh
+    exec /usr/bin/open "https://lichess.org"
+    EOF
+        chmod +x "$out/Applications/Lichess.app/Contents/MacOS/Lichess"
+  ''
+  + ''
     runHook postInstall
   '';
 

--- a/modules/home/agent-tools.nix
+++ b/modules/home/agent-tools.nix
@@ -119,98 +119,106 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable (lib.mkMerge [
-   {
-    home.packages = [
-      cfg.ompPackage
-    ]
-    ++ lib.optional cfg.seedPlainConfig cfg.seedPackage;
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        home.packages = [
+          cfg.ompPackage
+        ]
+        ++ lib.optional cfg.seedPlainConfig cfg.seedPackage;
 
-    xdg.configFile = {
-      "omp/defaults.yml".source = defaultsConfig;
-      "omp/policy.yml".source = policyConfig;
-      "omp/untrusted.yml".source = untrustedConfig;
-      "omp/presets/budget.yml".source = presets.budget;
-      "omp/presets/fable-primary.yml".source = presets.fable;
-      "omp/presets/gpt56.yml".source = presets.gpt;
-      "omp/presets/sonnet-value.yml".source = presets.sonnet;
-      "omp/presets/claude-hard.yml".source = presets.claude;
-      "omp/presets/context-1m.yml".source = presets.context;
-      "omp/presets/fast-mixed.yml".source = presets.fast;
-      "omp/presets/gpt-speed.yml".source = presets.gptSpeed;
-      "omp/presets/claude-speed.yml".source = presets.claudeSpeed;
-      "omp/presets/mixed-regular.yml".source = presets.mixedRegular;
-      "omp/presets/mixed-smart.yml".source = presets.mixedSmart;
-      "omp/presets/gpt-only.yml".source = presets.gptOnly;
-      "omp/presets/claude-only.yml".source = presets.claudeOnly;
-    };
+        xdg.configFile = {
+          "omp/defaults.yml".source = defaultsConfig;
+          "omp/policy.yml".source = policyConfig;
+          "omp/untrusted.yml".source = untrustedConfig;
+          "omp/presets/budget.yml".source = presets.budget;
+          "omp/presets/fable-primary.yml".source = presets.fable;
+          "omp/presets/gpt56.yml".source = presets.gpt;
+          "omp/presets/sonnet-value.yml".source = presets.sonnet;
+          "omp/presets/claude-hard.yml".source = presets.claude;
+          "omp/presets/context-1m.yml".source = presets.context;
+          "omp/presets/fast-mixed.yml".source = presets.fast;
+          "omp/presets/gpt-speed.yml".source = presets.gptSpeed;
+          "omp/presets/claude-speed.yml".source = presets.claudeSpeed;
+          "omp/presets/mixed-regular.yml".source = presets.mixedRegular;
+          "omp/presets/mixed-smart.yml".source = presets.mixedSmart;
+          "omp/presets/gpt-only.yml".source = presets.gptOnly;
+          "omp/presets/claude-only.yml".source = presets.claudeOnly;
+        };
 
-    home.file = {
-      ".agents/skills" = {
-        source = ../../agents/skills;
-        recursive = true;
-      };
-    };
+        home.file = {
+          ".agents/skills" = {
+            source = ../../agents/skills;
+            recursive = true;
+          };
+        };
 
-    home.activation = lib.mkMerge [
-      (lib.mkIf cfg.migrateLegacy {
-        migrateLegacyAgentTools = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
-          if [[ -v DRY_RUN ]]; then
-            export AGENT_TOOLS_DRY_RUN=1
-          fi
-          ${lib.getExe cfg.migrationPackage} prepare
-        '';
-
-        finalizeLegacyAgentTools = lib.hm.dag.entryAfter [ "installPackages" "linkGeneration" ] ''
-          if [[ -v DRY_RUN ]]; then
-            export AGENT_TOOLS_DRY_RUN=1
-          fi
-          ${lib.getExe cfg.migrationPackage} finalize "$newGenPath/home-files"
-        '';
-      })
-      (lib.mkIf cfg.seedPlainConfig {
-        # Runs after the legacy migration so a first activation seeds the
-        # transformed configuration, never the pre-migration backup source.
-        # Seeding is a convenience: a failure (for example unparseable
-        # operator YAML) warns instead of failing the whole activation.
-        seedPlainOmpConfig =
-          lib.hm.dag.entryAfter
-            ([ "installPackages" "linkGeneration" ] ++ lib.optional cfg.migrateLegacy "finalizeLegacyAgentTools")
-            ''
+        home.activation = lib.mkMerge [
+          (lib.mkIf cfg.migrateLegacy {
+            migrateLegacyAgentTools = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
               if [[ -v DRY_RUN ]]; then
                 export AGENT_TOOLS_DRY_RUN=1
               fi
-              if ! ${lib.getExe cfg.seedPackage} apply; then
-                echo "warning: plain-omp seeding failed; inspect with atyrode-omp-seed status" >&2
-              fi
+              ${lib.getExe cfg.migrationPackage} prepare
             '';
+
+            finalizeLegacyAgentTools = lib.hm.dag.entryAfter [ "installPackages" "linkGeneration" ] ''
+              if [[ -v DRY_RUN ]]; then
+                export AGENT_TOOLS_DRY_RUN=1
+              fi
+              ${lib.getExe cfg.migrationPackage} finalize "$newGenPath/home-files"
+            '';
+          })
+          (lib.mkIf cfg.seedPlainConfig {
+            # Runs after the legacy migration so a first activation seeds the
+            # transformed configuration, never the pre-migration backup source.
+            # Seeding is a convenience: a failure (for example unparseable
+            # operator YAML) warns instead of failing the whole activation.
+            seedPlainOmpConfig =
+              lib.hm.dag.entryAfter
+                (
+                  [
+                    "installPackages"
+                    "linkGeneration"
+                  ]
+                  ++ lib.optional cfg.migrateLegacy "finalizeLegacyAgentTools"
+                )
+                ''
+                  if [[ -v DRY_RUN ]]; then
+                    export AGENT_TOOLS_DRY_RUN=1
+                  fi
+                  if ! ${lib.getExe cfg.seedPackage} apply; then
+                    echo "warning: plain-omp seeding failed; inspect with atyrode-omp-seed status" >&2
+                  fi
+                '';
+          })
+        ];
+      }
+
+      (lib.mkIf lcfg.enable {
+        services.ollama = {
+          enable = true;
+          port = lcfg.port;
+          environmentVariables.OLLAMA_KEEP_ALIVE = lcfg.keepAlive;
+        };
+
+        # Auto-pull the classifier model once the daemon is up. systemd user
+        # services are Linux-only in Home Manager; on other platforms the daemon
+        # still runs (via the launchd agent the ollama module defines) but the
+        # model is pulled on first use / manually.
+        systemd.user.services.ollama-pull-classifier = lib.mkIf pkgs.stdenv.isLinux {
+          Unit = {
+            Description = "Pull the code picker's local classifier model to disk (${lcfg.model})";
+            After = [ "ollama.service" ];
+            Wants = [ "ollama.service" ];
+          };
+          Service = {
+            Type = "oneshot";
+            ExecStart = "${pullClassifierModel}";
+          };
+          Install.WantedBy = [ "default.target" ];
+        };
       })
-    ];
-   }
-
-    (lib.mkIf lcfg.enable {
-      services.ollama = {
-        enable = true;
-        port = lcfg.port;
-        environmentVariables.OLLAMA_KEEP_ALIVE = lcfg.keepAlive;
-      };
-
-      # Auto-pull the classifier model once the daemon is up. systemd user
-      # services are Linux-only in Home Manager; on other platforms the daemon
-      # still runs (via the launchd agent the ollama module defines) but the
-      # model is pulled on first use / manually.
-      systemd.user.services.ollama-pull-classifier = lib.mkIf pkgs.stdenv.isLinux {
-        Unit = {
-          Description = "Pull the code picker's local classifier model to disk (${lcfg.model})";
-          After = [ "ollama.service" ];
-          Wants = [ "ollama.service" ];
-        };
-        Service = {
-          Type = "oneshot";
-          ExecStart = "${pullClassifierModel}";
-        };
-        Install.WantedBy = [ "default.target" ];
-      };
-    })
-  ]);
+    ]
+  );
 }

--- a/pkgs/code-tui/default.nix
+++ b/pkgs/code-tui/default.nix
@@ -10,7 +10,10 @@ buildGoModule {
   # the source must carry both module dirs; modRoot points the build at code-tui.
   src = lib.fileset.toSource {
     root = ./..;
-    fileset = lib.fileset.unions [ ./. ../cli-kit ];
+    fileset = lib.fileset.unions [
+      ./.
+      ../cli-kit
+    ];
   };
   modRoot = "code-tui";
   # cli-kit is a local `replace` whose source lives in this build's src (above),

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1146,15 +1146,17 @@ let
     }
   ];
   presetProfiles = builtins.filter (p: p ? preset) paletteProfiles;
-  ompuProfile = lib.findFirst (p: p.cmd == "ompu") (throw "ompu missing from palette") paletteProfiles;
+  ompuProfile = lib.findFirst (
+    p: p.cmd == "ompu"
+  ) (throw "ompu missing from palette") paletteProfiles;
   # ompu loads defaultsConfig then untrusted.yml, and untrusted.yml overrides only
   # tools/approvals — never modelRoles/retry/thinking — so its routing is exactly the
   # managed defaults. Render it like any preset so the picker preview and omph show a
   # real model list (GUI parity) instead of a blank. (The bare `omp` genuinely has no
   # managed routing — upstream's built-in modelRoles is empty — so it stays off this list.)
-  routeSpecs =
-    (map (p: "${p.cmd}|${p.blurb}|${p.preset}") presetProfiles)
-    ++ [ "ompu|${ompuProfile.blurb}|${untrustedConfig}" ];
+  routeSpecs = (map (p: "${p.cmd}|${p.blurb}|${p.preset}") presetProfiles) ++ [
+    "ompu|${ompuProfile.blurb}|${untrustedConfig}"
+  ];
   routesHelp =
     runCommand "omp-routes-help-${lib.getVersion omp}"
       {
@@ -1404,13 +1406,38 @@ let
   nfGlyph = cp: builtins.fromJSON ''"\u${cp}"'';
   profileColor =
     cmd:
-    if builtins.elem cmd [ "ompz" "ompn" "ompm" ] then
+    if
+      builtins.elem cmd [
+        "ompz"
+        "ompn"
+        "ompm"
+      ]
+    then
       "#aa96e1" # mixed — purple
-    else if builtins.elem cmd [ "ompl" "ompb" "ompg" "ompo" ] then
+    else if
+      builtins.elem cmd [
+        "ompl"
+        "ompb"
+        "ompg"
+        "ompo"
+      ]
+    then
       "#62a7ff" # gpt-led — blue
-    else if builtins.elem cmd [ "ompk" "omps" "ompc" "ompe" ] then
+    else if
+      builtins.elem cmd [
+        "ompk"
+        "omps"
+        "ompc"
+        "ompe"
+      ]
+    then
       "#ff9f52" # claude-led — orange
-    else if builtins.elem cmd [ "ompf" "ompx" ] then
+    else if
+      builtins.elem cmd [
+        "ompf"
+        "ompx"
+      ]
+    then
       "#46bec8" # specialist — teal
     else if cmd == "ompu" then
       "#d05c60" # untrusted — red
@@ -1418,13 +1445,36 @@ let
       "#78c8aa"; # yours — green
   profileGlyph =
     cmd:
-    if builtins.elem cmd [ "ompz" "ompl" "ompk" ] then
+    if
+      builtins.elem cmd [
+        "ompz"
+        "ompl"
+        "ompk"
+      ]
+    then
       nfGlyph "f0e7" # bolt — speed
-    else if builtins.elem cmd [ "ompn" "ompb" "omps" ] then
+    else if
+      builtins.elem cmd [
+        "ompn"
+        "ompb"
+        "omps"
+      ]
+    then
       nfGlyph "f085" # cogs — routine
-    else if builtins.elem cmd [ "ompm" "ompg" "ompc" ] then
+    else if
+      builtins.elem cmd [
+        "ompm"
+        "ompg"
+        "ompc"
+      ]
+    then
       nfGlyph "f0eb" # lightbulb — smart
-    else if builtins.elem cmd [ "ompo" "ompe" ] then
+    else if
+      builtins.elem cmd [
+        "ompo"
+        "ompe"
+      ]
+    then
       nfGlyph "f127" # broken link — pure pool
     else if cmd == "ompf" then
       nfGlyph "f08d" # thumbtack — deterministic

--- a/pkgs/omp-seed/default.nix
+++ b/pkgs/omp-seed/default.nix
@@ -21,12 +21,11 @@ in
   ];
   # The seed ships from the Nix store but stays overridable so checks can
   # exercise seed updates against a fixture file.
-  text =
-    ''
-      : "''${OMP_SEED_FILE:=${seedConfig}}"
-      export OMP_SEED_FILE
-    ''
-    + lib.removePrefix "#!/usr/bin/env bash\nset -euo pipefail\n" script;
+  text = ''
+    : "''${OMP_SEED_FILE:=${seedConfig}}"
+    export OMP_SEED_FILE
+  ''
+  + lib.removePrefix "#!/usr/bin/env bash\nset -euo pipefail\n" script;
   meta = {
     description = "Drift-aware seeding of curated plain-omp defaults";
     license = lib.licenses.mit;


### PR DESCRIPTION
The repo exposes `nix fmt` (nixfmt) but nothing enforced it, so 7 `.nix` files had drifted (a few from this session's edits). Adds a `nixfmt` flake check (`nixfmt --check` over every `.nix` source, modelled on the existing `go-fmt` gate) and reformats the drifted files.

Scope: the formatting-gate slice of #13. The broader items (treefmt-nix aggregation, deadnix/statix/actionlint) remain open on #13.

Tested: `nix build .#checks.x86_64-linux.nixfmt` passes; the reformat is nixfmt-only (semantics-preserving).

Part of #13