### PR TITLE
fix(atyrode): clean output — GC progress, fold nh's verbose plan (+--verbose), honest preview count

### DIFF
--- a/checks/atyrode-cli.nix
+++ b/checks/atyrode-cli.nix
@@ -34,11 +34,18 @@ pkgs.runCommand "check-atyrode-cli"
     #!${pkgs.runtimeShell}
     printf '%s\n' "$*" > "$TMPDIR/nh-args"
     if [[ "''${ATYRODE_NH_NOISE:-0}" == 1 ]]; then
-      # Reproduce nh clean's real output shape: a genuine generation removal, the
-      # benign root-owned gcroots permission flood, and one real (non-permission)
-      # error — so the check can prove fold_gcroots_noise keeps the first and last
-      # while collapsing the flood.
+      # Reproduce nh 4.4.1 clean's real output shape: a verbose evaluation plan
+      # (Welcome/legend/one line per gcroot), the benign root-owned gcroots
+      # permission flood, and one real (non-permission) error — so the check can
+      # prove the plan and flood are folded while a genuine error survives.
+      echo 'Welcome to nh clean'
+      echo 'legend:'
+      echo 'OK: path to be kept'
+      echo 'gcroots'
       echo '- OK  /home/alex/.local/state/nix/profiles/profile-9-link'
+      echo '- DEL /nix/var/nix/profiles/per-user/root/channels-1-link'
+      echo '/home/alex/.local/state/nix/profiles/home-manager'
+      echo '- OK  /home/alex/.local/state/nix/profiles/home-manager-62-link'
       echo '> Removing /nix/var/nix/gcroots/auto/lvi04m7mn76ymzgzcx5rrifj5019psvd'
       echo '! Failed to remove path="/nix/var/nix/gcroots/auto/lvi04m7mn76ymzgzcx5rrifj5019psvd" err=Os { code: 13, kind: PermissionDenied, message: "Permission denied" } (nh/crates/nh-clean/src/clean.rs:606)'
       echo '> Removing /nix/var/nix/gcroots/auto/phm61mw9l2zpvj3fj6pmmyk22b1l3qg8'
@@ -46,8 +53,8 @@ pkgs.runCommand "check-atyrode-cli"
       echo '! Failed to remove path="/nix/store/genuine" err=Os { code: 2, kind: NotFound }' >&2
     elif [[ "''${ATYRODE_NH_REAP:-0}" == 1 ]]; then
       # Under elevation nh removes the same daemon-owned roots cleanly (no paired
-      # PermissionDenied), so the flood inverts into successful removals the fold
-      # must count as reaped rather than echo one-per-root.
+      # PermissionDenied), so the fold counts them as reaped (removals − failures)
+      # rather than echoing one line per root.
       echo '- OK  /home/alex/.local/state/nix/profiles/profile-9-link'
       echo '> Removing /nix/var/nix/gcroots/auto/lvi04m7mn76ymzgzcx5rrifj5019psvd'
       echo '> Removing /nix/var/nix/gcroots/auto/phm61mw9l2zpvj3fj6pmmyk22b1l3qg8'
@@ -502,8 +509,9 @@ pkgs.runCommand "check-atyrode-cli"
     ' <<<"$clean_json" >/dev/null \
       || { echo "clean --json summary wrong: $clean_json" >&2; exit 1; }
 
-    # clean folds nh's benign root-owned gcroots permission flood, keeps genuine
-    # removals and real (non-permission) errors, and resolves to a legible footer.
+    # clean folds nh's verbose evaluation plan AND the benign root-owned gcroots
+    # permission flood into its own footer, while a genuine (non-permission) error
+    # still survives.
     export ATYRODE_NIX_STORE="$TMPDIR/bin/fake-gc"
     noise_out="$(ATYRODE_NH_NOISE=1 atyrode clean --keep 3 2>&1 >/dev/null)"
     unset ATYRODE_NIX_STORE
@@ -523,10 +531,23 @@ pkgs.runCommand "check-atyrode-cli"
       && { echo 'footer must not print the old unrunnable sudo atyrode clean hint' >&2; exit 1; }
     grep -qF 'gcroots/auto/lvi04m7mn76' <<<"$noise_out" \
       && { echo 'clean must not print individual gcroots permission failures' >&2; exit 1; }
-    grep -qF 'profile-9-link' <<<"$noise_out" \
-      || { echo 'clean must keep genuine generation removals' >&2; exit 1; }
+    for folded in 'Welcome to nh clean' 'legend:' 'profile-9-link' 'home-manager-62-link' 'channels-1-link'; do
+      grep -qF "$folded" <<<"$noise_out" \
+        && { echo "clean must fold nh's verbose plan line: $folded" >&2; exit 1; }
+    done
     grep -qF '/nix/store/genuine' <<<"$noise_out" \
       || { echo 'clean must keep real (non-permission) failures' >&2; exit 1; }
+
+    # --verbose passes nh's full evaluation plan through instead of folding it.
+    export ATYRODE_NIX_STORE="$TMPDIR/bin/fake-gc"
+    verbose_out="$(ATYRODE_NH_NOISE=1 atyrode clean --keep 3 --verbose 2>&1 >/dev/null)"
+    unset ATYRODE_NIX_STORE
+    for shown in 'Welcome to nh clean' 'profile-9-link' 'home-manager-62-link'; do
+      grep -qF "$shown" <<<"$verbose_out" \
+        || { echo "--verbose must pass nh's plan line through: $shown" >&2; exit 1; }
+    done
+    grep -qF 'skipped 2 root-owned GC root(s)' <<<"$verbose_out" \
+      || { echo "--verbose must still tally skipped gcroots: $verbose_out" >&2; exit 1; }
 
     # Under elevation (EUID 0) the same roots are removed cleanly: the footer
     # reports them as reaped, counts (not echoes) them, and drops the sudo hint.
@@ -570,6 +591,19 @@ pkgs.runCommand "check-atyrode-cli"
       || { echo "declining must abort the clean: $decline_out" >&2; exit 1; }
     test ! -e "$TMPDIR/gc-args" \
       || { echo 'a declined clean must not collect garbage' >&2; exit 1; }
+
+    # The preview count honours BOTH --keep and --keep-since — it must not promise
+    # a removal that keep-since will spare. Stub generations: #1 2026-05-01,
+    # #2 2026-06-01, #3 2026-07-01 (current). All decline (n) so nothing runs.
+    keep_floor="$(printf 'n\n' | _ATYRODE_TEST_TTY=1 atyrode clean --keep 5 2>&1)"
+    grep -qF 'remove 0 of 3 generation(s)' <<<"$keep_floor" \
+      || { echo "preview: --keep above the total must spare all: $keep_floor" >&2; exit 1; }
+    since_wide="$(printf 'n\n' | _ATYRODE_TEST_TTY=1 atyrode clean --keep 0 --keep-since 100000d 2>&1)"
+    grep -qF 'remove 0 of 3 generation(s)' <<<"$since_wide" \
+      || { echo "preview: a wide --keep-since must spare recent generations: $since_wide" >&2; exit 1; }
+    since_narrow="$(printf 'n\n' | _ATYRODE_TEST_TTY=1 atyrode clean --keep 0 --keep-since 1s 2>&1)"
+    grep -qF 'remove 2 of 3 generation(s)' <<<"$since_narrow" \
+      || { echo "preview: a 1s --keep-since must count the older generations: $since_narrow" >&2; exit 1; }
 
     # Accepting proceeds through the collector.
     accept_out="$(printf 'y\n' | _ATYRODE_TEST_TTY=1 atyrode clean --keep 3 2>&1)"

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -933,25 +933,35 @@ collect_garbage() {
     return 0
   fi
 
-  local out pid rc=0 i=0 deleted=0 last=""
+  local out pid rc=0 i=0 deleted=0 frame=""
   local -a frames=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)
   out="$(mktemp)"
   "${gc[@]}" >"$out" 2>&1 &
   pid=$!
-  # nix-store --gc streams one `deleting '/nix/store/…'` line per path it removes.
-  # Tally those live and surface the path in flight, so the long opaque middle of
-  # a clean shows real motion (count climbing, names scrolling) instead of a bare
-  # spinner that could equally mean "working" or "hung".
+  # nix-store --gc first scans the whole store for unreachable paths (the deleted
+  # count sits at 0 for a while) and only then removes them. Reflect both phases on
+  # a single \r-rewritten line so the long opaque middle shows real motion. The
+  # line is kept short and carries no store path on purpose: a line that wraps past
+  # the terminal width defeats the carriage-return redraw and stacks up stale
+  # copies instead of updating in place (and "0 paths freed" mid-scan reads as
+  # stuck, so that phase says "scanning" instead).
   while kill -0 "$pid" 2>/dev/null; do
-    deleted="$(grep -c "^deleting '" "$out" 2>/dev/null || printf 0)"
-    last="$(grep "^deleting '" "$out" 2>/dev/null | tail -n1 || true)"
-    last="${last#deleting \'}"; last="${last%\'}"
-    [[ -n "$last" ]] && last="$(basename "$last")"
-    printf '\r\033[K  %s collecting garbage — %s paths freed%s' \
-      "$(paint 36 "${frames[$((i++ % ${#frames[@]}))]}")" \
-      "$(paint '1' "$deleted")" \
-      "${last:+  $(paint 2 "${last:0:44}")}" >&2
-    sleep 0.15
+    # grep -c already prints "0" on no match (and exits 1); `|| true` keeps that
+    # single "0" instead of appending a second one — a "0\n0" value embeds a
+    # newline that splits the progress line and breaks the \r redraw.
+    deleted="$(grep -c "^deleting '" "$out" 2>/dev/null || true)"
+    # Advance the spinner in the parent shell: doing i++ inside the $(paint …)
+    # command substitution would increment a throwaway subshell copy, freezing the
+    # frame (SC2030/SC2031).
+    frame="${frames[$((i++ % ${#frames[@]}))]}"
+    if [[ "${deleted:-0}" -eq 0 ]]; then
+      printf '\r\033[K  %s %s' "$(paint 36 "$frame")" \
+        "$(paint 2 'collecting garbage — scanning the store…')" >&2
+    else
+      printf '\r\033[K  %s collecting garbage — %s paths freed' \
+        "$(paint 36 "$frame")" "$(paint '1' "$deleted")" >&2
+    fi
+    sleep 0.12
   done
   wait "$pid" || rc=$?
   printf '\r\033[K' >&2

--- a/pkgs/atyrode/atyrode
+++ b/pkgs/atyrode/atyrode
@@ -32,7 +32,7 @@ Usage:
   atyrode host [HOST] [--json]
   atyrode generations [--json] [--sizes]
   atyrode rollback [--to N] [--dry-run] [--yes]
-  atyrode clean [--dry-run] [--keep N] [--keep-since DUR] [--all] [--yes] [--json]
+  atyrode clean [--dry-run] [--keep N] [--keep-since DUR] [--all] [--yes] [--verbose] [--json]
 
 The host registry is the authority for identity, platform, and capabilities.
 apply activates the published flake by default, resolving REF (default main)
@@ -45,8 +45,9 @@ macOS, home-manager on Linux); rollback activates an earlier one (previous by
 default, or --to N) after confirming. clean reclaims disk from generations the
 config no longer references, always keeping the current one and a rollback
 window (--keep / --keep-since); it previews the plan and asks before touching
-anything (--yes skips the prompt, --dry-run only previews), and on macOS it also
-sweeps stale Home Manager Apps aliases. The auto GC roots that pin old
+anything (--yes skips the prompt, --dry-run only previews), folds nh's verbose
+evaluation plan into its own summary (--verbose passes nh's full output through),
+and on macOS it also sweeps stale Home Manager Apps aliases. The auto GC roots that pin old
 generations are owned by the Nix daemon; a non-root clean cannot unlink them and
 prints the exact `sudo … nix-store --gc` command to reap them (atyrode never
 self-elevates). Commands reserved for later issues: workspace and agent.
@@ -979,30 +980,35 @@ collect_garbage() {
   rm -f "$out"
 }
 
-# fold_gcroots_noise collapses one expected, benign flood in nh clean's output:
-# the "Failed to remove path …/gcroots/auto/… PermissionDenied" lines. Those auto
-# GC roots are owned by the Nix daemon/root, so a user-scope clean cannot unlink
-# them — but that is harmless, the store GC still reclaims whatever they no longer
-# protect. nh prints one such line per root, which drowns the real work and reads
-# like a crash. Here we suppress them and write two space-separated tallies —
-# skipped (permission-denied) and reaped (removed cleanly) — to the file named by
-# the first argument, so cmd_clean can report them once in its summary footer.
-# Every other line — generation removals, genuine errors, non-permission failures
-# — passes through untouched. A "> Removing …/gcroots/auto/…" line is held one
-# step: a paired PermissionDenied suppresses it as skipped, otherwise it flushes
-# as a reaped root (counted, not echoed one-per-root — under elevation the flood
-# would just invert from failures to removals). Reaped roots only appear when the
-# clean runs with enough privilege to unlink them (see cmd_clean's reap hint).
-fold_gcroots_noise() {
-  local count_file="${1:-/dev/null}"
-  awk -v countfile="$count_file" '
-    function flush_pending() { if (pending != "") { reaped++; pending = "" } }
-    /^> Removing .*\/gcroots\/auto\// { flush_pending(); pending = $0; next }
-    /Failed to remove path.*\/gcroots\/auto\/.*PermissionDenied/ { skipped++; pending = ""; next }
-    { flush_pending(); print }
+# fold_nh_clean_noise tames `nh clean`'s output down to what matters. nh 4.4.1
+# prints a full evaluation plan on every run — a legend plus one "- OK/RE/DEL"
+# line per GC root (well over 100 lines) — and one "> Removing …/gcroots/auto/…"
+# plus paired "! Failed … PermissionDenied" per daemon-owned root a user-scope
+# clean cannot unlink. atyrode already reports the outcome in its own footer, so
+# by default we drop the plan and the auto-gcroot chatter, keeping only genuine
+# (non-permission) errors and anything unexpected. Two tallies are written to the
+# file named by the first argument: skipped (permission failures) and reaped
+# (auto-root removals that succeeded = removals − failures; counted by totals, as
+# nh emits the removals and failures in separate batches, not adjacent pairs). The
+# second argument, when 1 (--verbose), passes nh's full output through untouched
+# while still counting. ANSI colour is stripped only for matching; kept lines
+# print with their original colouring.
+fold_nh_clean_noise() {
+  local count_file="${1:-/dev/null}" verbose="${2:-0}"
+  awk -v countfile="$count_file" -v verbose="$verbose" '
+    { s = $0; gsub(/\033\[[0-9;]*m/, "", s) }
+    s ~ /^> Removing .*\/gcroots\/auto\// { removing++; if (!verbose) next }
+    s ~ /Failed to remove path.*\/gcroots\/auto\/.*PermissionDenied/ { failed++; if (!verbose) next }
+    !verbose && s ~ /^(Welcome to nh clean|Keeping |legend:|RE:|OK:|DEL:)/ { next }
+    !verbose && s ~ /^(orphaned gcroots|gcroots)$/ { next }
+    !verbose && s ~ /^- (OK|RE|DEL)/ { next }
+    !verbose && s ~ /\/nix\/profiles\/[A-Za-z0-9._-]+$/ { next }
+    !verbose && s ~ /Profiles directory not found/ { next }
+    !verbose && s ~ /^[[:space:]]*$/ { next }
+    { print }
     END {
-      flush_pending()
-      printf "%d %d\n", skipped + 0, reaped + 0 > countfile
+      reaped = removing - failed; if (reaped < 0) reaped = 0
+      printf "%d %d\n", failed + 0, reaped + 0 > countfile
     }
   '
 }
@@ -1104,35 +1110,63 @@ clean_footer() {
   printf 'atyrode: %s\n' "$out" >&2
 }
 
-# clean_preview describes what a clean is about to do — its keep window, how many
-# of the current generations fall outside it (an upper bound: nh additionally
-# spares anything newer than --keep-since), and that the current generation and
-# rollback window are never touched — so an accidental `atyrode clean` can be read
-# and declined before anything is removed. Store reclaim is not estimated: closure
-# sizes overlap heavily, so the honest figure is the one the GC reports afterwards.
+# keepsince_cutoff resolves --keep-since (nh's compact form: 30d, 1h, 4w, 45m, …)
+# to an epoch-second cutoff; anything newer is always kept. Prints nothing when the
+# duration can't be parsed, so callers fall back to a keep-only estimate.
+keepsince_cutoff() {
+  local dur="$1" num
+  [[ "$dur" =~ ^([0-9]+)[[:space:]]*([A-Za-z]+)$ ]] || return 0
+  num="${BASH_REMATCH[1]}"
+  local unit
+  case "${BASH_REMATCH[2]}" in
+    s | sec | secs | second | seconds) unit=seconds ;;
+    m | min | mins | minute | minutes) unit=minutes ;;
+    h | hr | hrs | hour | hours) unit=hours ;;
+    d | day | days) unit=days ;;
+    w | week | weeks) unit=weeks ;;
+    *) return 0 ;;
+  esac
+  date -d "$num $unit ago" +%s 2>/dev/null || true
+}
+
+# clean_preview describes what a clean is about to do — its keep window, exactly
+# how many generations fall outside it (honouring BOTH --keep and --keep-since, so
+# it never over-promises a removal that keep-since will spare), and that the
+# current generation and rollback window are never touched — so an accidental
+# `atyrode clean` can be read and declined before anything is removed. Store
+# reclaim is not estimated: closure sizes overlap heavily, so the honest figure is
+# the one the GC reports afterwards.
 clean_preview() {
   local scope="$1" keep="$2" keep_since="$3"
   local profile; profile="$(gen_profile)"
-  local -a gens=()
-  local line gen rest current="" total=0 candidates=0 i rank
+  local -a gens=() dates=()
+  local line gen d t rest current="" total=0 removable=0 i rank
   if [[ -e "$profile" ]]; then
     while IFS= read -r line; do
-      read -r gen rest <<<"$line"
-      gens+=("$gen")
+      read -r gen d t rest <<<"$line"
+      gens+=("$gen"); dates+=("$d $t")
       [[ "$line" == *"(current)"* ]] && current="$gen"
     done < <(nix_env -p "$profile" --list-generations 2>/dev/null)
   fi
   total=${#gens[@]}
+  local cutoff; cutoff="$(keepsince_cutoff "$keep_since")"
   for (( i = 0; i < total; i++ )); do
     rank=$(( total - 1 - i ))
-    [[ "$rank" -ge "$keep" && "${gens[$i]}" != "$current" ]] && candidates=$(( candidates + 1 ))
+    [[ "$rank" -ge "$keep" && "${gens[$i]}" != "$current" ]] || continue
+    if [[ -n "$cutoff" ]]; then
+      # Removable only if also older than the keep-since window.
+      local ge; ge="$(date -d "${dates[$i]}" +%s 2>/dev/null || echo 0)"
+      [[ "$ge" -gt 0 && "$ge" -lt "$cutoff" ]] && removable=$(( removable + 1 ))
+    else
+      removable=$(( removable + 1 )) # duration unparseable → keep-only upper bound
+    fi
   done
   local bullet; bullet="$(paint 36 '•')"
   printf 'atyrode: %s\n' "$(paint 1 "clean ($scope) is about to:")" >&2
   printf '  %s keep the newest %s generation(s), anything newer than %s, and the current one\n' \
     "$bullet" "$(paint 1 "$keep")" "$(paint 1 "$keep_since")" >&2
-  printf '  %s remove up to %s of %s generation(s) that fall outside that window\n' \
-    "$bullet" "$(paint 33 "$candidates")" "$(paint 1 "$total")" >&2
+  printf '  %s remove %s of %s generation(s) that fall outside that window\n' \
+    "$bullet" "$(paint 33 "$removable")" "$(paint 1 "$total")" >&2
   printf '  %s garbage-collect unreferenced store paths %s\n' \
     "$bullet" "$(paint 2 '(reclaimed space reported after)')" >&2
 }
@@ -1141,7 +1175,7 @@ clean_preview() {
 # keeping the current generation and a rollback window (never an auto-wipe of the
 # safety net). Also sweeps stale macOS app aliases (see clean_macos_residue).
 cmd_clean() {
-  local dry=0 keep=5 keep_since=30d scope=user assume_yes=0 json=0
+  local dry=0 keep=5 keep_since=30d scope=user assume_yes=0 json=0 verbose=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -n | --dry-run) dry=1 ;;
@@ -1149,6 +1183,7 @@ cmd_clean() {
       --keep-since) shift; keep_since="${1:-}" ;;
       --all) scope=all ;; # also the system profile (nix-darwin); needs elevation
       -y | --yes) assume_yes=1 ;;
+      -v | --verbose) verbose=1 ;; # pass nh clean's full evaluation plan through
       --json) json=1 ;; # machine-readable reclaim summary on stdout (cockpit)
       *) die "$EX_USAGE" "unknown clean option: $1" ;;
     esac
@@ -1173,15 +1208,16 @@ cmd_clean() {
   # Let nh remove the stale generations and gcroots, but skip its garbage
   # collection (--no-gc) — nh runs it silently. We collect below instead, with a
   # progress indicator, so the slow final step isn't an unexplained freeze. nh's
-  # own chatter (and the folded gcroots summary) goes to stderr so that under
-  # --json stdout carries only the machine-readable summary; pipefail propagates
-  # nh's exit status through the filter.
+  # own chatter (its plan and the folded gcroots summary) goes to stderr so that
+  # under --json stdout carries only the machine-readable summary; pipefail
+  # propagates nh's exit status through the filter. --verbose passes nh's full
+  # evaluation plan through instead of folding it.
   local gens_before; gens_before="$(count_generations)"
   local nh_args=("$nh_command" clean "$scope" --keep "$keep" --keep-since "$keep_since" --no-gc)
   [[ "$dry" == 0 ]] || nh_args+=(--dry)
   local skipped_file; skipped_file="$(mktemp)"
-  "${nh_args[@]}" 2>&1 | fold_gcroots_noise "$skipped_file" >&2 || die "$EX_SOFTWARE" "nh clean failed"
-  # fold_gcroots_noise writes "<skipped> <reaped>"; default both to 0 if unread.
+  "${nh_args[@]}" 2>&1 | fold_nh_clean_noise "$skipped_file" "$verbose" >&2 || die "$EX_SOFTWARE" "nh clean failed"
+  # fold_nh_clean_noise writes "<skipped> <reaped>"; default both to 0 if unread.
   local skipped=0 reaped=0
   read -r skipped reaped < "$skipped_file" 2>/dev/null || true
   skipped="${skipped:-0}"; reaped="${reaped:-0}"


### PR DESCRIPTION
Polish pass on `atyrode clean`'s output, from live testing (three rounds of "why does it do X?").

## 1. GC progress line (the original report: "why multiple lines?")
Three defects, all now fixed:
- `grep -c` prints `0` on no match **and** exits 1, so `|| printf 0` appended a second `0` → `"0\n0"` embedded a newline that split the line and defeated the `\r` redraw (**this was the duplicate-lines cause**).
- The spinner frame was `i++`'d inside a `$(paint …)` subshell, so it never advanced (frozen `⠋`; caught by shellcheck).
- `nix-store --gc` scans the whole store before deleting (count pinned at 0), so it read as stuck-at-`0 paths freed`. That phase now says `scanning the store…`, and the in-flight path was dropped so the line stays short and never wraps.

Result: one `\r`-updated line — `⠹ collecting garbage — 14 paths freed` → `✓ N deleted, X freed`.

## 2. Fold nh 4.4.1's verbose plan (the "so many lines")
A newer `nh` prints a full evaluation plan every run (legend + one line per GC root, 130+ lines); `nh -q` doesn't suppress it. `fold_nh_clean_noise` now folds that plan **and** the auto-gcroot chatter into atyrode's own summary by default (**~65 lines → ~8**), keeping genuine errors. `atyrode clean --verbose` passes nh's full output through. Skipped/reaped are now counted by totals (removals − failures) instead of fragile adjacent pairing, which had leaked the `> Removing …` lines.

## 3. Honest preview count (the "why 0 removed when it said 49?")
The confirm preview counted only `--keep` and ignored `--keep-since`, promising removals the 30-day window then spared. It now parses each generation's date against the window and reports the **exact** removable count (0 when everything is recent, as it is on a <30-day-old machine).

## Testing
`nix build .#checks.x86_64-linux.atyrode-cli` green, `nixfmt`/`shellcheck` clean. New assertions: plan folded by default / shown under `--verbose` (skipped still tallied); preview count honours both `--keep` and `--keep-since` (deterministic fixtures). Verified end-to-end by driving the test binary under a pty against a realistic 65-line nh plan → 8-line output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
