### PR TITLE
fix(code): keep selected auth profile authoritative

### DIFF
--- a/pkgs/code-tui/auth.go
+++ b/pkgs/code-tui/auth.go
@@ -103,15 +103,37 @@ func persistAuthProfile(statePath, id string) error {
 	return os.Rename(tmpName, statePath)
 }
 
-// withOMPProfile puts the global flag before the subcommand/forwarded arguments,
-// which works for both `omp usage --json` and interactive launches.
+// withOMPProfile makes the selected UI profile authoritative. Any forwarded
+// profile flag is removed before the selected flag is inserted, so the identity
+// shown beside usage cannot diverge from the profile OMP launches. Arguments
+// after `--` are messages and remain untouched.
 func withOMPProfile(profile string, args ...string) []string {
-	if profile == "" {
-		return append([]string(nil), args...)
+	clean := make([]string, 0, len(args))
+	skipValue := false
+scan:
+	for i, arg := range args {
+		if skipValue {
+			skipValue = false
+			continue
+		}
+		switch {
+		case arg == "--":
+			clean = append(clean, args[i:]...)
+			break scan
+		case arg == "--profile":
+			skipValue = true
+		case strings.HasPrefix(arg, "--profile="):
+			continue
+		default:
+			clean = append(clean, arg)
+		}
 	}
-	out := make([]string, 0, len(args)+2)
+	if profile == "" {
+		return clean
+	}
+	out := make([]string, 0, len(clean)+2)
 	out = append(out, "--profile", profile)
-	return append(out, args...)
+	return append(out, clean...)
 }
 
 func (m model) activeAuthProfile() authProfile {

--- a/pkgs/code-tui/auth_test.go
+++ b/pkgs/code-tui/auth_test.go
@@ -62,7 +62,7 @@ func TestLoadAvailabilityUsesSelectedProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("ARGS_PATH", argsPath)
-	got := loadAvailability(script+" usage --json", "mum")
+	got := loadAvailability(script+" --profile default usage --json", "mum")
 	if !got.ok {
 		t.Fatal("usage response was not accepted")
 	}
@@ -92,10 +92,50 @@ func TestUsagePanelNamesWholeAuthCombination(t *testing.T) {
 	}
 }
 
-func TestWithOMPProfilePrecedesForwardedArgs(t *testing.T) {
-	got := withOMPProfile("mum", "--config", "/tmp/generated.yml", "--resume")
-	want := []string{"--profile", "mum", "--config", "/tmp/generated.yml", "--resume"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("args = %#v, want %#v", got, want)
+func TestWithOMPProfileOverridesForwardedProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile string
+		args    []string
+		want    []string
+	}{
+		{
+			name:    "no override",
+			profile: "mum",
+			args:    []string{"--config", "/tmp/generated.yml", "--resume"},
+			want:    []string{"--profile", "mum", "--config", "/tmp/generated.yml", "--resume"},
+		},
+		{
+			name:    "separate override",
+			profile: "mum",
+			args:    []string{"--config", "/tmp/generated.yml", "--profile", "default", "--resume"},
+			want:    []string{"--profile", "mum", "--config", "/tmp/generated.yml", "--resume"},
+		},
+		{
+			name:    "equals override",
+			profile: "mum",
+			args:    []string{"--profile=default", "--resume"},
+			want:    []string{"--profile", "mum", "--resume"},
+		},
+		{
+			name:    "message after terminator",
+			profile: "mum",
+			args:    []string{"--resume", "--", "--profile", "literal message"},
+			want:    []string{"--profile", "mum", "--resume", "--", "--profile", "literal message"},
+		},
+		{
+			name:    "sandbox strips override",
+			profile: "",
+			args:    []string{"--profile", "default", "--resume"},
+			want:    []string{"--resume"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := withOMPProfile(tt.profile, tt.args...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("args = %#v, want %#v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -1679,8 +1679,8 @@ func launchGenerated(cfg, prompt, profile string) {
 		fmt.Fprintln(os.Stderr, "code: omp not found:", err)
 		os.Exit(1)
 	}
-	args := append([]string{path}, withOMPProfile(profile, "--config", tmp.Name())...)
-	args = append(args, os.Args[1:]...)
+	forwarded := append([]string{"--config", tmp.Name()}, os.Args[1:]...)
+	args := append([]string{path}, withOMPProfile(profile, forwarded...)...)
 	if prompt != "" { // forward the suggest-box prompt as omp's first message
 		args = append(args, prompt)
 	}


### PR DESCRIPTION
## Context
A caller could pass `--profile` through `code`, causing OMP to launch a different credential root from the identity pair shown in the usage widget. The fixed `ompu` path could also inherit a profile flag it rejects.

## Solution
Sanitize forwarded arguments before launch: remove pre-terminator `--profile VALUE` and `--profile=VALUE`, insert the UI-selected profile for trusted launches, strip overrides for the fixed sandbox, and preserve literal message arguments after `--`.

## How to test
- `nix build --no-link --print-build-logs .#code-tui`
- `nix build --no-link --print-build-logs .#checks.x86_64-linux.go-fmt`
- `nix build --no-link --print-build-logs .#checks.x86_64-linux.omp-stack`