### PR TITLE
fix(code): load auth profiles from managed config

### DIFF
--- a/modules/home/agent-tools.nix
+++ b/modules/home/agent-tools.nix
@@ -131,12 +131,11 @@ in
         ]
         ++ lib.optional cfg.seedPlainConfig cfg.seedPackage;
 
-        home.sessionVariables.CODE_AUTH_PROFILES = builtins.toJSON codeAuthProfiles;
-
         xdg.configFile = {
           "omp/defaults.yml".source = defaultsConfig;
           "omp/policy.yml".source = policyConfig;
           "omp/untrusted.yml".source = untrustedConfig;
+          "atyrode/code-auth-profiles.json".text = builtins.toJSON codeAuthProfiles;
         };
 
         home.file = {

--- a/pkgs/omp-configured/README.md
+++ b/pkgs/omp-configured/README.md
@@ -43,10 +43,11 @@ That puts `code`, `omp`, `omp-managed`, and `ompu` on your PATH. It's self-conta
   routing grid are **baked into the package**.
 - Your bare `omp` configuration remains mutable; `code` only selects its OMP
   state root at launch time.
-- The wrapper accepts `CODE_AUTH_PROFILES` as a JSON array of `{id, label,
-  claude, codex}` objects. Without an override it exposes only OMP's `default`
-  profile, keeping the standalone package neutral; the dotfiles' Home Manager
-  module supplies the operator's named combinations.
+- The wrapper reads named combinations from
+  `$XDG_CONFIG_HOME/atyrode/code-auth-profiles.json`; `CODE_AUTH_PROFILES` can
+  override that file with a JSON array of `{id, label, claude, codex}` objects.
+  Without either source it exposes only OMP's `default` profile, keeping the
+  standalone package neutral. The dotfiles' Home Manager module owns the file.
 - Every usage fetch runs against the selected profile, so the displayed quota
   and the profile used for the subsequent launch cannot diverge.
 

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1169,18 +1169,27 @@ let
       export CODE_OMP_UNTRUSTED=${lib.getExe ompUntrusted}
       export CODE_USAGE="$omp_bin usage --json"
       if [[ ! -v CODE_AUTH_PROFILES ]]; then
-        export CODE_AUTH_PROFILES=${
-          lib.escapeShellArg (
-            builtins.toJSON [
-              {
-                id = "default";
-                label = "default";
-                claude = "current";
-                codex = "current";
-              }
-            ]
-          )
-        }
+        auth_profiles_file="''${XDG_CONFIG_HOME:-$HOME/.config}/atyrode/code-auth-profiles.json"
+        if [[ -r "$auth_profiles_file" ]]; then
+          CODE_AUTH_PROFILES="$(cat "$auth_profiles_file")"
+        else
+          # shellcheck disable=SC2089
+          CODE_AUTH_PROFILES=${
+            lib.escapeShellArg (
+              builtins.toJSON [
+                {
+                  id = "default";
+                  label = "default";
+                  claude = "current";
+                  codex = "current";
+                }
+              ]
+            )
+          }
+        fi
+        # JSON quotes are data consumed by code-tui, not shell syntax.
+        # shellcheck disable=SC2090
+        export CODE_AUTH_PROFILES
       fi
       export CODE_AUTH_STATE="''${CODE_AUTH_STATE:-''${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/code-auth-profile}"
       # The generator's prompt→profile classifier runs on the resident,


### PR DESCRIPTION
## Context
The profile switch landed via a Home Manager session variable, which only reaches newly started shells. An already-open terminal would still see the standalone one-profile fallback after activation.

## Solution
Write the named combinations to an XDG config file and have the `code` wrapper read it on every launch. `CODE_AUTH_PROFILES` remains an explicit override and standalone installs still fall back to the neutral default profile.

## How to test
- `nix eval --raw '.#homeConfigurations.alex-x86_64-linux.config.xdg.configFile."atyrode/code-auth-profiles.json".text'`
- `nix build --no-link --print-build-logs .#omp-configured .#checks.x86_64-linux.home-evaluation .#checks.x86_64-linux.nixfmt .#checks.x86_64-linux.docs-links`