### PR TITLE
feat(code): manual fable-as-main sub-dial in the profile generator

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -110,7 +110,8 @@ entry that could go stale.
 `code` is the profile generator. It opens a Bubble Tea TUI with a
 prompt→profile classifier running on the resident Nix-managed ollama daemon
 (loopback HTTP). You type a prompt and/or adjust the facet dials (lane, model
-tier, thinking, spark, fable), and a preview pane shows the resulting role →
+tier, thinking, spark, fable — with fable's manual-only "main" sub-dial that
+promotes it to the default agent), and a preview pane shows the resulting role →
 model routing — model names coloured by provider (blue/orange) and brightness
 scaled by thinking level — above the `omp usage` panel (per-window `N% used`
 with green→red gradient bars, `free` on an idle bucket and `tight` at ≥80%).
@@ -147,7 +148,8 @@ preview always matches what a launch would route.
 
 `omp/defaults.yml` is the authoritative role map and fallback-chain definition;
 the generator derives every profile from it and the `omp/models.yml` catalog,
-adjusting the table by facet (lane, model tier, thinking, spark, fable) rather
+adjusting the table by facet (lane, model tier, thinking, spark, fable, and
+fable's main sub-dial) rather
 than from hand-curated preset files.
 
 `omp-managed` loads configuration in this order:

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -65,7 +65,7 @@ var keys = keyMap{
 // defaultSel returns a fresh copy of the generator's default facet selection —
 // used both to seed the model and to restore it via the reset key.
 func defaultSel() map[string]string {
-	return map[string]string{"lane": "mixed", "model": "normal", "thinking": "medium", "advisor": "glance", "spark": "on", "fable": "off", "fast": "off"}
+	return map[string]string{"lane": "mixed", "model": "normal", "thinking": "medium", "advisor": "glance", "spark": "on", "fable": "off", "main": "off", "fast": "off"}
 }
 
 // ── palette ──────────────────────────────────────────────────────────────────
@@ -419,6 +419,10 @@ func facetDefs(glyphs map[string]string) []facet {
 		{"fast", []string{"on", "off"}, glyphs["fast"]},
 		{"spark", []string{"on", "off"}, glyphs["spark"]},
 		{"fable", []string{"on", "off"}, glyphs["fable"]},
+		// fable-as-main: hand the scarce elite the default (main-agent) role too.
+		// A sub-setting of fable — only visible while fable is on (see
+		// visibleFacets) and never set by a suggestion (see validFacetActions).
+		{"main", []string{"on", "off"}, glyphs["main"]},
 	}
 }
 
@@ -671,7 +675,8 @@ func (m model) applyAdvisor(rows []string, level, lane string) []string {
 
 // visibleFacets drops facets that don't apply to the current lane, so the
 // generator only ever shows actionable options: no spark/fast on a Claude-only
-// pool, no fable on a GPT-only pool.
+// pool, no fable on a GPT-only pool. main is fable's sub-setting, so it only
+// shows while fable is on (and the lane can host it at all).
 func (m model) visibleFacets() []facet {
 	lane := m.sel["lane"]
 	var out []facet
@@ -679,7 +684,10 @@ func (m model) visibleFacets() []facet {
 		if lane == "claude-only" && (f.key == "spark" || f.key == "fast") {
 			continue
 		}
-		if lane == "gpt-only" && f.key == "fable" {
+		if lane == "gpt-only" && (f.key == "fable" || f.key == "main") {
+			continue
+		}
+		if f.key == "main" && m.sel["fable"] != "on" {
 			continue
 		}
 		out = append(out, f)
@@ -702,6 +710,9 @@ func comboID(sel map[string]string) string {
 	}
 	if fb == "on" {
 		faid = "fa"
+		if sel["main"] == "on" {
+			faid = "famain"
+		}
 	}
 	return fmt.Sprintf("%s_%s_%s_%s_%s", lane, sel["model"], sel["thinking"], spid, faid)
 }
@@ -1422,6 +1433,12 @@ func (m *model) cycleFacet(dir int) {
 	}
 	idx = (idx + dir + len(f.values)) % len(f.values)
 	m.sel[f.key] = f.values[idx]
+	// main is fable's sub-setting: whenever fable leaves "on" it must clear too,
+	// so a later fable re-enable never silently resurrects the (expensive)
+	// fable-as-main escalation — it is re-chosen deliberately every time.
+	if m.sel["fable"] != "on" {
+		m.sel["main"] = "off"
+	}
 	// changing the lane can hide/show facets; keep the cursor in range.
 	if nv := len(m.visibleFacets()); m.fcur >= nv {
 		m.fcur = nv - 1
@@ -1542,7 +1559,7 @@ func (m model) genLines() ([]string, int) {
 				col := acc
 				if f.key == "lane" {
 					col = laneColor(v)
-				} else if (f.key == "spark" || f.key == "fable") && v == "on" {
+				} else if (f.key == "spark" || f.key == "fable" || f.key == "main") && v == "on" {
 					col = cGreen
 				}
 				st := lipgloss.NewStyle().Foreground(lipgloss.Color(col)).Bold(true)
@@ -1567,6 +1584,8 @@ func (m model) genLines() ([]string, int) {
 				}
 				row += "   " + stWarn.Render(gWarn+" "+w+" — no usage left")
 			}
+		case f.key == "main" && m.sel["main"] == "on":
+			row += "   " + stDim.Render("Fable leads the default agent — heaviest draw on its scarce bucket")
 		case f.key == "fast" && m.sel["fast"] == "on":
 			row += "   " + stDim.Render("priority service tier — quicker OpenAI replies")
 		}
@@ -1578,10 +1597,10 @@ func (m model) genLines() ([]string, int) {
 func main() {
 	// Facet glyphs are intrinsic to the generator, so the binary carries sane
 	// defaults (Nerd Font, FA range). CODE_FACET_GLYPHS may override any of them.
-	//   lane ⇄  model ⚙  thinking 💡  spark 🚀  fable 📖  fast ⚡
+	//   lane ⇄  model ⚙  thinking 💡  spark 🚀  fable 📖  main 🎯  fast ⚡
 	glyphs := map[string]string{
-		"lane": "", "model": "", "thinking": "", "advisor": "",
-		"spark": "", "fable": "", "fast": "",
+		"lane": "", "model": "", "thinking": "", "advisor": "",
+		"spark": "", "fable": "", "main": "\uf140", "fast": "",
 	}
 	for _, kv := range strings.Split(os.Getenv("CODE_FACET_GLYPHS"), ",") {
 		if p := strings.SplitN(kv, "=", 2); len(p) == 2 && p[1] != "" {

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -120,7 +120,8 @@ func TestLvl(t *testing.T) {
 }
 
 // TestComboID covers the lane-driven suppression: gpt-only forces fable off,
-// claude-only forces spark off, regardless of the toggles.
+// claude-only forces spark off, regardless of the toggles — plus the fable-main
+// segment: famain only when fable is on too, and lane suppression wins over both.
 func TestComboID(t *testing.T) {
 	cases := []struct {
 		sel  map[string]string
@@ -130,6 +131,9 @@ func TestComboID(t *testing.T) {
 		{map[string]string{"lane": "mixed", "model": "normal", "thinking": "medium", "spark": "off", "fable": "on"}, "mixed_normal_medium_nosp_fa"},
 		{map[string]string{"lane": "gpt-only", "model": "fast", "thinking": "high", "spark": "on", "fable": "on"}, "gpt-only_fast_high_sp_nofa"},
 		{map[string]string{"lane": "claude-only", "model": "smart", "thinking": "low", "spark": "on", "fable": "on"}, "claude-only_smart_low_nosp_fa"},
+		{map[string]string{"lane": "mixed", "model": "smart", "thinking": "high", "spark": "off", "fable": "on", "main": "on"}, "mixed_smart_high_nosp_famain"},
+		{map[string]string{"lane": "mixed", "model": "smart", "thinking": "high", "spark": "off", "fable": "off", "main": "on"}, "mixed_smart_high_nosp_nofa"},
+		{map[string]string{"lane": "gpt-only", "model": "smart", "thinking": "high", "spark": "on", "fable": "on", "main": "on"}, "gpt-only_smart_high_sp_nofa"},
 	}
 	for _, c := range cases {
 		if got := comboID(c.sel); got != c.want {
@@ -167,6 +171,49 @@ func TestDefaultSelValid(t *testing.T) {
 		if !found {
 			t.Errorf("defaultSel[%q]=%q is not a valid value (allowed: %v)", k, v, values)
 		}
+	}
+}
+
+// TestMainFacetVisibility locks the sub-setting behavior: the main (fable-as-main)
+// dial only exists while fable is on and the lane can host Fable at all.
+func TestMainFacetVisibility(t *testing.T) {
+	has := func(sel map[string]string) bool {
+		m := model{facets: facetDefs(map[string]string{}), sel: sel}
+		for _, f := range m.visibleFacets() {
+			if f.key == "main" {
+				return true
+			}
+		}
+		return false
+	}
+	if !has(map[string]string{"lane": "mixed", "fable": "on"}) {
+		t.Errorf("main must be visible when fable is on")
+	}
+	if has(map[string]string{"lane": "mixed", "fable": "off"}) {
+		t.Errorf("main must be hidden while fable is off")
+	}
+	if has(map[string]string{"lane": "gpt-only", "fable": "on"}) {
+		t.Errorf("main must be hidden on a gpt-only lane")
+	}
+}
+
+// TestCycleFacetClearsMain: manually toggling fable off must clear fable-as-main
+// too, so a later fable re-enable never silently resurrects the escalation.
+func TestCycleFacetClearsMain(t *testing.T) {
+	m := &model{facets: facetDefs(map[string]string{}), sel: defaultSel()}
+	m.sel["fable"] = "on"
+	m.sel["main"] = "on"
+	for i, f := range m.visibleFacets() {
+		if f.key == "fable" {
+			m.fcur = i
+		}
+	}
+	m.cycleFacet(1) // fable on → off
+	if m.sel["fable"] != "off" {
+		t.Fatalf("cycle should have turned fable off, got %q", m.sel["fable"])
+	}
+	if m.sel["main"] != "off" {
+		t.Errorf("main must clear when fable is manually turned off, got %q", m.sel["main"])
 	}
 }
 

--- a/pkgs/code-tui/suggest.go
+++ b/pkgs/code-tui/suggest.go
@@ -113,6 +113,12 @@ func (m *model) repairConstraints() {
 	if m.avail.down(bucketOf("spark")) {
 		m.sel["spark"] = "off"
 	}
+	// fable-as-main is fable's sub-setting: it can never outlive fable itself, so
+	// any repair (or derived toggle) that turns fable off clears it too. Turning
+	// fable back on requires the operator to re-choose main deliberately.
+	if m.sel["fable"] != "on" {
+		m.sel["main"] = "off"
+	}
 }
 
 // BoxTitle labels the suggest box with its purpose and the model in use, so the
@@ -121,7 +127,9 @@ func (m model) BoxTitle() string { return "prompt → profile · " + evalModel()
 
 // validFacetActions keeps only the actions that name a real facet with a value
 // that facet offers — the whitelist that makes an agent proposal no more powerful
-// than a manual change.
+// than a manual change. main (fable-as-main) is the one exception: the elite is
+// scarce and expensive, so promoting it to the default agent is a decision the
+// operator takes by hand — no proposal may set it, in either direction.
 func validFacetActions(facets []facet, actions []clikit.Action) []clikit.Action {
 	valid := map[string]map[string]bool{}
 	for _, f := range facets {
@@ -133,6 +141,9 @@ func validFacetActions(facets []facet, actions []clikit.Action) []clikit.Action 
 	}
 	var out []clikit.Action
 	for _, a := range actions {
+		if a.Key == "main" {
+			continue
+		}
 		if vs, ok := valid[a.Key]; ok && vs[a.Value] {
 			out = append(out, a)
 		}

--- a/pkgs/code-tui/suggest_test.go
+++ b/pkgs/code-tui/suggest_test.go
@@ -15,6 +15,7 @@ func TestValidFacetActions(t *testing.T) {
 		{Key: "lane", Value: "purple"},   // invalid value → dropped
 		{Key: "nonsense", Value: "x"},    // unknown facet → dropped
 		{Key: "spark", Value: "on"},      // valid
+		{Key: "main", Value: "on"},       // manual-only facet → dropped
 	}
 	got := validFacetActions(facets, in)
 	want := []clikit.Action{{Key: "model", Value: "fast"}, {Key: "thinking", Value: "high"}, {Key: "spark", Value: "on"}}
@@ -150,6 +151,40 @@ func TestRepairConstraintsQuota(t *testing.T) {
 	}
 	if m.sel["spark"] != "off" {
 		t.Errorf("spark must be off when its bucket is unauthed, got %q", m.sel["spark"])
+	}
+}
+
+// TestRepairConstraintsMainCascade: fable-as-main can never outlive fable — any
+// repair path that ends with fable off (lane, quota, or a derived toggle) must
+// clear main too, so a later fable=on never resurrects the escalation unasked.
+func TestRepairConstraintsMainCascade(t *testing.T) {
+	// gpt-only forces fable off → main follows.
+	m := &model{sel: map[string]string{"lane": "gpt-only", "fable": "on", "main": "on"},
+		avail: availability{bucket: map[string]string{}}}
+	m.repairConstraints()
+	if m.sel["main"] != "off" {
+		t.Errorf("main must cascade off with fable under gpt-only, got %q", m.sel["main"])
+	}
+	// a maxed fable bucket forces fable off → main follows.
+	m = &model{sel: map[string]string{"lane": "mixed", "fable": "on", "main": "on"},
+		avail: availability{bucket: map[string]string{"claude-fable": "maxed"}}}
+	m.repairConstraints()
+	if m.sel["main"] != "off" {
+		t.Errorf("main must cascade off when fable's bucket is maxed, got %q", m.sel["main"])
+	}
+	// fable already off (e.g. deriveToggles sized down) → stale main clears.
+	m = &model{sel: map[string]string{"lane": "mixed", "fable": "off", "main": "on"},
+		avail: availability{bucket: map[string]string{}}}
+	m.repairConstraints()
+	if m.sel["main"] != "off" {
+		t.Errorf("main must clear whenever fable is off, got %q", m.sel["main"])
+	}
+	// fable on and available → a manually chosen main survives repair.
+	m = &model{sel: map[string]string{"lane": "mixed", "fable": "on", "main": "on"},
+		avail: availability{bucket: map[string]string{}}}
+	m.repairConstraints()
+	if m.sel["main"] != "on" {
+		t.Errorf("a manual main must survive repair while fable stays on, got %q", m.sel["main"])
 	}
 }
 

--- a/pkgs/omp-configured/README.md
+++ b/pkgs/omp-configured/README.md
@@ -7,7 +7,9 @@ profile from a prompt (or a few dials) and launches it, with a per-provider usag
 ## What you get
 
 - **`code`** — the profile generator (Bubble Tea TUI). Type a prompt and/or adjust the
-  facet dials (lane, model tier, thinking, spark, fable); a local prompt→profile classifier
+  facet dials (lane, model tier, thinking, spark, fable — plus, while fable is on, a
+  "main" sub-dial that hands Fable the default-agent role; that escalation is manual
+  only, never suggested); a local prompt→profile classifier
   (running on the resident ollama daemon) suggests settings. The usage widget
   names the active OMP authentication combination; **`a`** switches it and
   refreshes usage from that profile. **Enter** launches:

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -948,8 +948,8 @@ let
 
   # First-principles facet grid: the generator (a models.yml + routing rules,
   # see generate-profiles.py) emits a rendered routing block for every valid
-  # (lane, model-tier, thinking, spark, fable) combination, baked at build time
-  # so the generator view stays immutable and reviewable.
+  # (lane, model-tier, thinking, spark, fable, fable-as-main) combination, baked
+  # at build time so the generator view stays immutable and reviewable.
   generatedProfiles =
     runCommand "omp-generated-profiles"
       { nativeBuildInputs = [ (python3.withPackages (ps: [ ps.pyyaml ])) ]; }

--- a/pkgs/omp-configured/generate-profiles.py
+++ b/pkgs/omp-configured/generate-profiles.py
@@ -2,15 +2,15 @@
 """Generate the full facet grid of profiles from first principles.
 
 Runs at package build time. For every valid (lane, model-tier, thinking, spark,
-fable) combination it emits a routing block in the plain format the `code`
-generator's colorizeRoute renders unchanged:
+fable, fable-as-main) combination it emits a routing block in the plain format
+the `code` generator's colorizeRoute renders unchanged:
 
-    <combo-id>  <lane> · <model-tier> · <thinking>[ · spark][ · fable]
+    <combo-id>  <lane> · <model-tier> · <thinking>[ · spark][ · fable[ · main]]
       thinking <t> · fallback on · advisor <on|off>
       ● default    <model:level>  → <fallback> → ...
       ...
 
-The combo-id is `<lane>_<mtier>_<thinking>_<sp|nosp>_<fa|nofa>` — the runtime
+The combo-id is `<lane>_<mtier>_<thinking>_<sp|nosp>_<fa|famain|nofa>` — the runtime
 facet selector rebuilds the same id from the current facet state to look up the
 block. The model catalog is loaded from omp/models.yml (issue #79).
 """
@@ -165,7 +165,7 @@ def pure(lane):
     return lane in ('gpt-only', 'claude-only')
 
 
-def gen(lane, mtier, thinking, spark, fable):
+def gen(lane, mtier, thinking, spark, fable, fable_main=False):
     """Return {role: (lead_key, level, [chain (key, level)...])}."""
     P = primary(lane)
     base = TMAP[mtier]
@@ -214,23 +214,33 @@ def gen(lane, mtier, thinking, spark, fable):
         rp = rprov(r)
         t = min(3, base + 1) if r in DELIB else base
         th = thinking if extreme else (BUMP[thinking] if r in DELIB else thinking)
-        lead = 'fable' if (fable and r in DELIB and rp == 'A' and mtier in ('smart', 'normal')) else LADDER[rp][t]
+        # Fable leads the deliberative Claude roles when on; the explicit (manual)
+        # fable-as-main escalation additionally hands it the default role — the
+        # main agent — regardless of the lane's provider preference. Both keep the
+        # smart/normal gate: a 'fast' tier explicitly trades smarts for speed, so
+        # the scarce elite never leads there.
+        fable_here = fable and mtier in ('smart', 'normal') and (
+            (fable_main and r == 'default') or (r in DELIB and rp == 'A'))
+        lead = 'fable' if fable_here else LADDER[rp][t]
         out[r] = (lead, th, [(m, th) for m in build_chain(lead, isp)])
     return out
 
 
-def combo_id(lane, mtier, thinking, spark, fable):
-    return f"{lane}_{mtier}_{thinking}_{'sp' if spark else 'nosp'}_{'fa' if fable else 'nofa'}"
+def combo_id(lane, mtier, thinking, spark, fable, fable_main=False):
+    fa = 'famain' if (fable and fable_main) else ('fa' if fable else 'nofa')
+    return f"{lane}_{mtier}_{thinking}_{'sp' if spark else 'nosp'}_{fa}"
 
 
-def render(lane, mtier, thinking, spark, fable):
-    roles = gen(lane, mtier, thinking, spark, fable)
-    cid = combo_id(lane, mtier, thinking, spark, fable)
+def render(lane, mtier, thinking, spark, fable, fable_main=False):
+    roles = gen(lane, mtier, thinking, spark, fable, fable_main)
+    cid = combo_id(lane, mtier, thinking, spark, fable, fable_main)
     desc_bits = [lane, mtier, thinking]
     if spark:
         desc_bits.append('spark')
     if fable:
         desc_bits.append('fable')
+    if fable and fable_main:
+        desc_bits.append('main')
     lines = [f"{cid}  {' · '.join(desc_bits)}"]
     adv_on = roles['advisor'][0] is not None
     lines.append(f"  thinking {thinking} · fallback on · advisor {'on' if adv_on else 'off'}")
@@ -272,11 +282,13 @@ def render_advisors():
     return "\n".join(lines)
 
 
-def valid(lane, mtier, thinking, spark, fable):
+def valid(lane, mtier, thinking, spark, fable, fable_main=False):
     if lane == 'gpt-only' and fable:
         return False       # no Fable on pure GPT
     if lane == 'claude-only' and spark:
         return False       # no Spark on pure Claude
+    if fable_main and not fable:
+        return False       # fable-as-main only exists on top of fable
     return True
 
 
@@ -290,8 +302,9 @@ def main():
             for thinking in THINKING:
                 for spark in (True, False):
                     for fable in (True, False):
-                        if valid(lane, mtier, thinking, spark, fable):
-                            print(render(lane, mtier, thinking, spark, fable))
+                        for fable_main in (False, True):
+                            if valid(lane, mtier, thinking, spark, fable, fable_main):
+                                print(render(lane, mtier, thinking, spark, fable, fable_main))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

When the **fable** facet is on, a new **main** on/off sub-dial appears directly under it in the `code` generator (off by default). On **ON**, `claude-fable-5` also leads the **default (main-agent) role**; on **OFF**, behavior is exactly today's (fable leads only the deliberative Claude roles).

## Design

- **Grid**: `generate-profiles.py` grows a `fable_main` axis; the combo-id fable segment becomes three-valued (`nofa|fa|famain`), so **all 292 pre-existing blocks are byte-identical** and 126 `famain` blocks are added (verified by block-level diff). The fable-led default keeps a full safety net (`fable → opus → sol → terra`; pure Claude lanes stay in-pool) and keeps fable's existing smart/normal gate — a `fast` tier never hands leads to the scarce elite.
- **Manual-only escalation** (the point of the feature, Fable being scarce/expensive):
  - the prompt→profile classifier can never set it — `validFacetActions` drops `main` in either direction;
  - `deriveToggles`/`repairConstraints` never enable it, and any path that ends with fable off (gpt-only lane, maxed/unauthed bucket, derived size-down, manual fable-off cycling) **clears `main` too**, so re-enabling fable never silently resurrects the escalation. Invariant: `main on ⇒ fable on`.
- **TUI**: the sub-dial only renders while fable is on and the lane can host Fable; selected **on** renders green like spark/fable, with a dim explainer ("Fable leads the default agent — heaviest draw on its scarce bucket"). Cost/speed meters already weight the default role heaviest, so fable-as-main reads dear/slow with no meter changes.

## Verification

- `go test ./...` in `pkgs/code-tui` (new: comboID famain cases, sub-dial visibility, manual-cycle cascade, repair cascade, proposal filtering) — pass.
- Old-vs-new generator diff: 0 changed, 0 removed, 126 added (all `famain`).
- Exhaustive cross-check: every TUI-reachable selection resolves to a baked block.
- `nix flake check` (x86_64-linux) — all checks passed.

Docs updated: `docs/agent-tools.md`, `pkgs/omp-configured/README.md`, generator/nix comments.