### PR TITLE
docs: promote TUI verification to stable documentation, fix color recipe

### DIFF
--- a/agents/skills/tui-visual-verification/SKILL.md
+++ b/agents/skills/tui-visual-verification/SKILL.md
@@ -3,87 +3,19 @@ name: tui-visual-verification
 description: Run a Bubble Tea (or any terminal) TUI headlessly, drive it with keys, and verify the rendered output — character-exact via tmux capture-pane, pixel-level via freeze PNG renders. Use whenever building or changing TUI layout, colors, or glyphs.
 ---
 
-# TUI visual verification (tmux capture + freeze)
+# TUI visual verification
 
-Unit tests on render functions miss what actually reaches the terminal: wrapped
-rows that overflow a pane, styles that reset mid-line, glyphs silently wiped to
-empty strings. Verify TUI changes against the real program, headlessly.
+The owning documentation lives in the repository:
+[docs/tui-verification.md](../../../docs/tui-verification.md).
 
-## 0. Agent environments suppress color — undo that first
+Follow it whenever you build or change TUI layout, colors, or glyphs. The three
+rules that prevent the historical failures:
 
-Agent harnesses commonly export `NO_COLOR=1`, `CI=1`, and `TERM=dumb`. lipgloss
-honors `NO_COLOR` and renders colorless, so a naive run "proves" a color bug
-that does not exist. Always launch the app under test with:
-
-```console
-$ env -u NO_COLOR CLICOLOR_FORCE=1 COLORTERM=truecolor TERM=xterm-256color <app>
-```
-
-Know the ceiling: termenv caps any `TERM` beginning with `tmux`/`screen` at
-ANSI-256, so hex colors appear as approximations inside tmux. That is fine for
-verification (colors present, distinguishable); do not chase truecolor there.
-
-## 1. Character-exact verification with tmux (authoritative)
-
-Run the TUI in a detached tmux session, drive it with `send-keys`, and read
-back the exact rendered character grid:
-
-```console
-$ tmux new-session -d -s tui -x 150 -y 44 \
-    "env -u NO_COLOR CLICOLOR_FORCE=1 CODE_GENERATED=… <app>; sleep 300"
-$ tmux send-keys -t tui Down Down Right          # navigate and change a dial
-$ tmux capture-pane -t tui -p  > /tmp/frame.txt  # plain text grid
-$ tmux capture-pane -t tui -pe > /tmp/frame.ansi # with SGR color sequences
-```
-
-This is deterministic and assertable:
-
-- **Layout / overflow**: count physical lines, check every row's width, and
-  look at the *bottom* of the frame — vertical overflow from wrapped or added
-  rows always lands there (pushed footers, clipped hints).
-- **Glyphs**: Nerd Font icons live in the Private Use Area and are *invisible*
-  in most editors and agent tooling — never eye-verify them, and never retype a
-  source line containing them (that is how they get wiped). Grep the capture
-  for the exact codepoints (e.g. `\uf02d`) programmatically.
-- **Colors / style bleed**: inspect the SGR sequences in the `-e` capture
-  around a suspect region (e.g. text that wraps and loses its dim style).
-
-For `code` specifically: build with `nix build .#code-tui`, generate the grid
-with `MODELS_YML=omp/models.yml python3 pkgs/omp-configured/generate-profiles.py`,
-and point `CODE_GENERATED` at the output. No further wrapper env is required.
-
-## 2. Pixel-level view with freeze (validated, deterministic)
-
-To actually *look* at a frame (colors, pills, contrast), render the ANSI
-capture to PNG with `freeze` — no server, no browser, no client sizing:
-
-```console
-$ nix shell nixpkgs#charm-freeze -c \
-    freeze --language ansi /tmp/frame.ansi -o /tmp/frame.png \
-    --font.family "JetBrains Mono,Symbols Nerd Font Mono"
-```
-
-Install the fonts once where freeze runs (`nixpkgs#jetbrains-mono`,
-`nixpkgs#nerd-fonts.symbols-only` → `~/.local/share/fonts` + `fc-cache -f`).
-Caveat: freeze's per-glyph font fallback is imperfect, so PUA icons may render
-as boxes even when correct — the codepoint grep from step 1 stays authoritative
-for glyphs; the PNG is for layout and color judgment.
-
-## 3. Alternatives for live or scripted viewing
-
-- **vhs** (`nixpkgs#vhs`): scripted terminal driver — `.tape` files with
-  `Type`/`Down`/`Sleep`/`Screenshot`/`Set FontFamily` — good for repeatable
-  demo flows. It drives ttyd + headless Chromium underneath, so it shares that
-  stack's flakiness in constrained agent sandboxes; prefer tmux + freeze for
-  verification.
-- **ttyd** (`nixpkgs#ttyd`): serve `tmux attach -t tui` over loopback HTTP and
-  screenshot from a browser tool — the only option for *watching* a session
-  live. Flaky under headless browsers (stalled loads, blank canvas, scrollback
-  cropping after resizes). If used: attach the browser client *before* the app
-  draws so it sets the window size, reload the page after any resize, and pass
-  `-t 'fontFamily=Symbols Nerd Font Mono,monospace'` for glyphs.
-
-## 4. Cleanup
-
-Kill the session and any server when done: `tmux kill-server`,
-`kill $(cat /tmp/ttyd.pid)`.
+1. Launch the app with
+   `env -u NO_COLOR -u CI CLICOLOR_FORCE=1 COLORTERM=truecolor TERM=xterm-256color`
+   — otherwise the harness env silently strips (`NO_COLOR`) or quantizes to 16
+   colors (`CI`, verified A/B) everything you are trying to judge.
+2. Verify glyphs by grepping `tmux capture-pane` output for exact PUA
+   codepoints; never by eye, and never retype source lines containing them.
+3. Judge pixels from `freeze --language ansi` PNG renders, and check the bottom
+   of the frame for overflow.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ not in a checklist.
 | [bootstrap.md](bootstrap.md) | The supported path from an unmanaged machine to a managed one, and activation |
 | [atyrode.md](atyrode.md) | The `atyrode` CLI — applying and inspecting the configuration |
 | [agent-tools.md](agent-tools.md) | OMP, the `code` profile generator, agents, and rules |
+| [tui-verification.md](tui-verification.md) | Headless TUI verification — driving and screenshotting terminal UIs without a graphical session |
 | [omp/](omp/README.md) | Versioned upstream OMP CLI and capability field guide, explicitly separated from repository wrapper behavior |
 | [agent-security.md](agent-security.md) | Trust tiers and the managed OMP policy for untrusted content |
 | [shell.md](shell.md) | The interactive shell surface (a launcher, not a dev environment) |

--- a/docs/tui-verification.md
+++ b/docs/tui-verification.md
@@ -1,0 +1,108 @@
+# Headless TUI verification
+
+How to run a terminal UI (the `code` generator, or any Bubble Tea program)
+without a graphical session, drive it with keys, and verify what it actually
+renders — for operators debugging a TUI and for agents shipping changes to one.
+Unit tests on render functions miss what reaches the terminal: wrapped rows
+that overflow a pane, styles that reset mid-line, glyphs silently wiped to
+empty strings.
+
+The toolchain: **tmux** (drive + capture, authoritative), **charm-freeze**
+(deterministic PNG renders), with ttyd/vhs as live-viewing alternatives.
+Packaging these into the managed agent tool suite is tracked in
+[issue #163](https://github.com/atyrode/dotfiles/issues/163).
+
+## 0. Fix the environment first — it silently degrades color
+
+Agent harnesses and CI export `NO_COLOR=1`, `CI=1`, and `TERM=dumb`, and each
+degrades color independently:
+
+- lipgloss honors `NO_COLOR` → fully colorless output;
+- termenv treats **any `CI` env as a 16-color terminal** regardless of
+  `TERM`/`COLORTERM` → hex colors quantize into 16 ANSI buckets (grays come out
+  purple), which defeats color judgment entirely;
+- termenv caps `TERM`s beginning with `tmux`/`screen` at ANSI-256.
+
+A naive run therefore "proves" color bugs that do not exist. Always launch the
+app under test with:
+
+```console
+$ env -u NO_COLOR -u CI CLICOLOR_FORCE=1 COLORTERM=truecolor TERM=xterm-256color <app>
+```
+
+With that exact env the app emits true 24-bit SGR (`38;2;r;g;b`) even inside a
+tmux pane. Verify with `grep -c '38;2;' frame.ansi` (> 0) before judging any
+color.
+
+## 1. Character-exact verification with tmux (authoritative)
+
+Run the TUI in a detached tmux session, drive it with `send-keys`, and read
+back the exact rendered character grid:
+
+```console
+$ tmux new-session -d -s tui -x 150 -y 44 \
+    "env -u NO_COLOR -u CI CLICOLOR_FORCE=1 COLORTERM=truecolor TERM=xterm-256color \
+     CODE_GENERATED=… <app>; sleep 300"
+$ tmux send-keys -t tui Down Down Right          # navigate and change a dial
+$ tmux capture-pane -t tui -p  > /tmp/frame.txt  # plain text grid
+$ tmux capture-pane -t tui -pe > /tmp/frame.ansi # with SGR color sequences
+```
+
+This is deterministic and assertable:
+
+- **Layout / overflow** — count physical lines, check every row's width, and
+  look at the *bottom* of the frame: vertical overflow from wrapped or added
+  rows always lands there (pushed footers, clipped hints).
+- **Glyphs** — Nerd Font icons live in the Private Use Area and are *invisible*
+  in most editors and agent tooling. Never eye-verify them, and never retype a
+  source line containing them (that is how they get wiped). Grep the capture
+  for the exact codepoints (e.g. `\uf02d`) programmatically.
+- **Colors / style bleed** — inspect the SGR sequences in the `-e` capture
+  around a suspect region (e.g. text that wraps and loses its dim style).
+
+For `code` specifically: build with `nix build .#code-tui`, generate the grid
+with `MODELS_YML=omp/models.yml python3 pkgs/omp-configured/generate-profiles.py`,
+and point `CODE_GENERATED` at the output. No further wrapper env is required.
+
+## 2. Pixel-level view with freeze (deterministic screenshots)
+
+To actually *look* at a frame (colors, pills, contrast), render the ANSI
+capture to PNG with `freeze` — no server, no browser, no client sizing:
+
+```console
+$ nix shell nixpkgs#charm-freeze -c \
+    freeze --language ansi /tmp/frame.ansi -o /tmp/frame.png \
+    --font.family "JetBrains Mono,Symbols Nerd Font Mono"
+```
+
+With the truecolor env from §0, the PNG reproduces the authored hex colors
+exactly (24-bit SGR bypasses freeze's ANSI theme palette). Install the fonts
+once where freeze runs (`nixpkgs#jetbrains-mono`,
+`nixpkgs#nerd-fonts.symbols-only` → `~/.local/share/fonts` + `fc-cache -f`).
+
+Known limitations:
+
+- freeze's per-glyph font fallback is unreliable, so PUA icons may render as
+  tofu boxes even when correct — the codepoint grep from §1 stays authoritative
+  for glyphs; the PNG is for layout and color judgment.
+- Background color runs can smear to end-of-line (pill labels render as a
+  full-width band) — a capture artifact, not an app bug.
+
+## 3. Alternatives for live or scripted viewing
+
+- **vhs** (`nixpkgs#vhs`) — scripted terminal driver: `.tape` files with
+  `Type`/`Down`/`Sleep`/`Screenshot`/`Set FontFamily`. Best on an operator
+  machine; it drives ttyd + headless Chromium underneath, so it shares that
+  stack's flakiness in constrained sandboxes.
+- **ttyd** (`nixpkgs#ttyd`) — serve `tmux attach -t tui` over loopback HTTP and
+  view or screenshot from a browser: the only option for *watching* a session
+  live. Flaky under headless browsers (stalled loads, blank canvas, scrollback
+  cropping after resizes). If used: keep it loopback-bound, attach the browser
+  client *before* the app draws so it sets the window size, reload the page
+  after any resize, and pass `-t 'fontFamily=Symbols Nerd Font Mono,monospace'`
+  for glyphs.
+
+## 4. Cleanup
+
+Kill the session and any server when done: `tmux kill-server`,
+`kill $(cat /tmp/ttyd.pid)`.


### PR DESCRIPTION
Operator-requested follow-ups to the TUI-verification workflow:

- **Promote to stable docs**: full content now lives at `docs/tui-verification.md` (registered in the docs map); `agents/skills/tui-visual-verification` becomes a thin discovery pointer, per the one-owning-document rule.
- **Fix the color recipe with the real cause**: the "colors look wrong / purple grays" report was traced to `CI=1` — termenv treats any `CI` env as a 16-color terminal, quantizing truecolor hexes into 16 ANSI buckets. Empirically A/B isolated on the actual binary: identical env with `CI=1` emits **0** `38;2;` truecolor sequences; with `-u CI`, **201**. The canonical launch env is now `env -u NO_COLOR -u CI CLICOLOR_FORCE=1 COLORTERM=truecolor TERM=xterm-256color`, with which freeze PNGs reproduce the authored hex colors exactly (verified visually: gray rules, accent-only selections, provider-colored models — matching the real-terminal experience).
- The previous "tmux caps truecolor" claim is corrected to its actual scope (`TERM` prefixed `tmux`/`screen` only, bypassed by the override).

`docs-links` check passes locally. Companion tooling proposal: #163.