### PR TITLE
feat(code): add OMP auth profile switching

### DIFF
--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -125,6 +125,8 @@ in
         done
         ${pkgs.omp-configured}/bin/code --help > "$TMPDIR/code-help.txt"
         grep -q 'build an OMP profile from a prompt' "$TMPDIR/code-help.txt"
+        grep -q 'a switches the' "$TMPDIR/code-help.txt"
+        grep -q 'visible OMP auth combination' "$TMPDIR/code-help.txt"
         ! grep -q 'pick an OMP launcher' "$TMPDIR/code-help.txt"
         test ! -e ${pkgs.omp-configured}/bin/pi
         test "$(

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -111,15 +111,30 @@ model routing — model names coloured by provider (blue/orange) and brightness
 scaled by thinking level — above the `omp usage` panel (per-window `N% used`
 with green→red gradient bars, `free` on an idle bucket and `tight` at ≥80%).
 
+The usage widget also shows the active authentication combination. Press **`a`**
+to switch between `mine` (**Claude Alex + Codex Alex**) and `mum`
+(**Claude Mum + Codex Alex**); the selection is persisted under the XDG state
+directory and is reused on the next launch. Usage is fetched from the selected
+OMP profile. Both the bare and generated trusted launch paths receive that same
+`--profile`; the `u` sandbox remains on its fixed, credential-sanitized
+`untrusted` profile.
+
+OMP profiles isolate their complete state, including every provider credential.
+Consequently the `mum` profile must authenticate both providers independently:
+open `omp --profile mum`, run `/login anthropic` with Mum's Claude identity, and
+run `/login openai-codex` with Alex's Codex identity. The existing `default`
+profile is the `mine` combination and remains the initial selection.
+
 There are three ways to leave the TUI:
 
-- **Enter with nothing changed** (no prompt, default dials) runs your default
-  `omp` — you didn't ask for anything special, so it launches your normal
-  session.
-- **Enter after typing a prompt or moving a dial** generates a managed profile
-  and launches it through `omp-managed` as a one-shot `--config`, forwarding the
-  typed prompt as the session's first message.
-- **`u`** opens the untrusted sandbox (`ompu`) for the current context.
+- **Enter with nothing changed** (no prompt, default dials) runs bare `omp`
+  inside the selected authentication profile — you didn't ask for special
+  routing, so it launches your normal session with the visible identity pair.
+- **Enter after typing a prompt or moving a dial** generates a managed routing
+  profile and launches it through `omp-managed` as a one-shot `--config`, with
+  the selected authentication profile and typed prompt carried into the session.
+- **`u`** opens the untrusted sandbox (`ompu`) for the current context; it never
+  inherits the selected personal authentication profile.
 
 `code --no-usage` (`-U`) skips the usage fetch, and `code --help` (`-h`) prints
 help. The full facet grid of profiles is enumerated at package build time by

--- a/modules/home/agent-tools.nix
+++ b/modules/home/agent-tools.nix
@@ -32,6 +32,25 @@ let
   policyConfig = ../../omp/policy.yml;
   untrustedConfig = ../../omp/untrusted.yml;
 
+  # Each OMP profile is a complete auth/state root. The second profile repeats
+  # the operator's Codex identity deliberately: OMP cannot share one provider's
+  # OAuth record across otherwise-isolated profiles, so both combinations are
+  # named explicitly in `code` and authenticated independently.
+  codeAuthProfiles = [
+    {
+      id = "default";
+      label = "mine";
+      claude = "Alex";
+      codex = "Alex";
+    }
+    {
+      id = "mum";
+      label = "mum";
+      claude = "Mum";
+      codex = "Alex";
+    }
+  ];
+
 in
 {
   options.atyrode.agentTools = {
@@ -111,6 +130,8 @@ in
           cfg.ompPackage
         ]
         ++ lib.optional cfg.seedPlainConfig cfg.seedPackage;
+
+        home.sessionVariables.CODE_AUTH_PROFILES = builtins.toJSON codeAuthProfiles;
 
         xdg.configFile = {
           "omp/defaults.yml".source = defaultsConfig;

--- a/pkgs/code-tui/auth.go
+++ b/pkgs/code-tui/auth.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// authProfile describes one complete OMP state root. OMP profiles isolate all
+// provider credentials, so the UI names both sides of the combination rather
+// than implying that only the Claude account changes.
+type authProfile struct {
+	ID     string `json:"id"`
+	Label  string `json:"label"`
+	Claude string `json:"claude"`
+	Codex  string `json:"codex"`
+}
+
+var validAuthProfileID = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+
+func parseAuthProfiles(raw string) []authProfile {
+	var profiles []authProfile
+	if raw != "" {
+		_ = json.Unmarshal([]byte(raw), &profiles)
+	}
+	valid := profiles[:0]
+	seen := map[string]bool{}
+	for _, p := range profiles {
+		p.ID = strings.TrimSpace(p.ID)
+		p.Label = strings.TrimSpace(p.Label)
+		p.Claude = strings.TrimSpace(p.Claude)
+		p.Codex = strings.TrimSpace(p.Codex)
+		if !validAuthProfileID.MatchString(p.ID) || p.ID == "." || p.ID == ".." || strings.HasSuffix(p.ID, ".") || seen[p.ID] {
+			continue
+		}
+		if p.Label == "" {
+			p.Label = p.ID
+		}
+		if p.Claude == "" {
+			p.Claude = p.Label
+		}
+		if p.Codex == "" {
+			p.Codex = p.Label
+		}
+		seen[p.ID] = true
+		valid = append(valid, p)
+	}
+	if len(valid) == 0 {
+		return []authProfile{{ID: "default", Label: "default", Claude: "current", Codex: "current"}}
+	}
+	return valid
+}
+
+func selectedAuthIndex(profiles []authProfile, statePath string) int {
+	if statePath == "" {
+		return 0
+	}
+	b, err := os.ReadFile(statePath)
+	if err != nil {
+		return 0
+	}
+	selected := strings.TrimSpace(string(b))
+	for i, p := range profiles {
+		if p.ID == selected {
+			return i
+		}
+	}
+	return 0
+}
+
+// persistAuthProfile commits the selection atomically. The mode is deliberately
+// private even though the profile name is not a secret: it is mutable auth state
+// and should not become a shared coordination surface on multi-user machines.
+func persistAuthProfile(statePath, id string) error {
+	if statePath == "" {
+		return nil
+	}
+	dir := filepath.Dir(statePath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".code-auth-profile-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := fmt.Fprintln(tmp, id); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, statePath)
+}
+
+// withOMPProfile puts the global flag before the subcommand/forwarded arguments,
+// which works for both `omp usage --json` and interactive launches.
+func withOMPProfile(profile string, args ...string) []string {
+	if profile == "" {
+		return append([]string(nil), args...)
+	}
+	out := make([]string, 0, len(args)+2)
+	out = append(out, "--profile", profile)
+	return append(out, args...)
+}
+
+func (m model) activeAuthProfile() authProfile {
+	if m.authIdx >= 0 && m.authIdx < len(m.authProfiles) {
+		return m.authProfiles[m.authIdx]
+	}
+	return authProfile{ID: "default", Label: "default", Claude: "current", Codex: "current"}
+}
+
+func (m *model) switchAuthProfile() error {
+	if len(m.authProfiles) < 2 {
+		return nil
+	}
+	next := (m.authIdx + 1) % len(m.authProfiles)
+	if err := persistAuthProfile(m.authState, m.authProfiles[next].ID); err != nil {
+		return err
+	}
+	m.authIdx = next
+	m.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
+	m.nextRefresh = time.Time{}
+	return nil
+}

--- a/pkgs/code-tui/auth_test.go
+++ b/pkgs/code-tui/auth_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseAuthProfiles(t *testing.T) {
+	got := parseAuthProfiles(`[
+		{"id":"default","label":"mine","claude":"Alex","codex":"Alex"},
+		{"id":"mum","label":"mum","claude":"Mum","codex":"Alex"},
+		{"id":"../bad","label":"bad"},
+		{"id":"mum","label":"duplicate"}
+	]`)
+	want := []authProfile{
+		{ID: "default", Label: "mine", Claude: "Alex", Codex: "Alex"},
+		{ID: "mum", Label: "mum", Claude: "Mum", Codex: "Alex"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("profiles = %#v, want %#v", got, want)
+	}
+}
+
+func TestAuthProfileSelectionPersists(t *testing.T) {
+	state := filepath.Join(t.TempDir(), "nested", "selected")
+	profiles := []authProfile{{ID: "default"}, {ID: "mum"}}
+	m := model{
+		authProfiles: profiles,
+		authState:    state,
+		avail:        availability{bucket: map[string]string{"claude-main": "ok"}},
+	}
+	if err := m.switchAuthProfile(); err != nil {
+		t.Fatal(err)
+	}
+	if m.activeAuthProfile().ID != "mum" {
+		t.Fatalf("active profile = %q, want mum", m.activeAuthProfile().ID)
+	}
+	if selectedAuthIndex(profiles, state) != 1 {
+		t.Fatal("persisted selection was not restored")
+	}
+	if m.avail.ok || len(m.avail.bucket) != 0 {
+		t.Fatalf("usage was not cleared after switch: %#v", m.avail)
+	}
+	info, err := os.Stat(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("state mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestLoadAvailabilityUsesSelectedProfile(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	script := filepath.Join(dir, "usage")
+	body := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$ARGS_PATH\"\nprintf '%s\\n' '{\"reports\":[]}'\n"
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ARGS_PATH", argsPath)
+	got := loadAvailability(script+" usage --json", "mum")
+	if !got.ok {
+		t.Fatal("usage response was not accepted")
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "--profile\nmum\nusage\n--json\n"; string(args) != want {
+		t.Fatalf("usage args = %q, want %q", args, want)
+	}
+}
+
+func TestUsagePanelNamesWholeAuthCombination(t *testing.T) {
+	m := model{
+		authProfiles: []authProfile{
+			{ID: "default", Label: "mine", Claude: "Alex", Codex: "Alex"},
+			{ID: "mum", Label: "mum", Claude: "Mum", Codex: "Alex"},
+		},
+		authIdx: 1,
+		avail:   availability{bucket: map[string]string{}, reset: map[string]int64{}},
+	}
+	panel := m.usagePanel()
+	for _, text := range []string{"auth", "mum", "Claude Mum", "Codex Alex", "switch"} {
+		if !strings.Contains(panel, text) {
+			t.Fatalf("usage panel missing %q: %q", text, panel)
+		}
+	}
+}
+
+func TestWithOMPProfilePrecedesForwardedArgs(t *testing.T) {
+	got := withOMPProfile("mum", "--config", "/tmp/generated.yml", "--resume")
+	want := []string{"--profile", "mum", "--config", "/tmp/generated.yml", "--resume"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -34,16 +34,16 @@ import (
 
 // ── keybindings (drive both input handling and the bubbles/help footer) ───────
 type keyMap struct {
-	Move, Change, Reset, Depth, Refresh, Collapse, Launch, Untrusted, Help, Quit key.Binding
+	Move, Change, Reset, Depth, Refresh, Auth, Collapse, Launch, Untrusted, Help, Quit key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Move, k.Change, k.Reset, k.Launch, k.Untrusted, k.Help, k.Quit}
+	return []key.Binding{k.Move, k.Change, k.Reset, k.Auth, k.Launch, k.Untrusted, k.Help, k.Quit}
 }
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Move, k.Change, k.Reset},
-		{k.Depth, k.Refresh, k.Collapse},
+		{k.Depth, k.Refresh, k.Auth, k.Collapse},
 		{k.Launch, k.Untrusted, k.Help, k.Quit},
 	}
 }
@@ -54,6 +54,7 @@ var keys = keyMap{
 	Reset:     key.NewBinding(key.WithKeys("d"), key.WithHelp("d", gReset+" defaults")),
 	Depth:     key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "primary ⇄ full chains")),
 	Refresh:   key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh usage")),
+	Auth:      key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "switch auth")),
 	Collapse:  key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "collapse")),
 	Launch:    key.NewBinding(key.WithKeys("enter"), key.WithHelp("⏎", "launch")),
 	Untrusted: key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "sandbox")),
@@ -223,13 +224,14 @@ type availability struct {
 	ok     bool
 }
 
-func loadAvailability(cmd string) availability {
+func loadAvailability(cmd, profile string) availability {
 	a := availability{bucket: map[string]string{}, reset: map[string]int64{}}
 	if cmd == "" {
 		return a
 	}
 	parts := strings.Fields(cmd)
-	out, err := exec.Command(parts[0], parts[1:]...).Output()
+	args := withOMPProfile(profile, parts[1:]...)
+	out, err := exec.Command(parts[0], args...).Output()
 	if err != nil || len(out) == 0 {
 		return a
 	}
@@ -958,6 +960,11 @@ type model struct {
 	rdy      bool
 	usageCmd string
 
+	authProfiles []authProfile
+	authIdx      int
+	authState    string
+	authErr      string
+
 	fetching    bool      // a usage fetch is in flight (manual or auto)
 	nextRefresh time.Time // when the next auto-refresh fires
 
@@ -978,21 +985,26 @@ func tickCmd() tea.Cmd {
 }
 
 // usageMsg carries availability fetched off the main thread so startup never
-// blocks on `omp usage --json` (a network call).
-type usageMsg availability
+// blocks on `omp --profile <id> usage --json` (a network call). The profile ID
+// travels with the result so a slow response from the old profile cannot replace
+// the newly selected profile's usage after an auth switch.
+type usageMsg struct {
+	profile string
+	avail   availability
+}
 
-func fetchUsageCmd(cmd string) tea.Cmd {
+func fetchUsageCmd(cmd, profile string) tea.Cmd {
 	if cmd == "" {
 		return nil
 	}
-	return func() tea.Msg { return usageMsg(loadAvailability(cmd)) }
+	return func() tea.Msg { return usageMsg{profile: profile, avail: loadAvailability(cmd, profile)} }
 }
 
 func (m model) Init() tea.Cmd {
 	if m.usageCmd == "" {
 		return nil
 	}
-	return tea.Batch(fetchUsageCmd(m.usageCmd), m.spin.Tick, tickCmd())
+	return tea.Batch(fetchUsageCmd(m.usageCmd, m.activeAuthProfile().ID), m.spin.Tick, tickCmd())
 }
 
 func (m model) listW() int {
@@ -1077,15 +1089,36 @@ func (m *model) refreshLine() string {
 		lipgloss.NewStyle().Foreground(lipgloss.Color(cHead)).Render("r") + stDim.Render(" now")
 }
 
+func (m *model) authLine() string {
+	p := m.activeAuthProfile()
+	label := lipgloss.NewStyle().Foreground(lipgloss.Color(cGreen)).Bold(true).Render(p.Label)
+	claude := lipgloss.NewStyle().Foreground(lipgloss.Color("#ff9f52")).Render("Claude " + p.Claude)
+	codex := lipgloss.NewStyle().Foreground(lipgloss.Color("#62a7ff")).Render("Codex " + p.Codex)
+	line := stDim.Render("   auth · ") + label + stDim.Render("  ") + claude + stDim.Render(" + ") + codex
+	if len(m.authProfiles) > 1 {
+		line += stDim.Render("  ·  ") + lipgloss.NewStyle().Foreground(lipgloss.Color(cHead)).Render("a") + stDim.Render(" switch")
+	}
+	if m.authErr != "" {
+		line += "\n" + stBrk.Render("  profile switch failed: "+m.authErr)
+	}
+	return line
+}
+
 func (m *model) usagePanel() string {
+	auth := m.authLine()
 	if !m.avail.ok {
-		if m.usageCmd != "" {
-			return stDim.Render("  " + m.spin.View() + " fetching usage…")
+		if m.usageCmd == "" {
+			return auth
 		}
-		return ""
+		if m.fetching || m.nextRefresh.IsZero() {
+			return auth + "\n" + stDim.Render("  "+m.spin.View()+" fetching usage…")
+		}
+		p := m.activeAuthProfile()
+		return auth + "\n" + stWarn.Render("  usage unavailable · authenticate with omp --profile "+p.ID)
 	}
 	if len(m.avail.wins) == 0 {
-		return ""
+		p := m.activeAuthProfile()
+		return auth + "\n" + stWarn.Render("  no provider usage · authenticate with omp --profile "+p.ID)
 	}
 	wins := append([]usageWin(nil), m.avail.wins...)
 	provOrder := func(p string) int {
@@ -1133,7 +1166,7 @@ func (m *model) usagePanel() string {
 		for _, p := range order {
 			cols = append(cols, lipgloss.NewStyle().Width(colW).Render(strings.Join(blocks[p], "\n")))
 		}
-		return m.refreshLine() + "\n" + lipgloss.JoinHorizontal(lipgloss.Top, cols...)
+		return auth + "\n" + m.refreshLine() + "\n" + lipgloss.JoinHorizontal(lipgloss.Top, cols...)
 	}
 	var lines []string
 	for i, p := range order {
@@ -1142,7 +1175,7 @@ func (m *model) usagePanel() string {
 		}
 		lines = append(lines, blocks[p]...)
 	}
-	return m.refreshLine() + "\n" + strings.Join(lines, "\n")
+	return auth + "\n" + m.refreshLine() + "\n" + strings.Join(lines, "\n")
 }
 
 func (m *model) usageRow(w usageWin) string {
@@ -1243,7 +1276,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.w, m.h = msg.Width, msg.Height
 		m.relayout()
 	case usageMsg:
-		m.avail = availability(msg)
+		if msg.profile != m.activeAuthProfile().ID {
+			return m, nil
+		}
+		m.avail = msg.avail
 		m.fetching = false
 		m.nextRefresh = time.Now().Add(refreshEvery)
 		m.relayout()
@@ -1252,11 +1288,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds := []tea.Cmd{tickCmd()}
 		if !m.fetching && !m.nextRefresh.IsZero() && !time.Now().Before(m.nextRefresh) {
 			m.fetching = true
-			cmds = append(cmds, fetchUsageCmd(m.usageCmd))
+			cmds = append(cmds, fetchUsageCmd(m.usageCmd, m.activeAuthProfile().ID))
 		}
 		return m, tea.Batch(cmds...)
 	case spinner.TickMsg:
-		if !m.avail.ok {
+		if m.fetching || !m.avail.ok {
 			var cmd tea.Cmd
 			m.spin, cmd = m.spin.Update(msg)
 			return m, cmd
@@ -1287,7 +1323,21 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "r":
 			if m.usageCmd != "" && !m.fetching {
 				m.fetching = true
-				return m, fetchUsageCmd(m.usageCmd)
+				return m, fetchUsageCmd(m.usageCmd, m.activeAuthProfile().ID)
+			}
+		case "a":
+			if len(m.authProfiles) > 1 {
+				if err := m.switchAuthProfile(); err != nil {
+					m.authErr = err.Error()
+					m.relayout()
+					break
+				}
+				m.authErr = ""
+				m.fetching = m.usageCmd != ""
+				m.relayout()
+				if m.fetching {
+					return m, fetchUsageCmd(m.usageCmd, m.activeAuthProfile().ID)
+				}
 			}
 		case "up", "k":
 			m.moveUp()
@@ -1541,17 +1591,24 @@ func main() {
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
 	generated := loadBlocks(os.Getenv("CODE_GENERATED"))
+	authProfiles := parseAuthProfiles(os.Getenv("CODE_AUTH_PROFILES"))
+	authState := os.Getenv("CODE_AUTH_STATE")
+	authIdx := selectedAuthIndex(authProfiles, authState)
 	m := model{
-		generated: generated,
-		advisors:  parseAdvisors(generated["__advisors__"]),
-		facts:     parseFacts(generated["__models__"]),
-		avail:     availability{bucket: map[string]string{}, reset: map[string]int64{}},
-		usageCmd:  os.Getenv("CODE_USAGE"),
-		spin:      sp,
-		help:      help.New(),
-		glyphs:    glyphs,
-		facets:    facetDefs(glyphs),
-		sel:       defaultSel(),
+		generated:    generated,
+		advisors:     parseAdvisors(generated["__advisors__"]),
+		facts:        parseFacts(generated["__models__"]),
+		avail:        availability{bucket: map[string]string{}, reset: map[string]int64{}},
+		usageCmd:     os.Getenv("CODE_USAGE"),
+		authProfiles: authProfiles,
+		authIdx:      authIdx,
+		authState:    authState,
+		fetching:     os.Getenv("CODE_USAGE") != "",
+		spin:         sp,
+		help:         help.New(),
+		glyphs:       glyphs,
+		facets:       facetDefs(glyphs),
+		sel:          defaultSel(),
 	}
 	// No mouse capture: with mouse reporting on, the terminal routes every mouse
 	// event (right-click, selection, paste) to the app, breaking native terminal
@@ -1562,23 +1619,25 @@ func main() {
 		os.Exit(1)
 	}
 	fm, _ := final.(model)
+	profile := fm.activeAuthProfile().ID
 	switch {
 	case fm.launchUntrusted:
-		// The untrusted sandbox owns its own routing/policy — no generated --config.
-		execForward("CODE_OMP_UNTRUSTED", "ompu", fm.firstPrompt)
+		// The sandbox owns the fixed `untrusted` profile and must never inherit the
+		// selected personal auth state.
+		execForward("CODE_OMP_UNTRUSTED", "ompu", fm.firstPrompt, "")
 	case fm.launchDefault:
-		// Nothing was generated — just run the user's bare default omp.
-		execForward("CODE_OMP_DEFAULT", "omp", fm.firstPrompt)
+		// Nothing was generated — run bare omp inside the selected auth profile.
+		execForward("CODE_OMP_DEFAULT", "omp", fm.firstPrompt, profile)
 	case fm.genConfig != "":
-		launchGenerated(fm.genConfig, fm.firstPrompt)
+		launchGenerated(fm.genConfig, fm.firstPrompt, profile)
 	}
 }
 
 // execForward execs the launcher named by env (falling back to a bare command
 // name on PATH), forwarding this process's args plus, when non-empty, the typed
-// prompt as a trailing first message. Used for the bare-omp default and the
-// untrusted sandbox launches — neither takes a generated --config.
-func execForward(env, fallback, prompt string) {
+// prompt as a trailing first message. The selected OMP profile is inserted before
+// forwarded arguments; an empty profile is reserved for the fixed ompu sandbox.
+func execForward(env, fallback, prompt, profile string) {
 	cmd := os.Getenv(env)
 	if cmd == "" {
 		cmd = fallback
@@ -1588,7 +1647,7 @@ func execForward(env, fallback, prompt string) {
 		fmt.Fprintln(os.Stderr, "code: not found:", err)
 		os.Exit(1)
 	}
-	args := append([]string{path}, os.Args[1:]...)
+	args := append([]string{path}, withOMPProfile(profile, os.Args[1:]...)...)
 	if prompt != "" { // forward the suggest-box prompt as the first message
 		args = append(args, prompt)
 	}
@@ -1603,7 +1662,7 @@ func execForward(env, fallback, prompt string) {
 // supplies the platform extensions, managed defaults, and policy (and caps the
 // overlay), so we must NOT re-layer defaults/policy here — doing so both
 // double-applies them and breaks when their paths aren't valid from the cwd.
-func launchGenerated(cfg, prompt string) {
+func launchGenerated(cfg, prompt, profile string) {
 	tmp, err := os.CreateTemp("", "code-gen-*.yml")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "code:", err)
@@ -1620,7 +1679,8 @@ func launchGenerated(cfg, prompt string) {
 		fmt.Fprintln(os.Stderr, "code: omp not found:", err)
 		os.Exit(1)
 	}
-	args := append([]string{path, "--config", tmp.Name()}, os.Args[1:]...)
+	args := append([]string{path}, withOMPProfile(profile, "--config", tmp.Name())...)
+	args = append(args, os.Args[1:]...)
 	if prompt != "" { // forward the suggest-box prompt as omp's first message
 		args = append(args, prompt)
 	}

--- a/pkgs/omp-configured/README.md
+++ b/pkgs/omp-configured/README.md
@@ -8,12 +8,15 @@ profile from a prompt (or a few dials) and launches it, with a per-provider usag
 
 - **`code`** — the profile generator (Bubble Tea TUI). Type a prompt and/or adjust the
   facet dials (lane, model tier, thinking, spark, fable); a local prompt→profile classifier
-  (running on the resident ollama daemon) suggests settings. **Enter** launches:
-  - with nothing changed → your **default `omp`** ("run my normal omp");
-  - after a prompt or a dial change → the **generated** profile, layered over the managed
-    defaults and policy.
+  (running on the resident ollama daemon) suggests settings. The usage widget
+  names the active OMP authentication combination; **`a`** switches it and
+  refreshes usage from that profile. **Enter** launches:
+  - with nothing changed → bare `omp` in the selected auth profile;
+  - after a prompt or a dial change → the **generated** routing profile, layered over the
+    managed defaults and policy, in that same auth profile.
 
-  Press **`u`** to open the untrusted sandbox for the current directory, `?` for all keys.
+  Press **`u`** to open the fixed untrusted sandbox for the current directory,
+  or `?` for all keys.
 - **`omp`** — passthrough to your own **unmanaged** `~/.omp` config (the one mutable base;
   `omp update` is blocked since the package is Nix-managed).
 - **`omp-managed`** — the managed-layering primitive: platform extensions + managed defaults
@@ -38,9 +41,14 @@ That puts `code`, `omp`, `omp-managed`, and `ompu` on your PATH. It's self-conta
 
 - The managed config (`defaults.yml`, `policy.yml`, `untrusted.yml`) and the generated
   routing grid are **baked into the package**.
-- Your bare `omp` keeps using your `~/.omp` config unchanged.
-- The usage panel prefers a private collector snapshot (`$TYRODE_MODEL_USAGE_SNAPSHOT`) and
-  **falls back to `omp usage`** when it's absent, so it works anywhere.
+- Your bare `omp` configuration remains mutable; `code` only selects its OMP
+  state root at launch time.
+- The wrapper accepts `CODE_AUTH_PROFILES` as a JSON array of `{id, label,
+  claude, codex}` objects. Without an override it exposes only OMP's `default`
+  profile, keeping the standalone package neutral; the dotfiles' Home Manager
+  module supplies the operator's named combinations.
+- Every usage fetch runs against the selected profile, so the displayed quota
+  and the profile used for the subsequent launch cannot diverge.
 
 ## How the managed layering stays reliable
 

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1168,12 +1168,30 @@ let
       export CODE_OMP_DEFAULT="$omp_bin"
       export CODE_OMP_UNTRUSTED=${lib.getExe ompUntrusted}
       export CODE_USAGE="$omp_bin usage --json"
+      if [[ ! -v CODE_AUTH_PROFILES ]]; then
+        export CODE_AUTH_PROFILES=${
+          lib.escapeShellArg (
+            builtins.toJSON [
+              {
+                id = "default";
+                label = "default";
+                claude = "current";
+                codex = "current";
+              }
+            ]
+          )
+        }
+      fi
+      export CODE_AUTH_STATE="''${CODE_AUTH_STATE:-''${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/code-auth-profile}"
       # The generator's prompt→profile classifier runs on the resident,
       # nix-managed ollama daemon (loopback HTTP, no auth) — see services.ollama
       # in the host config. CODE_OLLAMA_ENDPOINT / CODE_EVAL_MODEL override the
-      # daemon/model. Launch targets: ↵ with no changes runs your default omp
-      # (CODE_OMP_DEFAULT); a generated profile runs through the managed layering
-      # (CODE_OMP); `u` opens the untrusted sandbox (CODE_OMP_UNTRUSTED).
+      # daemon/model. The Bubble Tea usage widget owns the active OMP auth profile:
+      # `a` switches it, usage is fetched from that profile, and every trusted launch
+      # receives the same --profile. Launch targets: ↵ with no changes runs your
+      # selected bare omp (CODE_OMP_DEFAULT); a generated profile runs through the
+      # managed layering (CODE_OMP); `u` opens the fixed untrusted sandbox
+      # (CODE_OMP_UNTRUSTED).
 
       usage() {
         printf '%s\n' \
@@ -1185,9 +1203,10 @@ let
           '  code -U, --no-usage  open without fetching the usage panel' \
           '  code -h, --help      this help' \
           "" \
-          'In the generator: type a prompt or adjust the dials, ? shows all' \
-          'keys, Enter launches (your default omp if nothing was changed,' \
-          'the generated profile otherwise), u opens an untrusted sandbox.'
+          'In the generator: type a prompt or adjust the dials, a switches the' \
+          'visible OMP auth combination, ? shows all keys, Enter launches (your' \
+          'selected bare omp if nothing was changed, the generated profile' \
+          'otherwise), and u opens an untrusted sandbox.'
       }
 
       case "''${1:-}" in


### PR DESCRIPTION
## Context
`code` needs to select between two complete OMP credential combinations before launch, while making the active Claude/Codex identities unambiguous in the Bubble Tea usage widget.

## Solution
- configure `mine` (Claude Alex + Codex Alex) and `mum` (Claude Mum + Codex Alex) as isolated OMP profiles
- show the active combination in the usage widget and persist `a`-key switching in XDG state
- fetch usage and launch bare/generated OMP with the same selected `--profile`; keep `ompu` on its fixed sanitized profile
- cover profile parsing, persistence, profiled usage invocation, UI labeling, and launch argument ordering

## How to test
- `nix build --no-link --print-build-logs .#code-tui`
- `nix build --no-link --print-build-logs .#checks.x86_64-linux.omp-stack`
- `nix build --no-link --print-build-logs .#checks.x86_64-linux.home-evaluation`
- `nix build --no-link --print-build-logs .#checks.x86_64-linux.go-fmt .#checks.x86_64-linux.nixfmt`
- `nix build --no-link --print-build-logs .#checks.x86_64-linux.docs-links`