### PR TITLE
code-tui: flip advisor to GPT under fable-as-main; tree connector for default row

### DIFF
--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -526,7 +526,7 @@ const (
 // currentRows is the routing block the cost/speed meters score: the generator's
 // facet combo with the advisor dial applied.
 func (m model) currentRows() []string {
-	return m.applyAdvisor(m.generated[comboID(m.sel)], m.sel["advisor"], m.sel["lane"])
+	return m.applyAdvisor(m.generated[comboID(m.sel)], m.sel["advisor"])
 }
 
 func (m model) weightedModels(rows []string, fn func(w float64, id, lvl string)) {
@@ -621,14 +621,22 @@ func (m model) meter(label, glyph, fill string, n int) string {
 	return clikit.Meter(label, glyph, fill, n)
 }
 
-// advisorChain returns the advisor role's model chain for an intensity + lane,
-// sourced from the baked __advisors__ table. The advisor is the independent
-// second opinion, so it uses the opposite provider to the lane's preference — GPT
-// on a Claude-led (or pure-GPT) lane, Claude otherwise. Only the pure lanes stay
-// on their own provider (gpt-only keeps GPT; claude-only keeps Claude).
-func (m model) advisorChain(level, lane string) []string {
+// advisorChain returns the advisor role's model chain for an intensity, sourced
+// from the baked __advisors__ table. The advisor is the independent second
+// opinion, so it uses the opposite provider to whoever leads the session: GPT
+// when the lead is Claude — a Claude-led (or pure-GPT) lane, or fable-as-main
+// handing the default role to Fable — and Claude otherwise. Only the pure lanes
+// stay on their own provider (gpt-only keeps GPT; claude-only keeps Claude).
+func (m model) advisorChain(level string) []string {
+	lane := m.sel["lane"]
 	ctx := "claude"
 	if lane == "gpt-only" || lane == "claude-led" {
+		ctx = "gpt"
+	}
+	// fable-as-main puts Claude Fable in the default seat, so the second
+	// opinion flips to GPT — except on claude-only, where the pure-lane rule
+	// keeps the whole pool (advisor included) on Claude.
+	if lane != "claude-only" && m.sel["fable"] == "on" && m.sel["main"] == "on" {
 		ctx = "gpt"
 	}
 	return m.advisors[level+"/"+ctx]
@@ -649,8 +657,8 @@ func roleOf(row string) string {
 // applyAdvisor replaces the baked advisor row with one synthesised from the
 // chosen intensity (dropping it entirely when off), so the generated preview and
 // the launched config both reflect the advisor facet.
-func (m model) applyAdvisor(rows []string, level, lane string) []string {
-	chain := m.advisorChain(level, lane)
+func (m model) applyAdvisor(rows []string, level string) []string {
+	chain := m.advisorChain(level)
 	newRow := ""
 	if len(chain) > 0 {
 		newRow = "    advisor    " + strings.Join(chain, " → ")
@@ -744,7 +752,7 @@ func prefixed(model string) string {
 // thinking, advisor, and the priority tier when fast is on) from the generated
 // routing block for the current facets — what Enter launches omp with.
 func (m model) genConfigYAML() string {
-	rows := m.applyAdvisor(m.generated[comboID(m.sel)], m.sel["advisor"], m.sel["lane"])
+	rows := m.applyAdvisor(m.generated[comboID(m.sel)], m.sel["advisor"])
 	var mr, fc strings.Builder
 	advisorOn := false
 	for _, r := range rows {
@@ -1222,7 +1230,7 @@ func (m *model) syncPreview() {
 	id := comboID(m.sel)
 	if base, ok := m.generated[id]; ok {
 		_, roles := splitMeta(base)
-		roles = m.applyAdvisor(roles, m.sel["advisor"], m.sel["lane"])
+		roles = m.applyAdvisor(roles, m.sel["advisor"])
 		b.WriteString(renderRoute(roles, m.depth, m.avail, rw))
 	} else {
 		b.WriteString(stDim.Render("no profile for this combination") + "\n")
@@ -1561,11 +1569,12 @@ func (m model) genLines() ([]string, int) {
 		// main renders as fable's tabulated child "default": the indent + the
 		// default-role row lighting up Fable in the preview explain themselves,
 		// so it carries no flavor text (which would wrap on narrow panes anyway).
-		label, childPad := f.key, ""
+		label, childPad, childW := f.key, "", 0
 		if f.key == "main" {
-			label, childPad = "default", "  "
+			// tree-style L connector: reads as fable's child, like `tree`.
+			label, childPad, childW = "default", stDim.Render("└ "), 2
 		}
-		row := fmt.Sprintf("%s%s%s%s", ptr, childPad, gly, stDim.Render(pad(label, 9-len(childPad))))
+		row := fmt.Sprintf("%s%s%s%s", ptr, childPad, gly, stDim.Render(pad(label, 9-childW)))
 		for _, v := range f.values {
 			switch {
 			case v == m.sel[f.key]:

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -287,10 +287,71 @@ func TestGenLinesMainRow(t *testing.T) {
 	if mainRow == "" {
 		t.Fatalf("no row labelled 'default' while fable+main are on:\n%s", stripAnsi(strings.Join(lines, "\n")))
 	}
-	// tabulated child: unfocused prefix is the 2-space pointer slot + a 2-space
-	// indent before the glyph — 2 deeper than every other row.
-	if !strings.HasPrefix(mainRow, strings.Repeat(" ", 4)) {
-		t.Errorf("main row must be indented as fable's child, got %q", mainRow)
+	// tabulated child: unfocused prefix is the 2-space pointer slot + an
+	// L-shaped tree connector before the glyph — the connector makes the
+	// parent/child link to fable explicit, like the `tree` CLI.
+	if !strings.HasPrefix(mainRow, "  └ ") {
+		t.Errorf("main row must carry the └ child connector, got %q", mainRow)
+	}
+}
+
+// TestAdvisorChainFlip locks the advisor's opposite-provider rule: the second
+// opinion tracks whoever actually leads. Lane-led flips were already in place;
+// fable-as-main (fable on + default on) puts Claude Fable in the default seat,
+// so mixed/gpt-led lanes must flip the advisor to GPT too — same-provider lead
+// and advisor would reintroduce the tunnel-vision risk the advisor exists to
+// cut. Pure lanes keep their own provider; fable alone (main off) doesn't flip.
+func TestAdvisorChainFlip(t *testing.T) {
+	adv := map[string][]string{
+		"glance/gpt":    {"gpt-5.6-terra:low"},
+		"glance/claude": {"claude-quartz-5:low"},
+	}
+	cases := []struct {
+		lane, fable, main string
+		wantCtx           string
+	}{
+		{"mixed", "off", "off", "claude"},
+		{"gpt-led", "off", "off", "claude"},
+		{"claude-led", "off", "off", "gpt"},
+		{"gpt-only", "off", "off", "gpt"},
+		{"claude-only", "off", "off", "claude"},
+		// fable on but not leading: no flip.
+		{"mixed", "on", "off", "claude"},
+		// fable-as-main: Claude leads, advisor flips to GPT.
+		{"mixed", "on", "on", "gpt"},
+		{"gpt-led", "on", "on", "gpt"},
+		{"claude-led", "on", "on", "gpt"},
+		// pure Claude pool: pure-lane rule wins, no GPT in the pool.
+		{"claude-only", "on", "on", "claude"},
+	}
+	for _, c := range cases {
+		m := model{advisors: adv, sel: defaultSel()}
+		m.sel["lane"], m.sel["fable"], m.sel["main"] = c.lane, c.fable, c.main
+		got := m.advisorChain("glance")
+		want := adv["glance/"+c.wantCtx]
+		if len(got) == 0 || got[0] != want[0] {
+			t.Errorf("lane=%s fable=%s main=%s: advisor chain = %v, want %s (%v)",
+				c.lane, c.fable, c.main, got, c.wantCtx, want)
+		}
+	}
+}
+
+// TestApplyAdvisorFableMain: the flipped chain must flow through applyAdvisor —
+// the single seam feeding the preview, the cost/speed meters, and the launched
+// config YAML — not just the raw table lookup.
+func TestApplyAdvisorFableMain(t *testing.T) {
+	m := model{
+		advisors: map[string][]string{
+			"glance/gpt":    {"gpt-5.6-terra:low"},
+			"glance/claude": {"claude-quartz-5:low"},
+		},
+		sel: defaultSel(),
+	}
+	m.sel["fable"], m.sel["main"] = "on", "on" // mixed lane (default)
+	rows := m.applyAdvisor([]string{"    default    claude-fable-5:high"}, "glance")
+	joined := strings.Join(rows, "\n")
+	if !strings.Contains(joined, "advisor    gpt-5.6-terra:low") {
+		t.Errorf("fable-as-main must synthesise a GPT advisor row, got:\n%s", joined)
 	}
 }
 


### PR DESCRIPTION
Fixes #170.

## What

- **Advisor provider flip:** `advisorChain` now accounts for fable-as-main (fable on + default on). When Fable takes the default seat, the advisor flips to GPT on `mixed`/`gpt-led` lanes (previously it stayed Claude, giving a same-provider lead + advisor). `claude-led`/`gpt-only` were already GPT; `claude-only` keeps the pure-lane rule (whole pool stays Claude). Since every caller passed `m.sel` values, the `lane`/`level` params collapsed into direct `m.sel` reads — preview, cost/speed meters, and the launched config YAML all flow through `applyAdvisor` and pick up the flip together.
- **UI:** the `default` child row now renders with an L-shaped `└` connector (like the `tree` CLI) instead of a bare 2-space indent. Alignment preserved with a visual-width pad (the connector is multi-byte, so `len()` would have skewed the label column).

## Verification

- `go test ./...` green, including new `TestAdvisorChainFlip` (10-case lane×fable×main matrix) and `TestApplyAdvisorFableMain`; `TestGenLinesMainRow` updated for the connector.
- Headless run per `docs/tui-verification.md`: tmux capture against the real generated grid shows the advisor row moving `haiku:low → luna:low` as `default` toggles on, and back on toggle-off; `└` renders aligned; both PUA glyphs (f02d/f140) confirmed by codepoint grep; freeze PNG shows no overflow or style bleed.