### PR TITLE
fix(atyrode): fold clean's benign gcroots permission flood

### DIFF
--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -33,6 +33,18 @@ pkgs.runCommand "check-atyrode-cli"
     cat > "$TMPDIR/bin/nh" <<'EOF'
     #!${pkgs.runtimeShell}
     printf '%s\n' "$*" > "$TMPDIR/nh-args"
+    if [[ "''${ATYRODE_NH_NOISE:-0}" == 1 ]]; then
+      # Reproduce nh clean's real output shape: a genuine generation removal, the
+      # benign root-owned gcroots permission flood, and one real (non-permission)
+      # error — so the check can prove fold_gcroots_noise keeps the first and last
+      # while collapsing the flood.
+      echo '- OK  /home/alex/.local/state/nix/profiles/profile-9-link'
+      echo '> Removing /nix/var/nix/gcroots/auto/lvi04m7mn76ymzgzcx5rrifj5019psvd'
+      echo '! Failed to remove path="/nix/var/nix/gcroots/auto/lvi04m7mn76ymzgzcx5rrifj5019psvd" err=Os { code: 13, kind: PermissionDenied, message: "Permission denied" } (nh/crates/nh-clean/src/clean.rs:606)'
+      echo '> Removing /nix/var/nix/gcroots/auto/phm61mw9l2zpvj3fj6pmmyk22b1l3qg8'
+      echo '! Failed to remove path="/nix/var/nix/gcroots/auto/phm61mw9l2zpvj3fj6pmmyk22b1l3qg8" err=Os { code: 13, kind: PermissionDenied, message: "Permission denied" } (nh/crates/nh-clean/src/clean.rs:606)'
+      echo '! Failed to remove path="/nix/store/genuine" err=Os { code: 2, kind: NotFound }' >&2
+    fi
     [[ "''${ATYRODE_NH_FAIL:-0}" != 1 ]]
     EOF
     # Stub nix-env's generation listing (clean --json / generations read it).
@@ -459,6 +471,20 @@ pkgs.runCommand "check-atyrode-cli"
       and .reclaimCandidates[0].generation == 1
     ' <<<"$clean_json" >/dev/null \
       || { echo "clean --json summary wrong: $clean_json" >&2; exit 1; }
+
+    # clean folds nh's benign root-owned gcroots permission flood into a single
+    # summary line, but keeps genuine removals and real (non-permission) errors.
+    export ATYRODE_NIX_STORE="$TMPDIR/bin/fake-gc"
+    noise_out="$(ATYRODE_NH_NOISE=1 atyrode clean --keep 3 2>&1 >/dev/null)"
+    unset ATYRODE_NIX_STORE
+    grep -qF 'skipped 2 root-owned GC root(s)' <<<"$noise_out" \
+      || { echo "clean must summarize skipped gcroots: $noise_out" >&2; exit 1; }
+    grep -qF 'gcroots/auto/lvi04m7mn76' <<<"$noise_out" \
+      && { echo 'clean must not print individual gcroots permission failures' >&2; exit 1; }
+    grep -qF 'profile-9-link' <<<"$noise_out" \
+      || { echo 'clean must keep genuine generation removals' >&2; exit 1; }
+    grep -qF '/nix/store/genuine' <<<"$noise_out" \
+      || { echo 'clean must keep real (non-permission) failures' >&2; exit 1; }
 
     mkdir "$out"
   ''

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -914,6 +914,28 @@ collect_garbage() {
   rm -f "$out"
 }
 
+# fold_gcroots_noise collapses one expected, benign flood in nh clean's output:
+# the "Failed to remove path …/gcroots/auto/… PermissionDenied" lines. Those auto
+# GC roots are owned by the Nix daemon/root, so a user-scope clean cannot unlink
+# them — but that is harmless, the store GC still reclaims whatever they no longer
+# protect. nh prints one such line per root, which drowns the real work and reads
+# like a crash. Here we count them and emit a single summary instead; every other
+# line — generation removals, genuine errors, non-permission failures — passes
+# through untouched (a "> Removing …/gcroots/auto/…" line is held one step so its
+# paired permission failure can suppress it, and flushed if no failure follows).
+fold_gcroots_noise() {
+  awk '
+    /^> Removing .*\/gcroots\/auto\// { if (pending != "") print pending; pending = $0; next }
+    /Failed to remove path.*\/gcroots\/auto\/.*PermissionDenied/ { skipped++; pending = ""; next }
+    { if (pending != "") { print pending; pending = "" } print }
+    END {
+      if (pending != "") print pending
+      if (skipped > 0)
+        printf "atyrode: skipped %d root-owned GC root(s) under /nix/var/nix/gcroots/auto (owned by the Nix daemon, need elevation to remove — harmless: the store GC still reclaims what they no longer protect)\n", skipped
+    }
+  '
+}
+
 # clean — reclaim disk from generations the config no longer references, always
 # keeping the current generation and a rollback window (never an auto-wipe of the
 # safety net). Also sweeps stale macOS app aliases (see clean_macos_residue).
@@ -939,15 +961,13 @@ cmd_clean() {
   printf 'atyrode: reclaiming the Nix store (keeping %s generation(s) + everything newer than %s)\n' "$keep" "$keep_since" >&2
   # Let nh remove the stale generations and gcroots, but skip its garbage
   # collection (--no-gc) — nh runs it silently. We collect below instead, with a
-  # progress indicator, so the slow final step isn't an unexplained freeze. Under
-  # --json, nh's own chatter goes to stderr so stdout carries only the summary.
+  # progress indicator, so the slow final step isn't an unexplained freeze. nh's
+  # own chatter (and the folded gcroots summary) goes to stderr so that under
+  # --json stdout carries only the machine-readable summary; pipefail propagates
+  # nh's exit status through the filter.
   local nh_args=("$nh_command" clean "$scope" --keep "$keep" --keep-since "$keep_since" --no-gc)
   [[ "$dry" == 0 ]] || nh_args+=(--dry)
-  if [[ "$json" == 1 ]]; then
-    "${nh_args[@]}" >&2 || die "$EX_SOFTWARE" "nh clean failed"
-  else
-    "${nh_args[@]}" || die "$EX_SOFTWARE" "nh clean failed"
-  fi
+  "${nh_args[@]}" 2>&1 | fold_gcroots_noise >&2 || die "$EX_SOFTWARE" "nh clean failed"
 
   [[ "$dry" == 1 ]] || collect_garbage
 


### PR DESCRIPTION
## Problem

`atyrode clean` floods the terminal with red permission errors like:

```
> Removing /nix/var/nix/gcroots/auto/lvi04m7mn76ymzgzcx5rrifj5019psvd
! Failed to remove path="…/gcroots/auto/…" err=Os { code: 13, kind: PermissionDenied … }
```

one per auto GC root. Those roots under `/nix/var/nix/gcroots/auto/` are owned by the Nix daemon/root, so a user-scope clean simply can't unlink them. It's **harmless** — the store GC still reclaims whatever they no longer protect — but the wall of red drowns the real cleaning output and reads like a crash.

## Fix

`fold_gcroots_noise` collapses that one specific benign flood into a single summary line:

```
atyrode: skipped 13 root-owned GC root(s) under /nix/var/nix/gcroots/auto (owned by the Nix daemon, need elevation to remove — harmless: the store GC still reclaims what they no longer protect)
```

Everything else passes through untouched — genuine generation removals, successful removals, and **real** (non-permission) failures still surface. `pipefail` keeps nh's exit status propagating through the filter, so a genuine `nh clean` failure still aborts.

## Test

The `atyrode-cli` check reproduces nh's real output shape (a generation removal + the gcroots permission flood + one genuine non-permission error) and asserts the fold: summary present, individual permission failures gone, genuine removal and real error kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)