### PR TITLE
Docs(omp): add versioned feature wiki

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ not in a checklist.
 | [bootstrap.md](bootstrap.md) | The supported path from an unmanaged machine to a managed one, and activation |
 | [atyrode.md](atyrode.md) | The `atyrode` CLI — applying and inspecting the configuration |
 | [agent-tools.md](agent-tools.md) | OMP, the `code` profile generator, agents, and rules |
+| [omp/](omp/README.md) | Versioned upstream OMP CLI and capability field guide, explicitly separated from repository wrapper behavior |
 | [agent-security.md](agent-security.md) | Trust tiers and the managed OMP policy for untrusted content |
 | [shell.md](shell.md) | The interactive shell surface (a launcher, not a dev environment) |
 | [codex-state.md](codex-state.md) | Codex mutable configuration and the one-time defaults seed |

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -59,6 +59,10 @@ them together.
 | `ompu` | Deliberately untrusted repositories | Dedicated state, sanitized credentials, restricted integrations, and isolated writing tasks |
 | `code` | The profile generator TUI (see below) | Generates a managed profile and launches it through `omp-managed`, or runs bare `omp` when nothing is asked for |
 
+For discoverability beyond the wrapper contract, see the versioned
+[OMP feature wiki](omp/README.md). Its CLI tables describe plain upstream OMP;
+this document remains authoritative for `code`, `omp-managed`, and `ompu`.
+
 Plain `omp` executes upstream OMP directly: no extension, defaults, or policy
 overlay is injected, so its models, approvals, and interface belong to the
 operator's mutable configuration and can change on the fly. Only `omp update`

--- a/docs/omp/README.md
+++ b/docs/omp/README.md
@@ -1,0 +1,88 @@
+# OMP feature wiki
+
+> - **Audited:** 2026-07-14
+> - **Repository pin:** `omp` v16.4.8
+> - **Upstream release:** [v16.4.8](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.8) (2026-07-12)
+> - **Audit range:** v16.0.0 through v16.4.8, plus the v16.4.8 CLI help and documentation
+
+This is the compact “did you know this exists?” index for the OMP binary used by
+these dotfiles. It is for operators deciding what to invoke and for agents that
+need to discover an OMP capability before proposing new wrapper code.
+
+## Choose the correct surface first
+
+The [CLI reference](cli.md) describes **plain upstream `omp` v16.4.8**. These
+repository launchers are not interchangeable:
+
+| Invoke | Authentication and state | Configuration and policy |
+| --- | --- | --- |
+| `omp` | The selected OMP `--profile`, or OMP's default state root | Plain, mutable upstream configuration under `~/.omp`; no repository-managed policy is injected |
+| `code` | The `mine`/`mum` combination visible in its usage widget; press `a` to switch | With no generated input, launches plain `omp`; with a prompt or changed dial, launches a generated routing profile through the managed layers |
+| `omp-managed` | The selected OMP `--profile` | Injects the Nix-owned defaults, platform extensions, and enforced policy; maintenance subcommands bypass overlay injection but remain subject to repository intercepts/guards |
+| `ompu` | Always the fixed `untrusted` profile | Fixed credential-sanitized untrusted sandbox; does not inherit the personal profile selected in `code` |
+
+Read [Agent tools](../agent-tools.md) for the exact layering, ownership, and
+trust-boundary rules. Never copy a plain-`omp` example into `omp-managed` or
+`ompu` documentation without checking the wrapper behavior.
+
+## Pages
+
+- [CLI reference](cli.md) — launch arguments, command catalog, built-in tools,
+  and invocation examples.
+- [Capability field guide](features.md) — high-value workflows, built-in slash
+  commands, keybindings, and release-backed feature discoveries.
+
+For the fastest live discovery:
+
+```console
+$ omp --help                 # plain upstream launch flags and shell commands
+$ omp <command> --help       # one shell command
+```
+
+Inside an interactive upstream session:
+
+```text
+/help                        # active slash commands, including extensions
+/hotkeys                     # active chords after user remaps/extensions
+/tools                       # tools currently visible to the agent
+/context                     # estimated context-use breakdown
+/settings                    # merged interactive settings
+```
+
+Most of these commands remain available when a wrapper reaches the upstream
+TUI, subject to its injected settings and policy. One important exception is
+`/settings`: the managed extension intercepts it in `omp-managed` and generated
+managed launches, then directs the operator to the repository-owned edit paths.
+
+## Audit provenance
+
+Claims in this wiki were checked against:
+
+1. the repository pin in [`pkgs/omp/default.nix`](../../pkgs/omp/default.nix);
+2. the output of the packaged `omp v16.4.8 --help` and each listed shell
+   command's `--help`;
+3. the upstream documentation at the immutable
+   [`v16.4.8` tag](https://github.com/can1357/oh-my-pi/tree/v16.4.8/docs);
+4. upstream release notes from
+   [v16.0.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.0.0) through
+   [v16.4.8](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.8); and
+5. the repository-owned wrapper behavior in [Agent tools](../agent-tools.md).
+
+Upstream had already published
+[v16.5.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.5.0) and
+[v16.5.1](https://github.com/can1357/oh-my-pi/releases/tag/v16.5.1) when this
+audit was written. They are intentionally excluded because these dotfiles still
+package v16.4.8. Availability in upstream `main` or a newer release is not proof
+that a feature exists in the packaged binary.
+
+## Refreshing the wiki after a pin update
+
+1. Update the version and audit date above.
+2. Compare `omp --help` and every `omp <command> --help` with
+   [CLI reference](cli.md).
+3. Review all release notes after the previous pin; fold user-facing additions,
+   changes, removals, and deprecations into [the field guide](features.md).
+4. Re-check linked upstream docs at the new immutable tag.
+5. Re-check `code`, `omp-managed`, and `ompu` independently so upstream flags
+   are not mistaken for wrapper guarantees.
+6. Run the repository documentation-link and formatting checks.

--- a/docs/omp/cli.md
+++ b/docs/omp/cli.md
@@ -1,0 +1,201 @@
+# Plain OMP v16.4.8 CLI reference
+
+> **Scope:** this page is a snapshot of the packaged **upstream `omp` v16.4.8**
+> executable, audited 2026-07-14. It is not a promise that `code`,
+> `omp-managed`, or `ompu` preserve every flag unchanged. See the
+> [launcher matrix](README.md#choose-the-correct-surface-first) first.
+
+## Launch shape
+
+```text
+omp [COMMAND]
+omp [FLAGS] [MESSAGES...]
+```
+
+A message may contain ordinary text or an `@path` file/image mention. With no
+shell command, OMP starts the coding-agent session. Use `-p` for one-shot
+non-interactive execution.
+
+### Model and routing
+
+| Flag | Effect |
+| --- | --- |
+| `--model <selector>` | Select a model by fuzzy name or `provider/model`; this is preferred over legacy `--provider` |
+| `--models <a,b,...>` | Restrict the models available to `Ctrl+P` cycling |
+| `--smol <selector>` | Override the lightweight/smol role for this process |
+| `--slow <selector>` | Override the thorough/reasoning role for this process |
+| `--plan <selector>` | Override the planning role for this process |
+| `--provider <id>` | Legacy provider selector; prefer `--model` |
+| `--api-key <value>` | Supply a process-local credential override |
+| `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `auto` |
+| `--advisor` | Enable the second-model reviewer that injects notes into the main session |
+
+### Session, state, and prompt
+
+| Flag | Effect |
+| --- | --- |
+| `--profile <name>` | Use an isolated root for auth, sessions, settings, and caches |
+| `--alias <command>` | Create a shell shortcut for the selected profile and exit |
+| `--cwd <path>` | Set the launch working directory |
+| `-c`, `--continue` | Continue the terminal breadcrumb or most recent session |
+| `-r`, `--resume [id-or-path]` | Resume by prefix/path, or open the picker when no value is supplied |
+| `--session-dir <path>` | Override session storage and lookup |
+| `--no-session` | Run ephemerally without saving the session |
+| `--system-prompt <text-or-file>` | Replace the default coding-agent system prompt |
+| `--append-system-prompt <text-or-file>` | Append to the system prompt |
+| `--config <file>` | Add a one-run `config.yml`-style overlay; repeatable and later overlays win |
+| `--allow-home` | Permit launch directly in the home directory |
+| `--max-time <seconds>` | Stop the session after the given wall-clock duration |
+| `--no-title` | Disable session-title generation |
+
+An OMP profile isolates the **entire** state root, not just one provider's OAuth
+record. Authentication in `--profile mine` is independent of authentication in
+`--profile mum`. This is why `code` names complete Claude + Codex combinations
+rather than presenting provider credentials as independently swappable parts.
+
+### Tools and extensibility
+
+| Flag | Effect |
+| --- | --- |
+| `--no-tools` | Disable all built-in tools |
+| `--tools <a,b,...>` | Enable only the named built-in tools |
+| `--no-lsp` | Disable LSP tools, formatting, and diagnostics |
+| `--no-pty` | Disable PTY-backed interactive shell execution |
+| `-e`, `--extension <file>` | Load an extension file; repeatable |
+| `--hook <file>` | Load a hook/extension file; repeatable |
+| `--plugin-dir <path>` | Load a plugin directory; repeatable |
+| `--no-extensions` | Disable discovered extensions; explicit `-e` files still load |
+| `--no-skills` | Disable skill discovery and loading |
+| `--skills <globs>` | Filter loaded skills with comma-separated globs |
+| `--no-rules` | Disable rule discovery and loading |
+
+`omp-managed` refuses `--no-extensions` for managed root sessions because that
+would also disable the settings guard, managed agents, and managed rules. Plain
+`omp` has no repository-owned interception.
+
+### Output and approval
+
+| Flag | Effect |
+| --- | --- |
+| `-p`, `--print` | Process the prompt non-interactively and exit |
+| `--mode <mode>` | Select `text` (default), `json`, `rpc`, or `rpc-ui` |
+| `--print-thoughts` | Include thinking blocks in print-mode text output |
+| `--hide-thinking` | Hide thinking in the TUI without changing model reasoning |
+| `--export <session.jsonl>` | Export an existing session file to HTML and exit |
+| `--approval-mode <mode>` | Override approval behavior with `always-ask`, `write`, or `yolo` |
+| `--auto-approve` | Skip all tool approval prompts for this process |
+
+Treat `--auto-approve` and `--approval-mode yolo` as trust-boundary changes, not
+convenience switches. The managed policy may deliberately prevent them from
+weakening enforced rules.
+
+## Shell command catalog
+
+These are `omp` shell subcommands, not interactive `/slash` commands.
+
+| Command | Purpose |
+| --- | --- |
+| `acp` | Serve OMP over stdio using Agent Client Protocol |
+| `agents` | Unpack/manage bundled task-agent definitions |
+| `auth-broker` | Run and administer the credential vault used by remote/headless clients |
+| `auth-gateway` | Run a forwarding proxy backed by the configured auth broker |
+| `bench` | Compare model time-to-first-token and generation throughput |
+| `commit` | Generate a commit message and update changelogs |
+| `completions` | Print Bash, Zsh, or Fish completions |
+| `config` | List/get/set/reset configuration and print the active state path |
+| `dry-balance` | Simulate OAuth-account selection across random session IDs |
+| `gallery` | Preview built-in tool renderers in their lifecycle states |
+| `gc` | Dry-run or apply storage garbage collection |
+| `grep` | Exercise the built-in grep tool from the shell |
+| `grievances` | View, clean, or push auto-QA tool reports |
+| `install` | Install/link an extension package; alias of plugin install/link |
+| `join` | Join an encrypted live collaboration session |
+| `models` | List, search, and refresh available models |
+| `plugin` | Install, link, enable, disable, inspect, or diagnose plugins |
+| `read` | Show exactly what the built-in read tool returns for a path/URL/internal URI |
+| `say` | Synthesize speech with the local TTS engine and play it |
+| `search` | Exercise configured web-search providers |
+| `setup` | Run onboarding or install/check optional feature dependencies |
+| `shell` | Open OMP's interactive shell console |
+| `ssh` | Manage SSH host configurations |
+| `stats` | Print usage stats or launch the local dashboard |
+| `tiny-models` | Download the small local models used for titles/memory |
+| `token` | Resolve a provider API key/OAuth token, optionally selecting an account |
+| `ttsr` | Inspect and test Time-Traveling Stream Rules |
+| `update` | Check/install upstream updates; blocked by these Nix-managed wrappers |
+| `usage` | Show provider limits for every authenticated account; supports JSON, provider filtering, and redaction |
+| `worktree` | List or clear agent-managed worktrees under `~/.omp/wt` |
+
+Run `omp <command> --help` for the command's current arguments. Useful examples:
+
+```console
+$ omp models --json
+$ omp usage --redact
+$ omp stats --summary
+$ omp config list --json
+$ omp config path
+$ omp setup python --check
+$ omp plugin doctor
+$ omp gc                         # dry-run
+$ omp gc --apply                 # mutate storage
+$ omp worktree clear --dry-run
+```
+
+For managed state, use the repository-specific diagnostic rather than assuming
+upstream `omp config` reports injected layers:
+
+```console
+$ omp config managed --json
+```
+
+The repository-packaged `omp` passthrough intercepts that one action before
+dispatching to upstream. `config managed` is not an upstream v16.4.8
+subcommand, despite the intentionally plain-looking invocation.
+
+## Built-in agent tool catalog
+
+The packaged root help advertises these default tools:
+
+| Tool | Capability |
+| --- | --- |
+| `read` | Files, documents, archives, URLs, internal URIs, and structured stores |
+| `bash` | External commands and terminal processes |
+| `edit` / `write` | Surgical edits and file creation/overwrite |
+| `grep` / `glob` | Content search and path discovery |
+| `lsp` | Symbol-aware navigation, refactors, diagnostics, and code actions |
+| `python` | Persistent Python execution after `omp setup python` |
+| `notebook` | Notebook cell editing |
+| `inspect_image` | Vision-model image analysis |
+| `browser` | Puppeteer browser automation |
+| `task` | Parallel subagents |
+| `todo` | Structured task-list state |
+| `web_search` | Search through configured web providers |
+| `ask` | Interactive operator questions |
+
+Extensions and MCP servers can add tools, so `/tools` is authoritative for the
+active session. A wrapper can also limit or deny tools through policy.
+
+## Invocation examples, with surface made explicit
+
+```console
+# Plain mutable upstream state
+$ omp --profile work --model opus --thinking high "review this failure"
+$ omp -p --mode json --no-session "summarize @report.txt"
+$ omp --config ./experiment.yml --resume
+
+# Repository-managed configuration and policy
+$ omp-managed --profile work --resume
+
+# Pick auth in the code TUI, then forward --resume to the chosen launch path
+$ code --resume
+
+# Fixed restricted sandbox; never inherits code's mine/mum selection
+$ ompu "inspect this untrusted repository"
+```
+
+Sources: packaged `omp --help`; tagged upstream
+[settings](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/settings.md),
+[providers](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/providers.md),
+[models](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/models.md), and
+[secrets](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/secrets.md)
+documentation; repository [Agent tools](../agent-tools.md).

--- a/docs/omp/features.md
+++ b/docs/omp/features.md
@@ -1,0 +1,341 @@
+# OMP v16.4.8 capability field guide
+
+> **Scope:** built-in upstream capabilities present in the packaged `omp`
+> v16.4.8, audited 2026-07-14. Wrapper policy still matters: read the
+> [launcher matrix](README.md#choose-the-correct-surface-first).
+
+This page favors discoverability over implementation detail. The release links
+identify when a capability materially appeared or changed during the audited
+v16 series; the immutable v16.4.8 documentation links define the packaged
+behavior.
+
+## High-value “did you know?” workflows
+
+### Isolate a complete work identity
+
+`omp --profile <name>` isolates authentication, sessions, settings, and caches.
+`OMP_PROFILE` selects the same root through the environment, and
+`omp --profile work --alias omp-work` creates a shortcut.
+
+Inside a profile, `/login <provider>` and `/logout <provider>` manage
+provider-scoped credentials. `omp usage --redact` reports every authenticated
+account without exposing full account IDs; `omp dry-balance` previews OAuth
+account selection. See upstream
+[Providers](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/providers.md)
+and [Secrets](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/secrets.md).
+
+In these dotfiles, use `code`'s usage widget instead of typing profile names:
+`a` switches the visible `mine`/`mum` combination and every trusted launch gets
+that selected `--profile`. `ompu` remains fixed to `untrusted`.
+
+### Assign models by role instead of choosing one model for everything
+
+OMP has role routes for the main session, smol work, slow reasoning, planning,
+advisor review, and task-agent specialties. Edit role assignments with `/model`
+or `Alt+M`; use `/switch` or `Alt+P` for a temporary session model; and use
+`Ctrl+P` / `Shift+Ctrl+P` to cycle the configured quick-switch set. `/fast`
+controls provider priority service, while `/advisor` controls the reviewer
+runtime. Inspect shell-visible models with `omp models`.
+
+The session can also:
+
+- cycle thinking depth with `Shift+Tab` or pin it with `--thinking`;
+- run a passive second-model review with `--advisor` or `/advisor`; and
+- use provider priority service through `/fast` where supported.
+
+These dotfiles manage the role map and fallback chains for generated launches;
+plain `omp` remains mutable. See upstream
+[Models](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/models.md).
+
+### Change the shape of the work, not only the model
+
+- `/plan [prompt]` makes the agent propose and review a plan before mutation;
+  `/plan-review` reopens the latest review.
+- `/goal`, `/goal budget <N>`, and `/guided-goal` maintain a persistent
+  autonomous objective with a token budget.
+- `/vibe [prompt]` enters a read-only director mode whose dedicated `vibe_*`
+  tools create and manage persistent fast/good background workers.
+- `/loop [count|duration] [prompt]` repeats the next prompt after each yield.
+- `/queue <message>` schedules a follow-up while the current turn runs.
+- `/btw <question>` asks an ephemeral side question with current context.
+- `/tan <work>` starts a full background agent for tangential work.
+
+
+### Delegate real work and inspect it live
+
+The `task` tool launches typed subagents and can isolate them in git worktrees.
+The Agent Control Center (`/agents`) shows live state and allows steering,
+killing, reviving, and transcript inspection. From an enabled `eval` workflow,
+`output(id)` retrieves task/agent output by ID. Background process/job state is
+visible through `/jobs`.
+
+Useful distinctions:
+
+- `task` is for agent work and may produce an isolated patch;
+- `todo` is structured plan state, not delegation;
+- `/tan` is a convenient full background-agent side path; and
+- `omp worktree` inspects or dry-runs cleanup of OMP-owned worktrees.
+
+
+### Branch, fork, move, hand off, and resume sessions
+
+OMP's transcript is a navigable tree, not a flat terminal log:
+
+- `/branch` creates a new branch from an earlier message;
+- `/tree` moves among branches;
+- `/fork` creates and switches to a persistent copy;
+- `/handoff [focus]` summarizes context into a new session;
+- `/resume` switches sessions, while `--resume` can search by ID/path;
+- `/rename` changes the current session title;
+- `/move` starts fresh in another directory and leaves the old session
+  resumable; and
+- `/fresh` resets provider stream state without discarding the local transcript.
+
+`/export` writes browsable HTML, while `/dump` copies the full textual
+transcript. See the tagged
+[session-operations reference](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/session-operations-export-share-fork-resume.md).
+
+### Share a snapshot or collaborate live—with different trust models
+
+`/share` publishes an end-to-end encrypted snapshot. The decryption key remains
+in the URL fragment. `/collab` streams the running session through an encrypted
+relay; a full link permits guest prompting/interrupts while `/collab view`
+creates a read-only link. Guests can use `omp join <link>` or `/join <link>`.
+
+The host still runs the model and every tool. A full collab link is therefore a
+control credential and must be handled like a secret. See the tagged
+[Collab](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/collab.md)
+and
+[session-sharing](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/session-operations-export-share-fork-resume.md#share)
+docs.
+
+### Diagnose and reshape context before it becomes a failure
+
+- `/context` estimates tokens by source.
+- `/compact` reduces or reshapes older context using selectable modes: `soft`
+  and available `remote` paths summarize, while `snapcompact` archives history
+  into dense bitmap images without an LLM call.
+- `/shake elide` drops heavy tool/large-block content; `/shake images` drops
+  image blocks.
+- `/memory view|stats|diagnose|clear|enqueue` operates the persistent memory
+  backend and mental-model bank.
+- `/dump` preserves the transcript for inspection before destructive context
+  maintenance.
+
+See the tagged upstream
+[Memory](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/memory.md) and
+[Compaction](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/compaction.md)
+references for the active backend and compaction modes.
+
+### Use rich input without leaving the terminal
+
+| Input | Meaning |
+| --- | --- |
+| ordinary text | Send a normal prompt |
+| `@path` | Attach a text file, document, or image to the message |
+| `/...` | Run or discover an interactive slash command |
+| `!...` | Run a shell command through the terminal execution surface |
+| `$...` | Run Python after the optional Python backend is installed |
+| `#...` | Invoke a registered prompt action |
+| hold `Space` | Push-to-talk speech transcription when STT is configured |
+| `Ctrl+V` | Paste an image when available, otherwise clipboard text |
+
+Prompt actions, clipboard images, and optional speech/evaluator runtimes depend
+on the active configuration. Use `omp setup --help` to discover/check optional
+dependencies rather than assuming they are installed.
+
+### Give the agent more than file and shell access
+
+The v16.4.8 tool ecosystem includes code-aware LSP operations,
+document/archive reads, images, notebooks, browser automation, web search,
+structured todos, subagents, and interactive operator questions. The
+discoverable `eval` tool adds persistent language kernels when its runtimes are
+enabled. Extensions and MCP servers can add further tools.
+
+Notable release-backed additions include:
+
+- browser ARIA snapshots/references in
+  [v16.1.10](https://github.com/can1357/oh-my-pi/releases/tag/v16.1.10) and
+  explicit selector/navigation waits in
+  [v16.1.11](https://github.com/can1357/oh-my-pi/releases/tag/v16.1.11);
+- opt-in persistent Ruby and Julia evaluator kernels in
+  [v16.1.14](https://github.com/can1357/oh-my-pi/releases/tag/v16.1.14), then
+  shared worktree isolation for evaluator agents in
+  [v16.1.16](https://github.com/can1357/oh-my-pi/releases/tag/v16.1.16);
+- TinyFish, DuckDuckGo, xAI, and Firecrawl search adapters in
+  [v16.2.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.2.0), plus
+  multiple credential-free engines and aggregate search in
+  [v16.4.3](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.3); and
+- tagged tool contracts for
+  [image inspection](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/tools/inspect_image.md),
+  [image generation](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/tools/generate_image.md),
+  [speech generation](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/tools/tts.md),
+  and [evaluation](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/tools/eval.md).
+
+`/tools` shows what the current session actually exposes. Wrapper policy can
+remove or require approval for any capability.
+
+### Extend OMP without editing its core
+
+OMP v16.4.8 supports several extension boundaries:
+
+- TypeScript/JavaScript extensions and hooks via `-e`, `--hook`, discovery, or
+  plugin packages;
+- project/user skills, filterable with `--skills`;
+- project/user rules, disableable with `--no-rules`;
+- discovery diagnostics for both skills and rules;
+- MCP servers managed through `/mcp`;
+- marketplace plugins through `/marketplace`, `/plugins`, and
+  `/reload-plugins`;
+- custom models/providers in `models.yml`; and
+- custom interactive components, overlays, keybindings, tool renderers, and
+  status widgets.
+
+Start with the tagged
+[Extensions](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/extensions.md),
+[Skills](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/skills.md),
+[Rule matching](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/rulebook-matching-pipeline.md),
+[MCP](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/mcp-config.md), and
+[TUI integration](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/tui.md)
+docs.
+
+### Embed or automate the same agent
+
+The binary is not limited to the interactive TUI:
+
+- `-p` performs a one-shot request;
+- `--mode json` emits structured events;
+- `--mode rpc` and `--mode rpc-ui` expose protocol-mode execution;
+- `omp acp` serves Agent Client Protocol over stdio;
+- `omp auth-broker` and `omp auth-gateway` separate credential custody from
+  remote/headless inference; and
+- hooks/extensions can observe and alter lifecycle events.
+
+See the tagged
+[RPC](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/rpc.md) and
+[auth broker/gateway](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/auth-broker-gateway.md)
+docs; use `omp acp --help` for the packaged ACP server surface.
+
+### Inspect OMP itself before writing another wrapper
+
+Use the existing diagnostics as design inputs:
+
+```console
+$ omp read <path-or-url>       # exact read-tool behavior
+$ omp gallery                 # renderer lifecycle gallery
+$ omp grep --help             # grep-tool test surface
+$ omp search --help           # search-provider test surface
+$ omp models --json           # resolved model catalog
+$ omp usage --json            # provider quota state
+$ omp stats --summary         # usage summary
+$ omp plugin doctor           # plugin health
+$ omp gc                      # storage cleanup dry-run
+$ omp worktree clear --dry-run
+```
+
+Inside a session, `/debug`, `/tools`, `/context`, `/extensions`, `/agents`, and
+`/jobs` expose live state. These are usually better than inferring behavior from
+source or adding a duplicate diagnostic to `code`.
+
+## Release-note radar for the pinned v16 line
+
+This is a compact audit of operator-visible changes recorded between v16.0.0
+and v16.4.8, not a replacement for the current-feature sections above. Release
+notes can bundle or migrate older behavior, so an entry means “recorded in this
+release,” not necessarily “first invented here.”
+
+- [v16.4.8](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.8) —
+  Home/End navigation in the model browser and `c` to copy the edited plan from
+  plan review.
+- [v16.4.6](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.6) —
+  fallback-chain editing in the model hub, `/queue` plus `->`/`=>` shorthand,
+  usage-cache invalidation, and per-model TPS/TTFT history.
+- [v16.4.3](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.3) —
+  `/vibe`, credential-free multi-engine web search, PCRE2 grep fallback, and a
+  clearer interactive-terminal hint for `omp acp`.
+- [v16.4.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.0) —
+  the `max` thinking tier, Responses Lite transport, and Novita provider/login.
+- [v16.3.12](https://github.com/can1357/oh-my-pi/releases/tag/v16.3.12) —
+  `#<number>` PR/issue autocomplete to `pr://`/`issue://` internal URLs.
+- [v16.3.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.3.0) —
+  Anthropic server-side fallback configuration, subagent soft-budget notices,
+  and large-session performance work.
+- [v16.2.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.2.0) —
+  `ssh://` reads/searches/writes, `/move`, debugger-adapter discovery, file
+  move/delete edits, document-conversion caching, remote compaction controls,
+  LiteLLM discovery, and additional search providers.
+- [v16.1.16](https://github.com/can1357/oh-my-pi/releases/tag/v16.1.16) —
+  evaluator-agent worktree isolation, the eval tool's single-cell contract,
+  and a fullscreen resume picker.
+- [v16.1.14](https://github.com/can1357/oh-my-pi/releases/tag/v16.1.14) —
+  opt-in persistent Ruby and Julia evaluator kernels.
+- [v16.1.10](https://github.com/can1357/oh-my-pi/releases/tag/v16.1.10) and
+  [v16.1.11](https://github.com/can1357/oh-my-pi/releases/tag/v16.1.11) —
+  browser accessibility snapshots/references and explicit selector/navigation
+  waits.
+- [v16.0.10](https://github.com/can1357/oh-my-pi/releases/tag/v16.0.10) —
+  QR codes and separately hosted web-client deep links for collab.
+- [v16.0.1](https://github.com/can1357/oh-my-pi/releases/tag/v16.0.1) —
+  typed task-agent roles, plan-on-startup, image auto-resize, configurable
+  keybindings, PR-aware review, and clipboard-image paste among a large bundle
+  of carried-forward additions.
+
+## Default keybindings worth remembering
+
+Run `/hotkeys` for the authoritative active map: user remaps and extensions can
+change it. The pinned defaults include:
+
+| Chord | Action |
+| --- | --- |
+| `Ctrl+P` / `Shift+Ctrl+P` | Cycle configured quick-switch models forward/backward |
+| `Alt+P` | Pick a temporary model |
+| `Alt+M` | Open the role-model selector |
+| `Alt+Shift+P` | Toggle plan mode |
+| `Shift+Tab` | Cycle thinking level |
+| `Ctrl+T` | Show/hide thinking blocks |
+| `Ctrl+O` | Expand/collapse tool output |
+| `Ctrl+R` | Search prompt history |
+| `Ctrl+G` | Edit the draft in `$VISUAL`/`$EDITOR` |
+| `Ctrl+Q` or `Ctrl+Enter` | Queue a follow-up message |
+| `Alt+Up` | Return a queued message to the editor |
+| `Alt+R` | Retry the last failed turn |
+| `Ctrl+V` | Paste image, falling back to clipboard text |
+| hold `Space` | Push-to-talk speech transcription |
+
+Keybindings live in `~/.omp/agent/keybindings.yml`; see the tagged
+[Keybindings](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/keybindings.md)
+reference.
+
+## Built-in interactive slash-command index
+
+This table catalogs the v16.4.8 built-ins. `/help` remains authoritative because
+extensions may add commands and the active mode may restrict them.
+
+| Area | Commands |
+| --- | --- |
+| Models and work mode | `/model`, `/switch`, `/fast`, `/advisor`, `/plan`, `/plan-review`, `/vibe`, `/goal`, `/guided-goal`, `/loop`, `/queue` |
+| Side work | `/btw`, `/tan`, `/pause`, `/retry` |
+| Sessions | `/new`, `/fresh`, `/drop`, `/session`, `/resume`, `/branch`, `/fork`, `/tree`, `/handoff`, `/rename`, `/move` |
+| Context and memory | `/context`, `/compact`, `/shake`, `/memory` |
+| Export and collaboration | `/copy`, `/dump`, `/export`, `/share`, `/collab`, `/join`, `/leave` |
+| Authentication and usage | `/setup`, `/login`, `/logout`, `/usage`, `/stats` |
+| Agent operations | `/todo`, `/jobs`, `/agents`, `/tools`, `/force` |
+| Extensibility | `/extensions` (alias `/status`), `/mcp`, `/marketplace`, `/plugins`, `/reload-plugins`, `/omfg` |
+| Environment and UI | `/settings`, `/browser`, `/ssh`, `/hotkeys`, `/changelog`, `/debug` |
+| Lifecycle | `/exit`, `/quit` |
+
+Less obvious semantics:
+
+- `/fresh` changes provider stream identity but keeps the local transcript;
+  `/new` starts a new session; `/drop` deletes the current session first.
+- `/branch` selects a prior message as a branch point; `/fork` creates a new
+  persistent file; `/handoff` starts a summarized successor.
+- `/force <tool> [prompt]` makes the next turn request a specific tool.
+- `/omfg <complaint>` forges a Time-Traveling Stream Rule intended to prevent a
+  recurring streamed-output behavior.
+- `/settings` opens upstream settings only under plain `omp`. The managed
+  extension intercepts it under `omp-managed`/generated managed launches and
+  points to repository-owned edit paths.
+
+Source: tagged upstream
+[built-in slash-command registry](https://github.com/can1357/oh-my-pi/blob/v16.4.8/packages/coding-agent/src/slash-commands/builtin-registry.ts).

--- a/pkgs/omp-configured/README.md
+++ b/pkgs/omp-configured/README.md
@@ -27,6 +27,9 @@ profile from a prompt (or a few dials) and launches it, with a per-provider usag
 
 The generator's model catalog and cost figures live in
 [`../../omp/models.yml`](../../omp/models.yml) (synced from `omp models`).
+The repository's versioned [OMP feature wiki](../../docs/omp/README.md) catalogs
+upstream CLI flags and less-obvious capabilities; this README remains
+authoritative for the four wrappers above.
 
 ## Install it standalone (Nix)
 


### PR DESCRIPTION
## Context

OMP exposes a broad CLI, interactive command, tool, and workflow surface that is difficult to discover from the `code` TUI alone. The repository also needs to distinguish plain upstream `omp` behavior from `code`, `omp-managed`, and `ompu`.

## Solution

- add a v16.4.8-stamped OMP wiki with an invocation matrix and audit provenance
- catalog all packaged root flags, shell commands, built-in tools, keybindings, slash commands, and high-value workflows
- add a release-note radar for v16.0.0 through v16.4.8
- link the wiki from the documentation map and nearby wrapper guides

## How to test

- `git diff --check`
- `nix build --no-link --print-build-logs .#checks.x86_64-linux.docs-links`
- verify all external wiki links resolve