### PR TITLE
fix(code): restore facet glyphs, rework generator UI, fix list overflow

### DIFF
--- a/agents/skills/tui-visual-verification/SKILL.md
+++ b/agents/skills/tui-visual-verification/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: tui-visual-verification
+description: Run a Bubble Tea (or any terminal) TUI headlessly, drive it with keys, and verify the rendered output — character-exact via tmux capture-pane, pixel-level via freeze PNG renders. Use whenever building or changing TUI layout, colors, or glyphs.
+---
+
+# TUI visual verification (tmux capture + freeze)
+
+Unit tests on render functions miss what actually reaches the terminal: wrapped
+rows that overflow a pane, styles that reset mid-line, glyphs silently wiped to
+empty strings. Verify TUI changes against the real program, headlessly.
+
+## 0. Agent environments suppress color — undo that first
+
+Agent harnesses commonly export `NO_COLOR=1`, `CI=1`, and `TERM=dumb`. lipgloss
+honors `NO_COLOR` and renders colorless, so a naive run "proves" a color bug
+that does not exist. Always launch the app under test with:
+
+```console
+$ env -u NO_COLOR CLICOLOR_FORCE=1 COLORTERM=truecolor TERM=xterm-256color <app>
+```
+
+Know the ceiling: termenv caps any `TERM` beginning with `tmux`/`screen` at
+ANSI-256, so hex colors appear as approximations inside tmux. That is fine for
+verification (colors present, distinguishable); do not chase truecolor there.
+
+## 1. Character-exact verification with tmux (authoritative)
+
+Run the TUI in a detached tmux session, drive it with `send-keys`, and read
+back the exact rendered character grid:
+
+```console
+$ tmux new-session -d -s tui -x 150 -y 44 \
+    "env -u NO_COLOR CLICOLOR_FORCE=1 CODE_GENERATED=… <app>; sleep 300"
+$ tmux send-keys -t tui Down Down Right          # navigate and change a dial
+$ tmux capture-pane -t tui -p  > /tmp/frame.txt  # plain text grid
+$ tmux capture-pane -t tui -pe > /tmp/frame.ansi # with SGR color sequences
+```
+
+This is deterministic and assertable:
+
+- **Layout / overflow**: count physical lines, check every row's width, and
+  look at the *bottom* of the frame — vertical overflow from wrapped or added
+  rows always lands there (pushed footers, clipped hints).
+- **Glyphs**: Nerd Font icons live in the Private Use Area and are *invisible*
+  in most editors and agent tooling — never eye-verify them, and never retype a
+  source line containing them (that is how they get wiped). Grep the capture
+  for the exact codepoints (e.g. `\uf02d`) programmatically.
+- **Colors / style bleed**: inspect the SGR sequences in the `-e` capture
+  around a suspect region (e.g. text that wraps and loses its dim style).
+
+For `code` specifically: build with `nix build .#code-tui`, generate the grid
+with `MODELS_YML=omp/models.yml python3 pkgs/omp-configured/generate-profiles.py`,
+and point `CODE_GENERATED` at the output. No further wrapper env is required.
+
+## 2. Pixel-level view with freeze (validated, deterministic)
+
+To actually *look* at a frame (colors, pills, contrast), render the ANSI
+capture to PNG with `freeze` — no server, no browser, no client sizing:
+
+```console
+$ nix shell nixpkgs#charm-freeze -c \
+    freeze --language ansi /tmp/frame.ansi -o /tmp/frame.png \
+    --font.family "JetBrains Mono,Symbols Nerd Font Mono"
+```
+
+Install the fonts once where freeze runs (`nixpkgs#jetbrains-mono`,
+`nixpkgs#nerd-fonts.symbols-only` → `~/.local/share/fonts` + `fc-cache -f`).
+Caveat: freeze's per-glyph font fallback is imperfect, so PUA icons may render
+as boxes even when correct — the codepoint grep from step 1 stays authoritative
+for glyphs; the PNG is for layout and color judgment.
+
+## 3. Alternatives for live or scripted viewing
+
+- **vhs** (`nixpkgs#vhs`): scripted terminal driver — `.tape` files with
+  `Type`/`Down`/`Sleep`/`Screenshot`/`Set FontFamily` — good for repeatable
+  demo flows. It drives ttyd + headless Chromium underneath, so it shares that
+  stack's flakiness in constrained agent sandboxes; prefer tmux + freeze for
+  verification.
+- **ttyd** (`nixpkgs#ttyd`): serve `tmux attach -t tui` over loopback HTTP and
+  screenshot from a browser tool — the only option for *watching* a session
+  live. Flaky under headless browsers (stalled loads, blank canvas, scrollback
+  cropping after resizes). If used: attach the browser client *before* the app
+  draws so it sets the window size, reload the page after any resize, and pass
+  `-t 'fontFamily=Symbols Nerd Font Mono,monospace'` for glyphs.
+
+## 4. Cleanup
+
+Kill the session and any server when done: `tmux kill-server`,
+`kill $(cat /tmp/ttyd.pid)`.

--- a/pkgs/cli-kit/layout.go
+++ b/pkgs/cli-kit/layout.go
@@ -54,7 +54,12 @@ func WindowList(lines []string, cursor, h, w int) string {
 		vis = append(vis, "")
 	}
 	lw := w - 1 // reserve a column for the scrollbar
-	list := lipgloss.NewStyle().Width(lw).MaxWidth(lw).Render(strings.Join(vis, "\n"))
+	// Clip BEFORE fixing the width: Width() word-wraps over-wide lines onto
+	// extra physical rows, silently making the column taller than h and pushing
+	// everything below it off-screen. MaxWidth alone truncates per line without
+	// wrapping; Width then only pads the (now fitting) lines to a stable lw.
+	clipped := lipgloss.NewStyle().MaxWidth(lw).Render(strings.Join(vis, "\n"))
+	list := lipgloss.NewStyle().Width(lw).Render(clipped)
 	return lipgloss.JoinHorizontal(lipgloss.Top, list, Scrollbar(total, h, start))
 }
 

--- a/pkgs/cli-kit/layout_test.go
+++ b/pkgs/cli-kit/layout_test.go
@@ -1,0 +1,44 @@
+package clikit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TestWindowListNeverWraps locks the height contract: a row wider than the
+// column must be CLIPPED, not wrapped — wrapping grew the column past h
+// physical lines and pushed everything below it (footers) off-screen.
+func TestWindowListNeverWraps(t *testing.T) {
+	long := strings.Repeat("x", 120) + " " + strings.Repeat("y", 80) // the space invites word-wrap
+	lines := []string{"short", long, "tail"}
+	const w = 30
+	for _, h := range []int{2, 3, 5} {
+		out := WindowList(lines, 0, h, w)
+		rows := strings.Split(out, "\n")
+		if len(rows) != h {
+			t.Errorf("h=%d: got %d physical rows, want exactly %d", h, len(rows), h)
+		}
+		for i, r := range rows {
+			if rw := lipgloss.Width(r); rw > w {
+				t.Errorf("h=%d row %d overflows the column: %d > %d", h, i, rw, w)
+			}
+		}
+	}
+}
+
+// TestWindowListStableGeometry: short content keeps the exact h × w footprint
+// (padded rows, blank scrollbar column) — the invariant layouts build on.
+func TestWindowListStableGeometry(t *testing.T) {
+	out := WindowList([]string{"a", "b"}, 0, 4, 20)
+	rows := strings.Split(out, "\n")
+	if len(rows) != 4 {
+		t.Fatalf("got %d rows, want 4", len(rows))
+	}
+	for i, r := range rows {
+		if rw := lipgloss.Width(r); rw != 20 {
+			t.Errorf("row %d width = %d, want 20", i, rw)
+		}
+	}
+}

--- a/pkgs/code-tui/default.nix
+++ b/pkgs/code-tui/default.nix
@@ -16,11 +16,13 @@ buildGoModule {
     ];
   };
   modRoot = "code-tui";
-  # cli-kit is a local `replace` whose source lives in this build's src (above),
-  # so any change to pkgs/cli-kit/*.go shifts this hash — bump it on cli-kit edits.
-  # A plain build can reuse a cached FOD and hide the change; get the true value
-  # from a fake-hash build (set to sha256-AAA…, read the reported `got:`) or CI.
-  vendorHash = "sha256-JbqO9z0UhyNRGJuT7PJrzsyJsc1VLrtbxBaNgnUfDtQ=";
+  # cli-kit is a local `replace` resolved from this build's src (above). With
+  # plain vendoring `go mod vendor` would copy cli-kit INTO the vendor FOD, so
+  # every cli-kit edit shifted this hash — and a warm cache could silently reuse
+  # a stale FOD and mask the change. proxyVendor keeps only the remote module
+  # cache in the FOD: the hash moves only when go.mod/go.sum change.
+  proxyVendor = true;
+  vendorHash = "sha256-8Ay9Rav9W+kM84C4DUqCZuwUJJ70nphS3tG6gdoTv64=";
 
   # The prompt→profile generator is invoked as `code`.
   postInstall = ''

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -841,9 +841,9 @@ func (m model) mode() int {
 		return modeSplit
 	}
 	// too narrow for side-by-side; stack the preview below the list if the
-	// terminal is tall enough to give the list, footer, and preview a usable
-	// share, else collapse.
-	if m.bodyH() >= 17 {
+	// terminal is tall enough to give the list, footer, and preview (with its
+	// pill head + fallback hint) a usable share, else collapse.
+	if m.bodyH() >= 19 {
 		return modeStacked
 	}
 	return modeCollapsed
@@ -912,7 +912,7 @@ func (m model) launchFooter() []string {
 // 1-line divider) between the list and the preview: the list takes what its
 // content needs, capped at ~60% and floored so the preview keeps ≥ minPrev rows.
 func stackedSplit(bodyH, bodyLen int) (listH, prevH int) {
-	const sep, minPrev, minList = 1, 6, 3
+	const sep, minPrev, minList = 1, 8, 3 // minPrev covers the preview chrome + ≥4 route rows
 	inner := bodyH - headRows - launchFooterRows - sep
 	listH = bodyLen
 	if c := inner * 3 / 5; listH > c {
@@ -933,19 +933,20 @@ func stackedSplit(bodyH, bodyLen int) (listH, prevH int) {
 
 // previewDims returns the preview viewport's inner (width, height) for the mode.
 // The full-width modes reserve the shared gutter; split leaves the preview's own
-// border + padding to do the breathing.
+// border + padding to do the breathing. Every mode reserves prevChromeRows for
+// the pinned pill head above and fallback-display hint below the viewport.
 func (m model) previewDims() (int, int) {
 	bodyH := m.contentH()
 	switch m.mode() {
 	case modeCollapsed:
-		return m.w - gut, bodyH
+		return m.w - gut, bodyH - prevChromeRows
 	case modeStacked:
 		body, _ := m.bodyLines()
 		_, ph := stackedSplit(bodyH, len(body))
-		return m.w - gut, ph
+		return m.w - gut, ph - prevChromeRows
 	default: // split — the pane draws a border + prevPadL inside its width, so the
 		// viewport (what renderRoute wraps to) gets the inner text area, not the box.
-		return m.w - m.listW() - 3 - prevPadL, bodyH
+		return m.w - m.listW() - 3 - prevPadL, bodyH - prevChromeRows
 	}
 }
 
@@ -1214,33 +1215,14 @@ func (m *model) syncPreview() {
 		return
 	}
 	rw := m.vp.Width
-	// routing rule carries the depth state, so `f` (primary ⇄ full chain) is
-	// discoverable — "primary" = each role's lead model only, "full" = its whole
-	// fallback chain.
-	depthLbl := "primary only"
-	if m.depth == 1 {
-		depthLbl = "full chains"
-	}
-	rHead := "── routing · " + depthLbl + " (f) "
-	rule := stDim.Render("── routing · ") + stHead.Render(depthLbl) +
-		stDim.Render(" (f) "+strings.Repeat("─", max(4, rw-lipgloss.Width(rHead))))
+	// No settings summary here: every dial is already visible (selected) in the
+	// generator list on the left, so the preview shows only what that selection
+	// produces — the role → model routing itself.
 	var b strings.Builder
 	id := comboID(m.sel)
 	if base, ok := m.generated[id]; ok {
 		_, roles := splitMeta(base)
 		roles = m.applyAdvisor(roles, m.sel["advisor"], m.sel["lane"])
-		// meta line rebuilt from the facets, so it always reflects the
-		// advisor dial and fast toggle (both live outside the baked grid).
-		line := stDim.Render("thinking " + m.sel["thinking"] + " · fallback on · advisor " + m.sel["advisor"])
-		if m.sel["lane"] != "claude-only" {
-			blue := lipgloss.NewStyle().Foreground(lipgloss.Color("#62a7ff"))
-			state := stDim.Render("off")
-			if m.sel["fast"] == "on" {
-				state = blue.Render("on")
-			}
-			line += stDim.Render(" · ") + blue.Render(m.glyphs["fast"]) + stDim.Render(" fast ") + state
-		}
-		b.WriteString(line + "\n" + rule + "\n")
 		b.WriteString(renderRoute(roles, m.depth, m.avail, rw))
 	} else {
 		b.WriteString(stDim.Render("no profile for this combination") + "\n")
@@ -1457,7 +1439,7 @@ func (m model) previewPane(w, h int) string {
 		Border(lipgloss.NormalBorder(), false, false, false, true).
 		BorderForeground(lipgloss.Color(cBord)).PaddingLeft(prevPadL).
 		Width(w).Height(h).
-		Render(m.vp.View())
+		Render(m.previewColumn())
 }
 
 // accent is the context colour — the selected lane in the generator.
@@ -1466,18 +1448,42 @@ func (m model) accent() string {
 	return laneColor(m.sel["lane"])
 }
 
-// sectionTitle is the accent-pilled "generator" label at the top of the left
-// column, coloured by the active lane.
-func (m model) sectionTitle() string {
+// pill renders an accent-backed section label, coloured by the active lane —
+// the shared shape of the generator (left) and routing (right) column heads.
+func (m model) pill(label string) string {
 	return lipgloss.NewStyle().Padding(0, 1).
 		Background(lipgloss.Color(m.accent())).Foreground(lipgloss.Color("#12161d")).Bold(true).
-		Render("generator")
+		Render(label)
+}
+
+// sectionTitle is the accent-pilled "generator" label at the top of the left
+// column.
+func (m model) sectionTitle() string {
+	return m.pill("generator")
 }
 
 // sectionHead is the gutter-inset title plus a blank separator (headRows tall);
 // it stays pinned above the scrolling facet list.
 func (m model) sectionHead() string {
 	return padLeft(m.sectionTitle(), gut) + "\n\n"
+}
+
+// prevChromeRows is the preview column's pinned chrome around the scrolling
+// viewport: the pill head above (headRows) plus a blank + the fallback-display
+// hint below.
+const prevChromeRows = headRows + 2
+
+// previewColumn assembles the right column: the pinned "routing" pill head, the
+// scrolling routing viewport, and the pinned fallback-display hint. The hint's
+// show/hide wording makes clear that f only changes what is DISPLAYED — the
+// launched profile always keeps its fallback chains.
+func (m model) previewColumn() string {
+	verb := "show"
+	if m.depth == 1 {
+		verb = "hide"
+	}
+	return m.pill("routing") + "\n\n" + m.vp.View() + "\n\n" +
+		stDim.Render("f · "+verb+" fallback chains")
 }
 
 // leftColumn renders the pinned section head plus the scrolling list body, the
@@ -1502,7 +1508,7 @@ func (m model) stackedContent(bodyH int) string {
 	listH, prevH := stackedSplit(bodyH, len(body))
 	top := m.leftColumn(m.w, headRows+listH+launchFooterRows)
 	div := stDim.Render(strings.Repeat("─", m.w))
-	preview := lipgloss.NewStyle().MaxHeight(prevH).Render(padLeft(m.vp.View(), gut))
+	preview := lipgloss.NewStyle().MaxHeight(prevH).Render(padLeft(m.previewColumn(), gut))
 	return lipgloss.JoinVertical(lipgloss.Left, top, div, preview)
 }
 
@@ -1517,7 +1523,7 @@ func (m model) View() string {
 	switch m.mode() {
 	case modeCollapsed:
 		if m.showResult && m.w < 62 {
-			content = padLeft(m.vp.View(), gut)
+			content = padLeft(m.previewColumn(), gut)
 		} else {
 			content = m.leftColumn(m.w, ch)
 		}
@@ -1552,7 +1558,14 @@ func (m model) genLines() ([]string, int) {
 			ptr = lipgloss.NewStyle().Foreground(lipgloss.Color(acc)).Render("▸ ")
 			cursor = len(lines)
 		}
-		row := fmt.Sprintf("%s%s%s", ptr, gly, stDim.Render(pad(f.key, 9)))
+		// main renders as fable's tabulated child "default": the indent + the
+		// default-role row lighting up Fable in the preview explain themselves,
+		// so it carries no flavor text (which would wrap on narrow panes anyway).
+		label, childPad := f.key, ""
+		if f.key == "main" {
+			label, childPad = "default", "  "
+		}
+		row := fmt.Sprintf("%s%s%s%s", ptr, childPad, gly, stDim.Render(pad(label, 9-len(childPad))))
 		for _, v := range f.values {
 			switch {
 			case v == m.sel[f.key]:
@@ -1584,24 +1597,31 @@ func (m model) genLines() ([]string, int) {
 				}
 				row += "   " + stWarn.Render(gWarn+" "+w+" — no usage left")
 			}
-		case f.key == "main" && m.sel["main"] == "on":
-			row += "   " + stDim.Render("Fable leads the default agent — heaviest draw on its scarce bucket")
 		case f.key == "fast" && m.sel["fast"] == "on":
-			row += "   " + stDim.Render("priority service tier — quicker OpenAI replies")
+			row += "   " + stDim.Render("GPT only")
 		}
 		lines = append(lines, row)
 	}
 	return lines, cursor
 }
 
-func main() {
-	// Facet glyphs are intrinsic to the generator, so the binary carries sane
-	// defaults (Nerd Font, FA range). CODE_FACET_GLYPHS may override any of them.
-	//   lane ⇄  model ⚙  thinking 💡  spark 🚀  fable 📖  main 🎯  fast ⚡
-	glyphs := map[string]string{
-		"lane": "", "model": "", "thinking": "", "advisor": "",
-		"spark": "", "fable": "", "main": "\uf140", "fast": "",
+// defaultGlyphs is the built-in facet-glyph set (Nerd Font, Font Awesome PUA
+// range), written as explicit \u escapes so the codepoints stay visible and
+// verifiable in source — a literal PUA glyph is invisible in most editors and
+// was once wiped by an edit exactly because of that. CODE_FACET_GLYPHS may
+// override any entry (see main).
+//
+//	lane ⇄ (f127)  model ⚙ (f085)  thinking 💡 (f0eb)  advisor 🧭 (f14e)
+//	spark 🚀 (f135)  fable 📖 (f02d)  default 🎯 (f140)  fast ⚡ (f0e7)
+func defaultGlyphs() map[string]string {
+	return map[string]string{
+		"lane": "\uf127", "model": "\uf085", "thinking": "\uf0eb", "advisor": "\uf14e",
+		"spark": "\uf135", "fable": "\uf02d", "main": "\uf140", "fast": "\uf0e7",
 	}
+}
+
+func main() {
+	glyphs := defaultGlyphs()
 	for _, kv := range strings.Split(os.Getenv("CODE_FACET_GLYPHS"), ",") {
 		if p := strings.SplitN(kv, "=", 2); len(p) == 2 && p[1] != "" {
 			glyphs[p[0]] = p[1]

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -1,11 +1,19 @@
 package main
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/charmbracelet/lipgloss"
 )
+
+// ansiRe strips SGR sequences so tests assert on visible text regardless of the
+// active color profile.
+var ansiRe = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func stripAnsi(s string) string { return ansiRe.ReplaceAllString(s, "") }
 
 // A realistic full-name routing row: renderRoute shortens the names for display.
 const sampleRow = "  default    gpt-5.6-terra:medium → gpt-5.6-luna:medium → claude-sonnet-5:medium → claude-haiku-4-5:medium"
@@ -231,5 +239,90 @@ func TestUnmodified(t *testing.T) {
 	}
 	if m := (model{sel: defaultSel(), firstPrompt: "add a login endpoint"}); m.unmodified() {
 		t.Errorf("a typed prompt should count as modified even at defaults")
+	}
+}
+
+// TestDefaultGlyphs pins the built-in facet glyphs to their Nerd Font (FA PUA)
+// codepoints. The literals are invisible in most editors — an edit once wiped
+// them all to empty strings without anything failing; this locks each value.
+func TestDefaultGlyphs(t *testing.T) {
+	want := map[string]rune{
+		"lane": 0xf127, "model": 0xf085, "thinking": 0xf0eb, "advisor": 0xf14e,
+		"spark": 0xf135, "fable": 0xf02d, "main": 0xf140, "fast": 0xf0e7,
+	}
+	g := defaultGlyphs()
+	if len(g) != len(want) {
+		t.Errorf("defaultGlyphs has %d entries, want %d", len(g), len(want))
+	}
+	for _, f := range facetDefs(g) {
+		r := []rune(g[f.key])
+		if len(r) != 1 {
+			t.Errorf("glyph for %q is %d runes, want exactly 1", f.key, len(r))
+			continue
+		}
+		if r[0] != want[f.key] {
+			t.Errorf("glyph for %q = U+%04X, want U+%04X", f.key, r[0], want[f.key])
+		}
+	}
+}
+
+// TestGenLinesMainRow: the fable-as-main dial renders as fable's tabulated child
+// labelled "default" (self-explanatory next to the preview), with no flavor text
+// — the old explainer wrapped on narrow panes and broke the layout.
+func TestGenLinesMainRow(t *testing.T) {
+	m := model{facets: facetDefs(defaultGlyphs()), sel: defaultSel()}
+	m.sel["fable"] = "on"
+	m.sel["main"] = "on"
+	lines, _ := m.genLines()
+	var mainRow string
+	for _, ln := range lines {
+		p := stripAnsi(ln)
+		if strings.Contains(p, "default") {
+			mainRow = p
+		}
+		if strings.Contains(p, "Fable leads") {
+			t.Errorf("main row must carry no flavor text, got %q", p)
+		}
+	}
+	if mainRow == "" {
+		t.Fatalf("no row labelled 'default' while fable+main are on:\n%s", stripAnsi(strings.Join(lines, "\n")))
+	}
+	// tabulated child: unfocused prefix is the 2-space pointer slot + a 2-space
+	// indent before the glyph — 2 deeper than every other row.
+	if !strings.HasPrefix(mainRow, strings.Repeat(" ", 4)) {
+		t.Errorf("main row must be indented as fable's child, got %q", mainRow)
+	}
+}
+
+// TestPreviewColumn locks the right column's shape: a pinned "routing" pill on
+// top, no settings-summary line (the dials are visible on the left), and the
+// pinned f cue at the bottom worded as a DISPLAY toggle (show/hide).
+func TestPreviewColumn(t *testing.T) {
+	id := comboID(defaultSel())
+	m := model{
+		generated: map[string][]string{id: {
+			"  thinking medium · fallback on · advisor on",
+			"    default    gpt-5.6-terra:medium → gpt-5.6-luna:medium",
+			"  ● task       gpt-5.6-terra:medium → gpt-5.6-luna:medium",
+		}},
+		sel: defaultSel(),
+		rdy: true,
+	}
+	m.vp = viewport.New(60, 6)
+	m.syncPreview()
+	plain := stripAnsi(m.previewColumn())
+	if !strings.Contains(plain, "routing") {
+		t.Errorf("preview column must carry the routing pill, got:\n%s", plain)
+	}
+	if strings.Contains(plain, "fallback on") || strings.Contains(plain, "thinking medium ·") {
+		t.Errorf("the baked settings-summary line must not reach the preview, got:\n%s", plain)
+	}
+	rows := strings.Split(strings.TrimRight(plain, "\n"), "\n")
+	if last := strings.TrimSpace(rows[len(rows)-1]); last != "f · show fallback chains" {
+		t.Errorf("bottom hint = %q, want %q", last, "f · show fallback chains")
+	}
+	m.depth = 1
+	if plain := stripAnsi(m.previewColumn()); !strings.Contains(plain, "f · hide fallback chains") {
+		t.Errorf("full-chain depth must flip the cue to hide, got:\n%s", plain)
 	}
 }

--- a/pkgs/omp-configured/generate-profiles.py
+++ b/pkgs/omp-configured/generate-profiles.py
@@ -214,13 +214,15 @@ def gen(lane, mtier, thinking, spark, fable, fable_main=False):
         rp = rprov(r)
         t = min(3, base + 1) if r in DELIB else base
         th = thinking if extreme else (BUMP[thinking] if r in DELIB else thinking)
-        # Fable leads the deliberative Claude roles when on; the explicit (manual)
-        # fable-as-main escalation additionally hands it the default role — the
-        # main agent — regardless of the lane's provider preference. Both keep the
-        # smart/normal gate: a 'fast' tier explicitly trades smarts for speed, so
-        # the scarce elite never leads there.
-        fable_here = fable and mtier in ('smart', 'normal') and (
-            (fable_main and r == 'default') or (r in DELIB and rp == 'A'))
+        # Fable leads the deliberative Claude roles when on — gated to the
+        # smart/normal tiers, since a 'fast' tier explicitly trades smarts for
+        # speed. The explicit (manual) fable-as-main escalation is an OVERRIDE:
+        # it hands Fable the default role — the main agent — on every model tier
+        # and regardless of the lane's provider preference, while the rest of the
+        # profile keeps following the dials.
+        fable_here = fable and (
+            (fable_main and r == 'default') or
+            (r in DELIB and rp == 'A' and mtier in ('smart', 'normal')))
         lead = 'fable' if fable_here else LADDER[rp][t]
         out[r] = (lead, th, [(m, th) for m in build_chain(lead, isp)])
     return out


### PR DESCRIPTION
Follow-up fixes on fable-as-main (#161), all operator-reported:

## Fixes

- **Glyph regression**: the Nerd Font facet glyphs were wiped by an edit that retyped the editor-invisible PUA literals. Restored as explicit `\uXXXX` escapes in `defaultGlyphs()` (recovered byte-for-byte from git history), locked by a codepoint-pinning test so this class of wipe can never ship silently again.
- **fable-as-main UI**: renders as fable's tabulated child labelled `default`, no flavor text (the old explainer wrapped on narrow panes with broken styling). Self-explanatory: the indent + the default-role row lighting up in the preview.
- **Right panel**: settings-summary line removed (dials are visible on the left), pinned `routing` pill mirrors the generator head, and the `f` cue is pinned at the bottom worded as a display toggle (`f · show/hide fallback chains`) so it can't read as toggling fallback itself.
- **Vertical overflow (cli-kit)**: `WindowList`'s `Width()` word-wrapped over-wide rows onto extra physical lines, silently growing the column past `h` and pushing footers off-screen. Now clips (`MaxWidth`) before padding; contract test added (`TestWindowListNeverWraps`).
- **fable-as-main × fast tier**: the manual override now hands Fable the default role on *every* model tier while the rest of the profile follows the dials. All 292 original grid blocks remain byte-identical; the 126 `famain` blocks all route `default → claude-fable-5` (verified programmatically).
- **fast explainer** shortened to `GPT only`.

## Build hygiene

- `proxyVendor = true` for code-tui: the local cli-kit `replace` no longer leaks into the vendor FOD, so `vendorHash` only moves on `go.mod`/`go.sum` changes. Proven: a cli-kit source edit rebuilds without invalidating the hash (previously every cli-kit edit demanded a manual fake-hash dance and a warm cache could mask changes).

## Tooling for future agents

- New `agents/skills/tui-visual-verification` skill (auto-linked to `~/.agents/skills`): headless TUI verification via tmux `capture-pane` (character/codepoint-exact) + `charm-freeze` PNG renders, with the `NO_COLOR`/`CLICOLOR_FORCE`, termenv-tmux-256, font, and client-sizing caveats learned here. Companion tooling proposal: #163.

## Verification

- `go test` cli-kit + code-tui (new: glyph pinning, main-row rendering, preview column structure, WindowList contract) — pass; gofmt clean.
- Generator grid re-diffed: 0 changed / 0 removed original blocks, 126 `famain` blocks with fable-led default.
- Live end-to-end in tmux: drove the real binary through fable→default→fast states; verified glyph codepoints in the captured grid, correct routing, no overflow; reviewed a freeze PNG render visually (colors, pills, alignment).
- `nix flake check` — all checks passed.