### PR TITLE
feat(atyrode): legible clean summary footer

### DIFF
--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -472,13 +472,15 @@ pkgs.runCommand "check-atyrode-cli"
     ' <<<"$clean_json" >/dev/null \
       || { echo "clean --json summary wrong: $clean_json" >&2; exit 1; }
 
-    # clean folds nh's benign root-owned gcroots permission flood into a single
-    # summary line, but keeps genuine removals and real (non-permission) errors.
+    # clean folds nh's benign root-owned gcroots permission flood, keeps genuine
+    # removals and real (non-permission) errors, and resolves to a legible footer.
     export ATYRODE_NIX_STORE="$TMPDIR/bin/fake-gc"
     noise_out="$(ATYRODE_NH_NOISE=1 atyrode clean --keep 3 2>&1 >/dev/null)"
     unset ATYRODE_NIX_STORE
+    grep -qE 'atyrode: .*kept 3 generation' <<<"$noise_out" \
+      || { echo "clean must print a legible summary footer: $noise_out" >&2; exit 1; }
     grep -qF 'skipped 2 root-owned GC root(s)' <<<"$noise_out" \
-      || { echo "clean must summarize skipped gcroots: $noise_out" >&2; exit 1; }
+      || { echo "footer must tally skipped gcroots: $noise_out" >&2; exit 1; }
     grep -qF 'gcroots/auto/lvi04m7mn76' <<<"$noise_out" \
       && { echo 'clean must not print individual gcroots permission failures' >&2; exit 1; }
     grep -qF 'profile-9-link' <<<"$noise_out" \

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -906,6 +906,10 @@ collect_garbage() {
   wait "$pid" || rc=$?
   printf '\r\033[K' >&2
   if [[ "$rc" == 0 ]]; then
+    # Expose the reclaimed size (e.g. "210.5 MiB") to the clean footer; empty if
+    # the collector reported no figure. _gc_freed is a global by design.
+    _gc_freed="$(grep -oiE '[0-9.]+ [kmgtp]?i?b freed' "$out" | tail -n1 || true)"
+    _gc_freed="${_gc_freed% freed}"
     printf 'atyrode: %s\n' "$(grep -iE 'freed|deleted' "$out" | tail -n1 || echo 'store collected')" >&2
   else
     cat "$out" >&2
@@ -919,21 +923,53 @@ collect_garbage() {
 # GC roots are owned by the Nix daemon/root, so a user-scope clean cannot unlink
 # them — but that is harmless, the store GC still reclaims whatever they no longer
 # protect. nh prints one such line per root, which drowns the real work and reads
-# like a crash. Here we count them and emit a single summary instead; every other
-# line — generation removals, genuine errors, non-permission failures — passes
-# through untouched (a "> Removing …/gcroots/auto/…" line is held one step so its
-# paired permission failure can suppress it, and flushed if no failure follows).
+# like a crash. Here we suppress them and write the count to the file named by the
+# first argument, so cmd_clean can report the tally once in its summary footer;
+# every other line — generation removals, genuine errors, non-permission failures
+# — passes through untouched (a "> Removing …/gcroots/auto/…" line is held one
+# step so its paired permission failure can suppress it, flushed if none follows).
 fold_gcroots_noise() {
-  awk '
+  local count_file="${1:-/dev/null}"
+  awk -v countfile="$count_file" '
     /^> Removing .*\/gcroots\/auto\// { if (pending != "") print pending; pending = $0; next }
     /Failed to remove path.*\/gcroots\/auto\/.*PermissionDenied/ { skipped++; pending = ""; next }
     { if (pending != "") { print pending; pending = "" } print }
     END {
       if (pending != "") print pending
-      if (skipped > 0)
-        printf "atyrode: skipped %d root-owned GC root(s) under /nix/var/nix/gcroots/auto (owned by the Nix daemon, need elevation to remove — harmless: the store GC still reclaims what they no longer protect)\n", skipped
+      print skipped + 0 > countfile
     }
   '
+}
+
+# count_generations reports how many generations the tracked profile has (0 when
+# it cannot be read) so the clean footer can show kept/removed counts.
+count_generations() {
+  local profile; profile="$(gen_profile)"
+  [[ -e "$profile" ]] || { printf 0; return; }
+  nix_env -p "$profile" --list-generations 2>/dev/null | grep -c . || true
+}
+
+# clean_footer resolves the wall of nh/gc output into one human-readable result
+# line: what was reclaimed, kept, and removed, plus how many root-owned GC roots
+# had to be skipped (daemon-owned; reaping them needs elevation — see #148).
+clean_footer() {
+  local dry="$1" before="$2" after="$3" skipped="$4" freed="$5"
+  local removed=0
+  [[ "$before" -gt "$after" ]] && removed=$(( before - after ))
+  local -a parts=()
+  if [[ "$dry" == 1 ]]; then
+    parts+=("dry-run — no changes made" "$before generation(s) present")
+  else
+    [[ -z "$freed" ]] || parts+=("reclaimed $freed")
+    parts+=("kept $after generation(s)" "removed $removed")
+  fi
+  [[ "${skipped:-0}" -gt 0 ]] &&
+    parts+=("skipped $skipped root-owned GC root(s) (daemon-owned, harmless; run with elevation to reap)")
+  local out="" p
+  for p in "${parts[@]}"; do
+    [[ -z "$out" ]] && out="$p" || out="$out · $p"
+  done
+  printf 'atyrode: %s\n' "$out" >&2
 }
 
 # clean — reclaim disk from generations the config no longer references, always
@@ -965,15 +1001,23 @@ cmd_clean() {
   # own chatter (and the folded gcroots summary) goes to stderr so that under
   # --json stdout carries only the machine-readable summary; pipefail propagates
   # nh's exit status through the filter.
+  local gens_before; gens_before="$(count_generations)"
   local nh_args=("$nh_command" clean "$scope" --keep "$keep" --keep-since "$keep_since" --no-gc)
   [[ "$dry" == 0 ]] || nh_args+=(--dry)
-  "${nh_args[@]}" 2>&1 | fold_gcroots_noise >&2 || die "$EX_SOFTWARE" "nh clean failed"
+  local skipped_file; skipped_file="$(mktemp)"
+  "${nh_args[@]}" 2>&1 | fold_gcroots_noise "$skipped_file" >&2 || die "$EX_SOFTWARE" "nh clean failed"
+  local skipped; skipped="$(cat "$skipped_file" 2>/dev/null || echo 0)"
+  rm -f "$skipped_file"
 
+  _gc_freed=""
   [[ "$dry" == 1 ]] || collect_garbage
 
   if [[ "$(uname -s)" == Darwin ]]; then
     clean_macos_residue "$dry" "$assume_yes"
   fi
+
+  local gens_after; gens_after="$(count_generations)"
+  clean_footer "$dry" "$gens_before" "$gens_after" "$skipped" "$_gc_freed"
 
   [[ "$json" == 0 ]] || clean_summary_json "$scope" "$keep" "$keep_since" "$dry"
 }


### PR DESCRIPTION
Closes part of #148 (the summary-footer criteria; elevation/reap path stays open there).

## Problem

`atyrode clean` left "what did this actually do?" unanswered — its output conflates **kept** vs **removed** generations (nh's `- OK` reads like "cleaned" but means "retained"), and before #147 it flooded with root-owned gcroots noise. Users saw a wall of paths and ~200 MB reclaimed with no clear tally.

## Fix

Resolve every run into one footer line:

```
atyrode: reclaimed 210 MiB · kept 5 generation(s) · removed 3 · skipped 124 root-owned GC root(s) (daemon-owned, harmless; run with elevation to reap)
```

- `fold_gcroots_noise` now writes its suppressed-root **count to a file** instead of printing a mid-stream line — the tally is reported once, in the footer (no more redundancy between the fold line and the summary).
- `count_generations` diffs the profile's generation count before/after → **kept** and **removed**.
- `collect_garbage` exposes the **reclaimed size** to the footer.
- **dry-run** shows a no-change preview (`dry-run — no changes made · N generation(s) present`) instead of fabricated kept/removed numbers.

## Deferred (still open in #148)

- Confirmed `--all`/elevation path to actually **reap** the root-owned auto-gcroots so the generation backlog (52 observed) can collect. That's a privileged operation and warrants its own careful change.

## Test

`atyrode-cli` check asserts the footer (`kept 3 generation…`), the skipped tally in the footer, and that the fold still suppresses individual permission lines while keeping genuine removals and real non-permission errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)