### PR TITLE
docs(adr): introduce architecture decision records

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,14 +19,14 @@ not in a checklist.
 | [agent-security.md](agent-security.md) | Trust tiers and the managed OMP policy for untrusted content |
 | [shell.md](shell.md) | The interactive shell surface (a launcher, not a dev environment) |
 | [codex-state.md](codex-state.md) | Codex mutable configuration and the one-time defaults seed |
+| [adr/](adr/README.md) | Architecture decision records — the *why* behind the conventions above |
+
+The topic docs above describe how each area works; the [ADRs](adr/README.md)
+record why the boundaries and conventions exist. When a doc explains a choice
+that had real alternatives, it links to the ADR rather than re-arguing it.
 
 ## Adding a machine
 
 Register the host in [`hosts/default.nix`](../hosts/default.nix) (see
 [hosts.md](hosts.md)), then follow [bootstrap.md](bootstrap.md). The
 documentation above is intended to be sufficient without chat history.
-
-## Not yet documented
-
-Architecture decision records (ADRs) for choices with meaningful alternatives or
-migration cost are still to be written — tracked in #15.

--- a/docs/adr/0001-capability-based-host-composition.md
+++ b/docs/adr/0001-capability-based-host-composition.md
@@ -1,0 +1,38 @@
+# ADR 0001: Capability-based host composition
+
+- Status: Accepted
+- Date: 2026-07-14
+
+## Context
+
+The repository configures several machines with overlapping but non-identical
+needs — a Linux development box, macOS laptops, and a headless server — across
+two platforms (NixOS/Home Manager and nix-darwin). The naive approach, one
+bespoke configuration file per host, duplicates shared setup and lets hosts
+drift apart silently. What each machine is *for* (does it run agents? is it a
+server? a desktop?) is the real axis of variation, not its hostname.
+
+## Decision
+
+Hosts are entries in a **registry** ([`hosts/default.nix`](../../hosts/default.nix))
+that declares each machine's identity, platform, and **capabilities** rather than
+its packages or modules directly. Configuration is composed from capability and
+profile modules ([`home/profiles/`](../../home/profiles/)); a host turns on the
+capabilities it needs (e.g. `agent-tools`, `desktop`, `server`) and inherits the
+modules and packages those capabilities own. The registry is the single source
+of host truth, and a public projection of it is committed so bootstrap can read
+host identity before Nix is available.
+
+See [hosts.md](../hosts.md) and [portable-profiles.md](../portable-profiles.md).
+
+## Consequences
+
+- Adding a machine is registering a host and selecting capabilities, not writing
+  a new configuration tree — the "Adding a machine" flow in the docs suffices.
+- Shared behavior lives in one capability module, so hosts cannot quietly drift;
+  a change to a capability reaches every host that declares it.
+- Capabilities are the seam for reuse: the capability modules are exported so
+  other Home Manager configurations can consume them (see ADR 0003 for how
+  packages attach to layers).
+- Checks assert the registry against its committed projection and against each
+  host's expected capabilities, so a mismatch fails CI rather than a machine.

--- a/docs/adr/0002-home-manager-primary-authority.md
+++ b/docs/adr/0002-home-manager-primary-authority.md
@@ -1,0 +1,34 @@
+# ADR 0002: Home Manager as primary authority; minimal system layer
+
+- Status: Accepted
+- Date: 2026-07-14
+
+## Context
+
+The configuration spans NixOS and macOS. macOS additionally has a system layer
+(nix-darwin) and a large ecosystem of GUI applications that Nix cannot always
+build or that ship as signed vendor bundles (Homebrew casks). A choice is forced:
+how much lives at the system level versus the per-user Home Manager level, and
+how are Homebrew-delivered apps kept declarative rather than hand-installed.
+
+## Decision
+
+**Home Manager is the primary authority** and owns the user environment on every
+platform — packages, dotfiles, shell, and agent tooling. The **system layer is
+kept minimal**: nix-darwin (and NixOS system config) own only what genuinely must
+be system-level (OS defaults, daemons, users). **Homebrew casks converge
+declaratively** — the set of casks is data the configuration owns and reconciles,
+not an imperative `brew install` history.
+
+See [system-boundary.md](../system-boundary.md).
+
+## Consequences
+
+- The same Home Manager modules and capability profiles work across Linux and
+  macOS, so most configuration is written once (ADR 0001).
+- macOS GUI apps that must come from Homebrew stay reproducible: the cask list is
+  reviewed and converged, and drift (a manually installed cask) is visible.
+- The system layer is small enough to reason about and re-create; it is not a
+  second, competing place for user configuration.
+- New machine setup is dominated by activating the Home Manager generation, not
+  by system provisioning (see [bootstrap.md](../bootstrap.md)).

--- a/docs/adr/0003-layered-package-ownership.md
+++ b/docs/adr/0003-layered-package-ownership.md
@@ -1,0 +1,37 @@
+# ADR 0003: Layered package ownership
+
+- Status: Accepted
+- Date: 2026-07-14
+
+## Context
+
+Packages arrive for different reasons and at different scopes: some belong on
+every machine, some only where a capability is active, some are specific to one
+host, and some are wanted only on demand for a single task. A single flat package
+list cannot express *why* a package is present or *where* it should appear, and it
+makes it impossible to check that a host has exactly what it should.
+
+## Decision
+
+Every package has **one owning layer**, and the layer determines its scope:
+
+- **global** — on every managed machine;
+- **capability** — present wherever a capability is active (e.g. `agent-tools`);
+- **project / host** — specific to a host or project;
+- **on-demand** — invoked transiently (e.g. via `nix run`), not installed.
+
+Ownership is recorded as data ([`inventory/packages.json`](../../inventory/packages.json))
+and checked, so a package cannot silently appear at the wrong scope.
+
+See [package-ownership.md](../package-ownership.md).
+
+## Consequences
+
+- The presence of any package is explainable by its owning layer; there is no
+  catch-all bucket.
+- Capability packages compose with capability-based host composition (ADR 0001):
+  turning a capability on brings its packages, off removes them.
+- A package-ownership check compares the declared inventory against what hosts
+  actually install, so drift fails CI.
+- On-demand tools stay out of the installed closure, keeping machines lean while
+  remaining one command away.

--- a/docs/adr/0004-agent-trust-tiers.md
+++ b/docs/adr/0004-agent-trust-tiers.md
@@ -1,0 +1,37 @@
+# ADR 0004: Agent trust tiers and sandboxed untrusted execution
+
+- Status: Accepted
+- Date: 2026-07-14
+
+## Context
+
+The machines run coding agents against repositories of varying provenance. A
+repository's contents — issue text, READMEs, code comments, tool output — are
+attacker-writable and can attempt prompt injection or exfiltration. Running every
+repository with the same credentials, tools, and approvals would let a hostile
+repository reach the operator's full authority. At the same time, the operator's
+own trusted work should not be slowed by sandbox friction.
+
+## Decision
+
+Agent execution is split into **trust tiers**. Trusted repositories run with the
+normal managed environment. **Untrusted repositories run in a dedicated sandbox**
+(the `ompu` launcher): stripped credentials, restricted tools and approval
+policy, and sanitized state, so a hostile repository cannot reach secrets or
+escalate. The **managed configuration layer is immutable** for the paths that
+enforce this posture (approvals, isolation, secrets) — a repository cannot edit
+its way out of the policy, at rest or in a live session. Non-operator repository
+content is treated as data to analyze, never as instructions to obey.
+
+See [agent-security.md](../agent-security.md) and [agent-tools.md](../agent-tools.md).
+
+## Consequences
+
+- A hostile repository is contained to a sandbox with no standing credentials;
+  the blast radius of a successful injection is bounded.
+- The trust decision is explicit (which tier a repository runs in), not implicit
+  in whichever directory the agent happened to open.
+- Because the enforcing config paths are Nix-owned and immutable, the guarantee
+  holds even if a session or a machine-local file is tampered with.
+- The sandbox is a launch *mode*, not a per-repository profile to curate, which
+  keeps the surface small (see ADR 0006).

--- a/docs/adr/0005-no-declarative-secret-manager.md
+++ b/docs/adr/0005-no-declarative-secret-manager.md
@@ -1,0 +1,35 @@
+# ADR 0005: No declarative secret manager until a concrete secret needs it
+
+- Status: Accepted
+- Date: 2026-07-14
+
+## Context
+
+Mature Nix dotfiles frequently adopt a declarative secret manager (agenix,
+sops-nix). It is tempting to add one for completeness. But a secret manager earns
+its complexity only when the repository must *deliver* a secret declaratively —
+an encrypted payload that Nix decrypts into a known path at activation. This
+repository currently has no such payload: agent credentials are owned by their
+tools (`~/.omp`, `~/.codex`) and never enter the Nix store, and the remaining
+secret-adjacent concern is Git credentials and commit signing.
+
+## Decision
+
+**Do not adopt agenix, sops-nix, or an equivalent yet.** Adding one now would be
+machinery without a payload to justify it. Instead: record the classes of secrets
+in play and their current owners, keep tool-owned credentials out of the store,
+and revisit a secret manager only when a concrete secret must be delivered
+declaratively. Git credential and signing bootstrap is tracked separately in #8.
+
+See [agent-security.md](../agent-security.md).
+
+## Consequences
+
+- No encryption tooling, key distribution, or `.age`/`.sops` files to maintain
+  until there is something for them to carry.
+- Tool credentials stay owned by the tools that created them; the configuration
+  never reads or copies them, which keeps them out of derivations and logs.
+- The trigger to revisit is explicit — "a concrete secret needs declarative
+  delivery" — so this is a recorded posture, not an oversight to be re-argued.
+- If that trigger arrives, this ADR is superseded by one that picks a tool
+  against the actual payload's threat model.

--- a/docs/adr/0006-managed-layering-over-profiles.md
+++ b/docs/adr/0006-managed-layering-over-profiles.md
@@ -1,0 +1,47 @@
+# ADR 0006: Managed layering and seeding over curated profiles
+
+- Status: Accepted
+- Date: 2026-07-14
+
+## Context
+
+Agent tools (OMP, Codex) can be configured two ways. One is a **curated matrix of
+switchable profiles**: many hand-tuned named presets the operator picks between,
+plus the machinery to switch, render, and browse them. The other is a **managed
+base layer** the tool always runs under, with configuration either generated
+on demand or seeded once. The repository originally built the first for both
+tools — an OMP preset-launcher matrix with a browsable wiki, and a Codex
+multi-profile switcher. In practice the switching was never used: a single
+sensible default plus the ability to synthesize a profile covered every case, and
+the curated matrices were pure maintenance burden and surface area.
+
+## Decision
+
+Deliver agent-tool configuration as an **immutable managed layer over the user's
+mutable base**, plus a **generator or a one-time seed** — not a curated set of
+switchable profiles.
+
+- **OMP**: the `code` tool generates a profile from a prompt (or dials) and
+  launches it through the zero-preset `omp-managed` layer; the hand-curated preset
+  launchers and the profiles wiki were removed (#151). This concerns *model
+  routing*. OMP's native `--profile` mechanism is retained for a distinct
+  purpose — **authentication and state isolation** (which account/credentials a
+  session uses, e.g. `mine` vs `mum`) — which the managed layer applies on top and
+  is not what was retired here.
+- **Codex**: runs vanilla against `~/.codex`; the curated defaults are a one-time
+  seed into `config.toml` (then user-owned), and the multi-profile switcher was
+  removed (#153).
+
+See [agent-tools.md](../agent-tools.md) and [codex-state.md](../codex-state.md).
+
+## Consequences
+
+- Far less surface to maintain and test: one managed layer and one generator/seed
+  per tool instead of a preset matrix and its switching, rendering, and browsing.
+- The managed layer stays immutable where it enforces policy (ADR 0004); the
+  configuration the operator actually edits is genuinely theirs (the seed applies
+  once, then never overwrites).
+- The model is uniform across tools — a plain CLI plus a managed layer — so there
+  is one mental model rather than two bespoke profile systems.
+- Curation moves from "pick a preset" to "generate what this task needs," which
+  matches how the tools are actually used.

--- a/docs/adr/0007-explicit-generation-cleanup.md
+++ b/docs/adr/0007-explicit-generation-cleanup.md
@@ -1,0 +1,43 @@
+# ADR 0007: Explicit, policy-driven generation and store cleanup
+
+- Status: Accepted
+- Date: 2026-07-14
+- Decision issue: `atyrode/dotfiles#21`
+
+## Context
+
+Home Manager generations, profile generations, build results, and GC roots
+accumulate independently, and garbage collection only frees paths once obsolete
+roots and generations are removed. Cleanup therefore needs a retention policy and
+safeguards. The tempting shortcuts are dangerous: garbage-collecting on every
+activation can wipe the rollback window a user depends on; raw
+`nix-collect-garbage` has no policy or protection; and granting broad
+trusted-user GC privileges widens the trust surface for a routine chore.
+
+## Decision
+
+Cleanup is **explicit and policy-driven**:
+
+- **`nh` is the human-facing backend** for generation inspection, diffs,
+  rollback, and cleanup; native `nix` commands are a fallback only for a tested
+  platform gap.
+- **`atyrode` owns the retention policy and safeguards**: it always keeps the
+  current generation and a rollback window, which are provably not selectable for
+  deletion.
+- **Cleanup never runs as a side effect of `atyrode apply`** — it is a separate,
+  dry-run-and-confirmation command.
+
+See [atyrode.md](../atyrode.md).
+
+## Consequences
+
+- `atyrode clean` cannot delete the current generation or the configured rollback
+  set; a test enforces this so the safety net cannot regress.
+- Activation never surprises the operator by reclaiming disk; disk pressure is
+  surfaced by diagnostics, not resolved by silent deletion.
+- `atyrode clean` splits garbage collection out of `nh` (`--no-gc`) and runs it
+  itself with a progress indicator and a legible summary (reclaimed / kept /
+  removed), so the slow final phase is not an unexplained freeze.
+- Cleanup work the operator cannot do without elevation — such as reaping
+  root-owned auto GC roots — is reported honestly (a folded summary line) rather
+  than hidden or dressed up as an error.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,41 @@
+# Architecture decision records
+
+ADRs record the **why** behind this repository's durable conventions and
+boundaries — the choices that had meaningful alternatives or migration cost.
+They are not a changelog (Git already preserves history) and not a how-to (the
+topic docs under [`docs/`](../README.md) cover operation). An ADR is short: the
+context that forced a choice, the decision, and its consequences.
+
+Where truth lives, in order:
+
+1. **Git configuration and Nix modules** state what the system should be.
+2. **ADRs (here)** state why the conventions and boundaries exist.
+3. **Topic docs** ([`docs/*.md`](../README.md)) state how each area works.
+4. **Issues and PRs** record execution and evidence.
+
+## When to write one
+
+Write an ADR when a choice sets or moves a durable boundary — a new ownership
+layer, a tool adopted or deliberately declined, a subsystem's model changing, or
+a posture (like "not yet") worth recording so it is not re-litigated. Skip it for
+routine fixes, mechanical refactors, or anything Git history already explains.
+
+## Format
+
+One file per decision: `docs/adr/NNNN-kebab-title.md`, numbered in order. Each
+carries `Status` (Accepted / Proposed / Superseded), `Date`, an optional linked
+decision issue, and `## Context` / `## Decision` / `## Consequences`. A superseded
+ADR stays in place with a pointer to the one that replaced it. Numbering is local
+to this repository.
+
+## Records
+
+| ADR | Decision |
+| --- | --- |
+| [0001](0001-capability-based-host-composition.md) | Capability-based host composition |
+| [0002](0002-home-manager-primary-authority.md) | Home Manager as primary authority; minimal system layer |
+| [0003](0003-layered-package-ownership.md) | Layered package ownership |
+| [0004](0004-agent-trust-tiers.md) | Agent trust tiers and sandboxed untrusted execution |
+| [0005](0005-no-declarative-secret-manager.md) | No declarative secret manager until a concrete secret needs it |
+| [0006](0006-managed-layering-over-profiles.md) | Managed layering and seeding over curated profiles |
+| [0007](0007-explicit-generation-cleanup.md) | Explicit, policy-driven generation and store cleanup |


### PR DESCRIPTION
Closes #15.

Adds `docs/adr/` — the one substantive piece of #15 that wasn't already built. The rest of its acceptance criteria were satisfied over time by the docs suite; this PR records the **why** behind the conventions and ticks the last box.

## #15 acceptance criteria
| Criterion | Where |
|---|---|
| Archive the stale migration inventory | ✅ `codex/MIGRATION_PLAN.md` already removed |
| Architecture overview + ownership | ✅ `docs/README.md` map + `system-boundary`/`package-ownership`/`hosts` |
| Bootstrap & activation workflows | ✅ `docs/bootstrap.md`, `docs/atyrode.md` |
| Where creds/sessions/caches/overrides/skills live | ✅ `agent-security`, `package-ownership`, `codex-state`, `agent-tools` |
| **Lightweight ADRs** | ✅ **this PR** |
| Link commands/modules to one owning doc | ✅ the docs map + ADRs link, don't duplicate |
| Broken-link / stale-path check | ✅ `checks/docs-links.nix` (covers the new ADRs too) |
| New machine addable from docs alone | ✅ `docs/README.md` "Adding a machine" flow |

## The ADR set (7)
Format mirrors the **tyrode-dev/infra** convention (`docs/adr/NNNN-*.md`; Status/Date/Context/Decision/Consequences) for cross-repo consistency — content is dotfiles-specific and **links** to the owning topic docs rather than re-arguing them.

1. **0001** capability-based host composition
2. **0002** Home Manager as primary authority; minimal system layer
3. **0003** layered package ownership
4. **0004** agent trust tiers & sandboxed untrusted execution
5. **0005** no declarative secret manager until a concrete secret needs it *(the posture #15 explicitly asks for)*
6. **0006** managed layering + seeding over curated profiles *(the durable "why" behind the OMP #151 and Codex #153 sunsets)*
7. **0007** explicit, policy-driven generation & store cleanup *(#21)*

## Verification
`docs-links` check passes (every ADR link resolves). Docs-only — zero collision with any code work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)