### PR TITLE
fix(atyrode): refuse store mutation when test tool-overrides leak into production

### DIFF
--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -93,6 +93,29 @@ pkgs.runCommand "check-atyrode-cli"
     set -e
     test "$production_identity_status" = 65
 
+    # A production binary must REFUSE a store-mutating command when a test-only
+    # tool-substitution override is set: those seams are ignored in production, so
+    # a stubbed-looking clean/apply/rollback would otherwise drive the real
+    # nh/nix-store against the live store. (Regression guard for a near-miss where
+    # the production binary was run with stub overrides during development.)
+    for prod_cmd in clean apply rollback; do
+      set +e
+      env -u ATYRODE_NH -u ATYRODE_NIX_ENV -u ATYRODE_GIT -u ATYRODE_GEN_PROFILE \
+        ATYRODE_NIX_STORE=/bin/true \
+        ${productionAtyrode}/bin/atyrode "$prod_cmd" --yes \
+        > /dev/null 2> "$TMPDIR/prod-guard.err"
+      prod_guard_status="$?"
+      set -e
+      test "$prod_guard_status" = 64 \
+        || { echo "production $prod_cmd must refuse a tool override (exit $prod_guard_status): $(cat "$TMPDIR/prod-guard.err")" >&2; exit 1; }
+      grep -qF 'ATYRODE_NIX_STORE is set' "$TMPDIR/prod-guard.err" \
+        || { echo "production $prod_cmd refusal must name the offending override" >&2; exit 1; }
+    done
+    # The guard is scoped to mutating verbs: a read-only command with the same
+    # override present still runs (production simply ignores the var there).
+    env ATYRODE_NIX_STORE=/bin/true ${productionAtyrode}/bin/atyrode --help >/dev/null 2>&1 \
+      || { echo 'production read-only commands must not be blocked by the mutation guard' >&2; exit 1; }
+
     atyrode capabilities list --json | jq -e '
       (map(.name) | index("base") and index("server"))
       and all(.[]; .description | length > 0)

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -1363,9 +1363,32 @@ cmd_rollback() {
   printf 'atyrode: now on generation %s\n' "$target" >&2
 }
 
+# guard_production_mutation refuses to run a store-mutating command when a
+# test-only tool-substitution override is present on a production binary. Those
+# vars (ATYRODE_NH, ATYRODE_NIX_STORE, ATYRODE_NIX_ENV, ATYRODE_GIT,
+# ATYRODE_GEN_PROFILE) are honoured only under enableTestHooks; a production build
+# silently ignores them, so a caller who sets them expecting stubs would instead
+# drive the REAL nh / nix-store / nix-env against the live store. Aborting turns
+# that silent, potentially destructive trap into a loud, safe stop. Scoped to the
+# mutating verbs so read-only commands keep ignoring the vars outright (a hostile
+# project environment can neither spoof nor block a plain `doctor`/`capabilities`).
+guard_production_mutation() {
+  [[ "$test_hooks" == 1 ]] && return 0
+  local v
+  for v in ATYRODE_NH ATYRODE_NIX_STORE ATYRODE_NIX_ENV ATYRODE_GIT ATYRODE_GEN_PROFILE; do
+    [[ -z "${!v:-}" ]] || die "$EX_USAGE" \
+      "$1 refuses to run: $v is set but a production build ignores it, so this would drive the real tool against the live store — unset $v, or use a build with enableTestHooks = true for stubs"
+  done
+}
+
 main() {
   local subcommand="${1:-help}"
   shift || true
+  # A production binary must never mutate the store while a caller believes its
+  # tool overrides are in effect (they are not) — refuse before dispatching.
+  case "$subcommand" in
+    apply | clean | rollback) guard_production_mutation "$subcommand" ;;
+  esac
   case "$subcommand" in
     apply) apply_config "$@" ;;
     clean) cmd_clean "$@" ;;


### PR DESCRIPTION
## The near-miss this prevents

The tool-substitution seams (`ATYRODE_NH`, `ATYRODE_NIX_STORE`, `ATYRODE_NIX_ENV`, `ATYRODE_GIT`, `ATYRODE_GEN_PROFILE`) are honoured only under `enableTestHooks`. A production binary **silently ignored** them — which is a trap: a caller who exports them expecting stubs (as the checks do) would instead drive the **real** `nh`/`nix-store` against the live store.

That happened during development on this branch's predecessor: the production binary was run with stub overrides and kicked off a real `nh clean`. No damage occurred (a fake `XDG_STATE_HOME` made `nh` find no user profile, root-owned gcroots hit permission-denied, and a SIGPIPE killed it before GC) — but it was luck, not design. At a moment with real consequences it could have run a real `nh clean` + `nix-store --gc`.

## The fix

Turn the silent ignore into a **loud refusal** for the store-mutating verbs (`apply`/`clean`/`rollback`): if any tool-substitution override is set on a production build, abort before dispatch with a clear message:

```
$ ATYRODE_NH=/stub atyrode clean --yes
atyrode: clean refuses to run: ATYRODE_NH is set but a production build ignores it,
so this would drive the real tool against the live store — unset ATYRODE_NH, or use
a build with enableTestHooks = true for stubs
$ echo $?
64
```

**Scoped deliberately to the mutating commands.** Read-only commands (`doctor`/`capabilities`/`host`) keep ignoring the vars outright, so:
- the existing "production ignores identity spoofing" contract is unchanged (that test drives `doctor host`, which is read-only);
- a hostile project `.envrc` can neither spoof identity nor DoS a plain diagnostic — only a *mutating* command refuses, and refusing is strictly safer than mutating.

## Testing

`nix build .#checks.x86_64-linux.atyrode-cli` (green), `nixfmt`/`shellcheck` clean. New `atyrode-cli` assertions: production `clean`/`apply`/`rollback` each refuse (exit 64, naming the offending var) with an override present, while a read-only command with the same var still runs. Also verified by hand: reran the original accident against the production binary — it now aborts before any real tool call.

Follows #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
