### PR TITLE
fix(atyrode): runnable reap hint + confirm prompt for clean

### DIFF
--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -489,9 +489,15 @@ pkgs.runCommand "check-atyrode-cli"
     grep -qF 'skipped 2 root-owned GC root(s)' <<<"$noise_out" \
       || { echo "footer must tally skipped gcroots: $noise_out" >&2; exit 1; }
     # A non-root clean cannot unlink the daemon-owned roots, so it names the exact
-    # elevated command to reap them (atyrode never self-elevates).
-    grep -qF 'reap them via `sudo atyrode clean`' <<<"$noise_out" \
-      || { echo "footer must point a non-root clean at sudo to reap: $noise_out" >&2; exit 1; }
+    # elevated command — an ABSOLUTE nix-store path (here the fake-gc stub) plus
+    # --gc, since a bare command is off root's secure_path (atyrode never
+    # self-elevates, and the old `sudo atyrode clean` hint was unrunnable there).
+    grep -qF 'reap them via' <<<"$noise_out" \
+      || { echo "footer must point a non-root clean at an elevated reap: $noise_out" >&2; exit 1; }
+    grep -qF "sudo $TMPDIR/bin/fake-gc --gc" <<<"$noise_out" \
+      || { echo "reap hint must name an absolute nix-store path + --gc: $noise_out" >&2; exit 1; }
+    grep -qF 'sudo atyrode clean' <<<"$noise_out" \
+      && { echo 'footer must not print the old unrunnable sudo atyrode clean hint' >&2; exit 1; }
     grep -qF 'gcroots/auto/lvi04m7mn76' <<<"$noise_out" \
       && { echo 'clean must not print individual gcroots permission failures' >&2; exit 1; }
     grep -qF 'profile-9-link' <<<"$noise_out" \
@@ -525,6 +531,39 @@ pkgs.runCommand "check-atyrode-cli"
         || { echo 'clean must not remove the stray result symlink' >&2; exit 1; }
     )
     rm -f "$TMPDIR/result"
+
+    # Interactive clean previews the plan and asks first, so an accidental run can
+    # be read and declined before anything is removed (_ATYRODE_TEST_TTY forces the
+    # interactive branch under the non-tty harness). Declining changes nothing: the
+    # garbage collector is never invoked.
+    export ATYRODE_NIX_STORE="$TMPDIR/bin/fake-gc"
+    rm -f "$TMPDIR/gc-args"
+    decline_out="$(printf 'n\n' | _ATYRODE_TEST_TTY=1 atyrode clean --keep 1 2>&1)"
+    grep -qF 'is about to' <<<"$decline_out" \
+      || { echo "interactive clean must preview the plan: $decline_out" >&2; exit 1; }
+    grep -qF 'keep the newest 1 generation(s)' <<<"$decline_out" \
+      || { echo "preview must state the keep window: $decline_out" >&2; exit 1; }
+    grep -qF 'clean declined — nothing changed' <<<"$decline_out" \
+      || { echo "declining must abort the clean: $decline_out" >&2; exit 1; }
+    test ! -e "$TMPDIR/gc-args" \
+      || { echo 'a declined clean must not collect garbage' >&2; exit 1; }
+
+    # Accepting proceeds through the collector.
+    accept_out="$(printf 'y\n' | _ATYRODE_TEST_TTY=1 atyrode clean --keep 3 2>&1)"
+    grep -qF 'is about to' <<<"$accept_out" \
+      || { echo "accepted clean must still preview: $accept_out" >&2; exit 1; }
+    test -e "$TMPDIR/gc-args" \
+      || { echo 'an accepted clean must collect garbage' >&2; exit 1; }
+    rm -f "$TMPDIR/gc-args"
+
+    # --yes is the explicit non-interactive path: it skips the prompt even on a tty.
+    yes_out="$(_ATYRODE_TEST_TTY=1 atyrode clean --keep 3 --yes </dev/null 2>&1)"
+    grep -qF 'is about to' <<<"$yes_out" \
+      && { echo '--yes must skip the confirmation preview' >&2; exit 1; }
+    test -e "$TMPDIR/gc-args" \
+      || { echo '--yes clean must collect garbage without prompting' >&2; exit 1; }
+    unset ATYRODE_NIX_STORE
+    rm -f "$TMPDIR/gc-args"
 
     mkdir "$out"
   ''

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -44,9 +44,11 @@ generations lists the activation profile's generations (nix-darwin system on
 macOS, home-manager on Linux); rollback activates an earlier one (previous by
 default, or --to N) after confirming. clean reclaims disk from generations the
 config no longer references, always keeping the current one and a rollback
-window (--keep / --keep-since); on macOS it also sweeps stale Home Manager Apps
-aliases. The auto GC roots that pin old generations are owned by the Nix daemon,
-so reaping them needs elevation: rerun as `sudo atyrode clean` (atyrode never
+window (--keep / --keep-since); it previews the plan and asks before touching
+anything (--yes skips the prompt, --dry-run only previews), and on macOS it also
+sweeps stale Home Manager Apps aliases. The auto GC roots that pin old
+generations are owned by the Nix daemon; a non-root clean cannot unlink them and
+prints the exact `sudo … nix-store --gc` command to reap them (atyrode never
 self-elevates). Commands reserved for later issues: workspace and agent.
 EOF
 }
@@ -835,10 +837,18 @@ review_seed_drift() {
   fi
 }
 
+# interactive reports whether we can hold a yes/no dialogue with a human (both
+# ends of the pipe are a terminal). A test override forces it on so the confirm
+# gates are exercisable from the non-tty check harness.
+interactive() {
+  [[ "$test_hooks" == 1 && -n "${_ATYRODE_TEST_TTY:-}" ]] && return 0
+  [[ -t 0 && -t 1 ]]
+}
+
 # Ask a yes/no question; default no, and no on a non-interactive stream.
 confirm() {
   local reply
-  [[ -t 0 && -t 1 ]] || return 1
+  interactive || return 1
   printf 'atyrode: %s [y/N] ' "$1" >&2
   read -r reply || return 1
   [[ "$reply" == [yY] || "$reply" == [yY][eE][sS] ]]
@@ -984,6 +994,19 @@ warn_stray_result_roots() {
   printf '  remove them (rm result*) so the store can reclaim those closures.\n' >&2
 }
 
+# nix_store_path resolves nix-store to an absolute path so the reap hint names a
+# command that survives elevation. On a non-NixOS host root's sudoers secure_path
+# excludes every Nix profile directory, so a bare `nix-store` (like `atyrode` or
+# `nh`) is not found under elevation — but an absolute path is executed directly,
+# bypassing the PATH search entirely. Honours the test override.
+nix_store_path() {
+  if [[ "$test_hooks" == 1 && -n "${ATYRODE_NIX_STORE:-}" ]]; then
+    printf '%s' "$ATYRODE_NIX_STORE"
+    return
+  fi
+  command -v nix-store 2>/dev/null || printf 'nix-store'
+}
+
 # count_generations reports how many generations the tracked profile has (0 when
 # it cannot be read) so the clean footer can show kept/removed counts.
 count_generations() {
@@ -1006,14 +1029,17 @@ clean_footer() {
     parts+=("dry-run — no changes made" "$before generation(s) present")
   else
     [[ -z "$freed" ]] || parts+=("reclaimed $freed")
-    parts+=("kept $after generation(s)" "removed $removed")
+    parts+=("kept $after generation(s)" "removed $removed generation(s)")
   fi
   [[ "${reaped:-0}" -gt 0 ]] && parts+=("reaped $reaped root-owned GC root(s)")
   if [[ "${skipped:-0}" -gt 0 ]]; then
     if [[ "$euid" == 0 ]]; then
       parts+=("skipped $skipped root-owned GC root(s) (unremovable)")
     else
-      parts+=("skipped $skipped root-owned GC root(s); reap them via \`sudo atyrode clean\`")
+      # Name an absolute nix-store path: under elevation a bare command is not on
+      # root's secure_path (see nix_store_path). `nix-store --gc` prunes these
+      # daemon-owned roots once this clean has dropped the generations they pin.
+      parts+=("skipped $skipped root-owned GC root(s); reap them via \`sudo $(nix_store_path) --gc\`")
     fi
   fi
   local out="" p
@@ -1021,6 +1047,35 @@ clean_footer() {
     [[ -z "$out" ]] && out="$p" || out="$out · $p"
   done
   printf 'atyrode: %s\n' "$out" >&2
+}
+
+# clean_preview describes what a clean is about to do — its keep window, how many
+# of the current generations fall outside it (an upper bound: nh additionally
+# spares anything newer than --keep-since), and that the current generation and
+# rollback window are never touched — so an accidental `atyrode clean` can be read
+# and declined before anything is removed. Store reclaim is not estimated: closure
+# sizes overlap heavily, so the honest figure is the one the GC reports afterwards.
+clean_preview() {
+  local scope="$1" keep="$2" keep_since="$3"
+  local profile; profile="$(gen_profile)"
+  local -a gens=()
+  local line gen rest current="" total=0 candidates=0 i rank
+  if [[ -e "$profile" ]]; then
+    while IFS= read -r line; do
+      read -r gen rest <<<"$line"
+      gens+=("$gen")
+      [[ "$line" == *"(current)"* ]] && current="$gen"
+    done < <(nix_env -p "$profile" --list-generations 2>/dev/null)
+  fi
+  total=${#gens[@]}
+  for (( i = 0; i < total; i++ )); do
+    rank=$(( total - 1 - i ))
+    [[ "$rank" -ge "$keep" && "${gens[$i]}" != "$current" ]] && candidates=$(( candidates + 1 ))
+  done
+  printf 'atyrode: clean (%s) is about to:\n' "$scope" >&2
+  printf '  • keep the newest %s generation(s), anything newer than %s, and the current one\n' "$keep" "$keep_since" >&2
+  printf '  • remove up to %s of %s generation(s) that fall outside that window\n' "$candidates" "$total" >&2
+  printf '  • garbage-collect unreferenced store paths (reclaimed space reported after)\n' >&2
 }
 
 # clean — reclaim disk from generations the config no longer references, always
@@ -1044,6 +1099,15 @@ cmd_clean() {
   command -v nh >/dev/null || die "$EX_UNAVAILABLE" "nh is unavailable"
   local nh_command=nh
   [[ "$test_hooks" != 1 || -z "${ATYRODE_NH:-}" ]] || nh_command="$ATYRODE_NH"
+
+  # Guard an accidental interactive run: show the plan and require confirmation.
+  # --dry-run previews without touching anything, --yes/--json are the explicit
+  # non-interactive paths (scripts, cockpit), so none of them prompt.
+  if [[ "$dry" == 0 && "$assume_yes" == 0 && "$json" == 0 ]] && interactive; then
+    clean_preview "$scope" "$keep" "$keep_since"
+    confirm "proceed and reclaim now?" ||
+      { printf 'atyrode: clean declined — nothing changed.\n' >&2; return 0; }
+  fi
 
   printf 'atyrode: reclaiming the Nix store (keeping %s generation(s) + everything newer than %s)\n' "$keep" "$keep_since" >&2
   # Let nh remove the stale generations and gcroots, but skip its garbage


### PR DESCRIPTION
Two follow-ups from running #148's `clean` live on this (non-NixOS) host.

## 1. The reap hint was unrunnable

#148 shipped a footer telling a non-root clean to *reap them via `sudo atyrode clean`*. In practice that fails:

```
➜ sudo atyrode clean
sudo: atyrode: command not found
```

On Nix-on-non-NixOS, root's sudoers `secure_path` is the stock `/usr/bin:/bin` — it excludes every Nix profile dir, so `atyrode` **and** `nh` aren't found under elevation. (And running the whole clean as root would target root's empty home-manager profile anyway.)

Fix: the footer now prints an **absolute** `sudo <nix-store> --gc`. An absolute path executes directly, bypassing the `secure_path` lookup, so it actually runs. Once the user-scope clean has dropped the old generations, `nix-store --gc` as root prunes the now-unpinned daemon-owned auto roots. `nix_store_path` resolves the path; atyrode still never self-elevates.

## 2. `clean` now previews + confirms

An accidental `atyrode clean` used to start deleting immediately. It now shows the plan and asks first:

```
atyrode: clean (user) is about to:
  • keep the newest 5 generation(s), anything newer than 30d, and the current one
  • remove up to N of M generation(s) that fall outside that window
  • garbage-collect unreferenced store paths (reclaimed space reported after)
atyrode: proceed and reclaim now? [y/N]
```

Declining collects nothing. `--dry-run` still only previews; `--yes` and `--json` stay the explicit non-interactive paths (scripts, cockpit #111) and don't prompt. Reclaim isn't estimated — closure sizes overlap, so the honest figure is what the GC reports after.

## 3. Minor wording

`removed N` → `removed N generation(s)`, so it doesn't read as *paths* next to the reclaimed byte figure (`reclaimed 4.2 GiB · … · removed 0 generation(s)`).

## Testing

`nix build .#checks.x86_64-linux.atyrode-cli` (green), `nixfmt --check` + `shellcheck` clean. New assertions in the `atyrode-cli` check:
- reap hint names an **absolute** nix-store path + `--gc` (and the old `sudo atyrode clean` string is gone);
- interactive decline previews the plan and runs **no** GC;
- acceptance proceeds; `--yes` skips the prompt (all via a new `_ATYRODE_TEST_TTY` override).

## Still worth a live confirm

The stub proves the hint is now *runnable*; whether `sudo <nix-store> --gc` fully drains the 125 auto-roots on the live daemon is the empirical step — the footer now hands you a command that actually executes to check.

Follows #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
