### PR TITLE
chore: bump omp 16.5.2, codex 0.144.4, refresh flake inputs and OMP wiki

### DIFF
--- a/docs/omp/README.md
+++ b/docs/omp/README.md
@@ -1,9 +1,9 @@
 # OMP feature wiki
 
 > - **Audited:** 2026-07-14
-> - **Repository pin:** `omp` v16.4.8
-> - **Upstream release:** [v16.4.8](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.8) (2026-07-12)
-> - **Audit range:** v16.0.0 through v16.4.8, plus the v16.4.8 CLI help and documentation
+> - **Repository pin:** `omp` v16.5.2
+> - **Upstream release:** [v16.5.2](https://github.com/can1357/oh-my-pi/releases/tag/v16.5.2) (2026-07-14)
+> - **Audit range:** v16.0.0 through v16.5.2, plus the v16.5.2 CLI help and documentation
 
 This is the compact “did you know this exists?” index for the OMP binary used by
 these dotfiles. It is for operators deciding what to invoke and for agents that
@@ -11,7 +11,7 @@ need to discover an OMP capability before proposing new wrapper code.
 
 ## Choose the correct surface first
 
-The [CLI reference](cli.md) describes **plain upstream `omp` v16.4.8**. These
+The [CLI reference](cli.md) describes **plain upstream `omp` v16.5.2**. These
 repository launchers are not interchangeable:
 
 | Invoke | Authentication and state | Configuration and policy |
@@ -59,21 +59,18 @@ managed launches, then directs the operator to the repository-owned edit paths.
 Claims in this wiki were checked against:
 
 1. the repository pin in [`pkgs/omp/default.nix`](../../pkgs/omp/default.nix);
-2. the output of the packaged `omp v16.4.8 --help` and each listed shell
+2. the output of the packaged `omp v16.5.2 --help` and each listed shell
    command's `--help`;
 3. the upstream documentation at the immutable
-   [`v16.4.8` tag](https://github.com/can1357/oh-my-pi/tree/v16.4.8/docs);
+   [`v16.5.2` tag](https://github.com/can1357/oh-my-pi/tree/v16.5.2/docs);
 4. upstream release notes from
    [v16.0.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.0.0) through
-   [v16.4.8](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.8); and
+   [v16.5.2](https://github.com/can1357/oh-my-pi/releases/tag/v16.5.2); and
 5. the repository-owned wrapper behavior in [Agent tools](../agent-tools.md).
 
-Upstream had already published
-[v16.5.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.5.0) and
-[v16.5.1](https://github.com/can1357/oh-my-pi/releases/tag/v16.5.1) when this
-audit was written. They are intentionally excluded because these dotfiles still
-package v16.4.8. Availability in upstream `main` or a newer release is not proof
-that a feature exists in the packaged binary.
+No upstream release newer than v16.5.2 had been published when this audit was
+written. Availability in upstream `main` or a newer release is not proof that a
+feature exists in the packaged binary.
 
 ## Refreshing the wiki after a pin update
 

--- a/docs/omp/cli.md
+++ b/docs/omp/cli.md
@@ -1,6 +1,6 @@
-# Plain OMP v16.4.8 CLI reference
+# Plain OMP v16.5.2 CLI reference
 
-> **Scope:** this page is a snapshot of the packaged **upstream `omp` v16.4.8**
+> **Scope:** this page is a snapshot of the packaged **upstream `omp` v16.5.2**
 > executable, audited 2026-07-14. It is not a promise that `code`,
 > `omp-managed`, or `ompu` preserve every flag unchanged. See the
 > [launcher matrix](README.md#choose-the-correct-surface-first) first.
@@ -25,6 +25,11 @@ non-interactive execution.
 | `--smol <selector>` | Override the lightweight/smol role for this process |
 | `--slow <selector>` | Override the thorough/reasoning role for this process |
 | `--plan <selector>` | Override the planning role for this process |
+| `--prewalk` | Start on the active model, then hand off to a fast/cheap model at the first edit/write after the plan's todo list exists (default off; `prewalk.enabled`) |
+| `--no-prewalk` | Disable prewalk even when `prewalk.enabled` is set |
+| `--prewalk-into <selector>` | Target model for the prewalk handoff (defaults to the `smol` role) |
+| `--plan-yolo` | Force read-only plan mode at start, auto-approve the plan on the model's first resolve call, then implement it on the `--plan-yolo-into` model |
+| `--plan-yolo-into <selector>` | Target model for plan-yolo execution (defaults to the `smol` role) |
 | `--provider <id>` | Legacy provider selector; prefer `--model` |
 | `--api-key <value>` | Supply a process-local credential override |
 | `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `auto` |
@@ -45,7 +50,7 @@ non-interactive execution.
 | `--append-system-prompt <text-or-file>` | Append to the system prompt |
 | `--config <file>` | Add a one-run `config.yml`-style overlay; repeatable and later overlays win |
 | `--allow-home` | Permit launch directly in the home directory |
-| `--max-time <seconds>` | Stop the session after the given wall-clock duration |
+| `--max-time <duration>` | Stop the session after the given wall-clock duration (`600`, `10m`, `1h`) |
 | `--no-title` | Disable session-title generation |
 
 An OMP profile isolates the **entire** state root, not just one provider's OAuth
@@ -149,7 +154,7 @@ $ omp config managed --json
 ```
 
 The repository-packaged `omp` passthrough intercepts that one action before
-dispatching to upstream. `config managed` is not an upstream v16.4.8
+dispatching to upstream. `config managed` is not an upstream v16.5.2
 subcommand, despite the intentionally plain-looking invocation.
 
 ## Built-in agent tool catalog
@@ -194,8 +199,8 @@ $ ompu "inspect this untrusted repository"
 ```
 
 Sources: packaged `omp --help`; tagged upstream
-[settings](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/settings.md),
-[providers](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/providers.md),
-[models](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/models.md), and
-[secrets](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/secrets.md)
+[settings](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/settings.md),
+[providers](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/providers.md),
+[models](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/models.md), and
+[secrets](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/secrets.md)
 documentation; repository [Agent tools](../agent-tools.md).

--- a/docs/omp/features.md
+++ b/docs/omp/features.md
@@ -1,12 +1,12 @@
-# OMP v16.4.8 capability field guide
+# OMP v16.5.2 capability field guide
 
 > **Scope:** built-in upstream capabilities present in the packaged `omp`
-> v16.4.8, audited 2026-07-14. Wrapper policy still matters: read the
+> v16.5.2, audited 2026-07-14. Wrapper policy still matters: read the
 > [launcher matrix](README.md#choose-the-correct-surface-first).
 
 This page favors discoverability over implementation detail. The release links
 identify when a capability materially appeared or changed during the audited
-v16 series; the immutable v16.4.8 documentation links define the packaged
+v16 series; the immutable v16.5.2 documentation links define the packaged
 behavior.
 
 ## High-value “did you know?” workflows
@@ -21,8 +21,8 @@ Inside a profile, `/login <provider>` and `/logout <provider>` manage
 provider-scoped credentials. `omp usage --redact` reports every authenticated
 account without exposing full account IDs; `omp dry-balance` previews OAuth
 account selection. See upstream
-[Providers](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/providers.md)
-and [Secrets](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/secrets.md).
+[Providers](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/providers.md)
+and [Secrets](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/secrets.md).
 
 In these dotfiles, use `code`'s usage widget instead of typing profile names:
 `a` switches the visible `mine`/`mum` combination and every trusted launch gets
@@ -45,12 +45,16 @@ The session can also:
 
 These dotfiles manage the role map and fallback chains for generated launches;
 plain `omp` remains mutable. See upstream
-[Models](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/models.md).
+[Models](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/models.md).
 
 ### Change the shape of the work, not only the model
 
 - `/plan [prompt]` makes the agent propose and review a plan before mutation;
   `/plan-review` reopens the latest review.
+- `--prewalk` (with `--prewalk-into`) plans on the strong active model, then
+  hands off to a fast/cheap model at the first edit/write once the todo list
+  exists; `--plan-yolo` (with `--plan-yolo-into`) additionally auto-approves
+  the plan. These replaced the `--reasoning-slide-*` flags in v16.5.0.
 - `/goal`, `/goal budget <N>`, and `/guided-goal` maintain a persistent
   autonomous objective with a token budget.
 - `/vibe [prompt]` enters a read-only director mode whose dedicated `vibe_*`
@@ -93,7 +97,7 @@ OMP's transcript is a navigable tree, not a flat terminal log:
 
 `/export` writes browsable HTML, while `/dump` copies the full textual
 transcript. See the tagged
-[session-operations reference](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/session-operations-export-share-fork-resume.md).
+[session-operations reference](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/session-operations-export-share-fork-resume.md).
 
 ### Share a snapshot or collaborate live—with different trust models
 
@@ -104,9 +108,9 @@ creates a read-only link. Guests can use `omp join <link>` or `/join <link>`.
 
 The host still runs the model and every tool. A full collab link is therefore a
 control credential and must be handled like a secret. See the tagged
-[Collab](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/collab.md)
+[Collab](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/collab.md)
 and
-[session-sharing](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/session-operations-export-share-fork-resume.md#share)
+[session-sharing](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/session-operations-export-share-fork-resume.md#share)
 docs.
 
 ### Diagnose and reshape context before it becomes a failure
@@ -123,8 +127,8 @@ docs.
   maintenance.
 
 See the tagged upstream
-[Memory](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/memory.md) and
-[Compaction](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/compaction.md)
+[Memory](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/memory.md) and
+[Compaction](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/compaction.md)
 references for the active backend and compaction modes.
 
 ### Use rich input without leaving the terminal
@@ -146,7 +150,7 @@ dependencies rather than assuming they are installed.
 
 ### Give the agent more than file and shell access
 
-The v16.4.8 tool ecosystem includes code-aware LSP operations,
+The v16.5.2 tool ecosystem includes code-aware LSP operations,
 document/archive reads, images, notebooks, browser automation, web search,
 structured todos, subagents, and interactive operator questions. The
 discoverable `eval` tool adds persistent language kernels when its runtimes are
@@ -165,19 +169,24 @@ Notable release-backed additions include:
 - TinyFish, DuckDuckGo, xAI, and Firecrawl search adapters in
   [v16.2.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.2.0), plus
   multiple credential-free engines and aggregate search in
-  [v16.4.3](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.3); and
+  [v16.4.3](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.3);
+- a project-scoped `launch` tool for shared long-running services and
+  debuggers — readiness probes, bounded logs, PTY input, restart policies,
+  and optional `detached` survival across broker shutdowns — gated behind
+  `launch.enabled` in
+  [v16.5.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.5.0); and
 - tagged tool contracts for
-  [image inspection](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/tools/inspect_image.md),
-  [image generation](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/tools/generate_image.md),
-  [speech generation](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/tools/tts.md),
-  and [evaluation](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/tools/eval.md).
+  [image inspection](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/tools/inspect_image.md),
+  [image generation](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/tools/generate_image.md),
+  [speech generation](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/tools/tts.md),
+  and [evaluation](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/tools/eval.md).
 
 `/tools` shows what the current session actually exposes. Wrapper policy can
 remove or require approval for any capability.
 
 ### Extend OMP without editing its core
 
-OMP v16.4.8 supports several extension boundaries:
+OMP v16.5.2 supports several extension boundaries:
 
 - TypeScript/JavaScript extensions and hooks via `-e`, `--hook`, discovery, or
   plugin packages;
@@ -192,11 +201,11 @@ OMP v16.4.8 supports several extension boundaries:
   status widgets.
 
 Start with the tagged
-[Extensions](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/extensions.md),
-[Skills](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/skills.md),
-[Rule matching](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/rulebook-matching-pipeline.md),
-[MCP](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/mcp-config.md), and
-[TUI integration](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/tui.md)
+[Extensions](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/extensions.md),
+[Skills](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/skills.md),
+[Rule matching](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/rulebook-matching-pipeline.md),
+[MCP](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/mcp-config.md), and
+[TUI integration](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/tui.md)
 docs.
 
 ### Embed or automate the same agent
@@ -212,8 +221,8 @@ The binary is not limited to the interactive TUI:
 - hooks/extensions can observe and alter lifecycle events.
 
 See the tagged
-[RPC](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/rpc.md) and
-[auth broker/gateway](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/auth-broker-gateway.md)
+[RPC](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/rpc.md) and
+[auth broker/gateway](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/auth-broker-gateway.md)
 docs; use `omp acp --help` for the packaged ACP server surface.
 
 ### Inspect OMP itself before writing another wrapper
@@ -240,10 +249,27 @@ source or adding a duplicate diagnostic to `code`.
 ## Release-note radar for the pinned v16 line
 
 This is a compact audit of operator-visible changes recorded between v16.0.0
-and v16.4.8, not a replacement for the current-feature sections above. Release
+and v16.5.2, not a replacement for the current-feature sections above. Release
 notes can bundle or migrate older behavior, so an entry means “recorded in this
 release,” not necessarily “first invented here.”
 
+- [v16.5.2](https://github.com/can1357/oh-my-pi/releases/tag/v16.5.2) —
+  proactive rate-limit header ingestion for all supported providers with
+  multi-account rotation before 429s, a `generate_image.enabled` setting and
+  whitelist gating for the image tool, duration-suffix `--max-time` values,
+  and a breaking agent-tool change: the separate `selector` parameters were
+  removed from `read` and `grep` (ranges/modes are appended to `path`).
+- [v16.5.1](https://github.com/can1357/oh-my-pi/releases/tag/v16.5.1) —
+  organization-scoped Anthropic credential and usage partitioning (visible in
+  `/usage`, `/logout`, and `omp token --list`), Cursor account usage in
+  `omp usage`, and `models.yaml` accepted as a custom-catalog fallback.
+- [v16.5.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.5.0) —
+  the `--prewalk` plan-then-hand-off flow replacing the `--reasoning-slide-*`
+  flags, a compact session-only model picker on `Alt+P` with `@` role search,
+  a gated project-scoped `launch` tool for shared long-running services
+  (including `detached` launches), redesigned Agent Hub cards, the
+  `tui.scrollbackRebuild` setting, and removal of the Bing/Yahoo scraping
+  search providers.
 - [v16.4.8](https://github.com/can1357/oh-my-pi/releases/tag/v16.4.8) —
   Home/End navigation in the model browser and `c` to copy the edited plan from
   plan review.
@@ -303,12 +329,12 @@ change it. The pinned defaults include:
 | hold `Space` | Push-to-talk speech transcription |
 
 Keybindings live in `~/.omp/agent/keybindings.yml`; see the tagged
-[Keybindings](https://github.com/can1357/oh-my-pi/blob/v16.4.8/docs/keybindings.md)
+[Keybindings](https://github.com/can1357/oh-my-pi/blob/v16.5.2/docs/keybindings.md)
 reference.
 
 ## Built-in interactive slash-command index
 
-This table catalogs the v16.4.8 built-ins. `/help` remains authoritative because
+This table catalogs the v16.5.2 built-ins. `/help` remains authoritative because
 extensions may add commands and the active mode may restrict them.
 
 | Area | Commands |
@@ -338,4 +364,4 @@ Less obvious semantics:
   points to repository-owned edit paths.
 
 Source: tagged upstream
-[built-in slash-command registry](https://github.com/can1357/oh-my-pi/blob/v16.4.8/packages/coding-agent/src/slash-commands/builtin-registry.ts).
+[built-in slash-command registry](https://github.com/can1357/oh-my-pi/blob/v16.5.2/packages/coding-agent/src/slash-commands/builtin-registry.ts).

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1781226006,
-        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
+        "lastModified": 1783446865,
+        "narHash": "sha256-nCrPEbQjgnSAOVWTxRXD9Yi6P3oECdtZISYcQCFI9Fs=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
+        "rev": "655769712a9a9499563d9685a8488f349354492d",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.1",
+        "ref": "6.0.9",
         "repo": "brew",
         "type": "github"
       }
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783744526,
-        "narHash": "sha256-yYVxW+uIbCx0Nt870fbErQbz+b2+3Gwpppe+JbIU+Co=",
+        "lastModified": 1783963347,
+        "narHash": "sha256-r376E2XpakiXwModDHIxlvB6qLq4iFVEq730vxOO4JY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2afec152df4e284d264f8489d16004c264aebf4c",
+        "rev": "a45a7c451455a51ae740ec3bce4024b312809c29",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1783771238,
-        "narHash": "sha256-PpmtcWFquEwmVgGj/DQ5ftnLyobGlewfzhG2OrCG4Fs=",
+        "lastModified": 1784067865,
+        "narHash": "sha256-sm1mo+uARjQSzwiXhRSpeLYhGwOcrXfY+WwpezdNb/c=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "cabac511d7db3b14b33553ed67adb27cb5dbac3d",
+        "rev": "01f922449e80f86a553ce16e9bfceaf4cb1677f0",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1783771565,
-        "narHash": "sha256-QzT69BouItrYcfFTQNS7qC2JJtGWkbQ4EwoQlUCpOzI=",
+        "lastModified": 1784068497,
+        "narHash": "sha256-bW7lVSgpHLX7XP3xa5ovFUfI/epO+33o14hnPiOrJDQ=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "3eb1e361dbadfa9a821a9c8c023fcfcbbb233b8c",
+        "rev": "8ba3dd2642f3cb673cf39bd3efd66bf9f63c7590",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1781389246,
-        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
+        "lastModified": 1783875858,
+        "narHash": "sha256-+yYNOkj/bkVQmwKH0hewqwBwAEoh4Gq2BmQPIP1jNrg=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
+        "rev": "60641da8324e6a1af716a0340d901ccb131c91ef",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783414108,
-        "narHash": "sha256-RY8e+gR2/DhXsYDxGDL6Hhe9+POD9u4+llwxMBqMQDs=",
+        "lastModified": 1783864904,
+        "narHash": "sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj+dNn/8Dsi3sPM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "96d6de10eb281b98f5cfcd1841394c03da5df77c",
+        "rev": "1111b9bc836afb7e31a7014e8d1272de9b1c917d",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "lastModified": 1784007870,
+        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
         "type": "github"
       },
       "original": {

--- a/pkgs/codex-bin/default.nix
+++ b/pkgs/codex-bin/default.nix
@@ -9,19 +9,19 @@
 # platform tracks the official release binaries, mirroring the omp repackage.
 # The Linux assets are static musl builds and need no loader fixup.
 let
-  version = "0.144.1";
+  version = "0.144.4";
   sources = {
     "aarch64-darwin" = {
       asset = "codex-aarch64-apple-darwin";
-      hash = "sha256-iOcqyL0wgV99GOYtrDM9wgzjrRy6lL4WSaGXfdm/27g=";
+      hash = "sha256-d8iWmkgTAvnbHZ6ipsIcCDq64/Go/Ipyddw4MjaZOR4=";
     };
     "x86_64-linux" = {
       asset = "codex-x86_64-unknown-linux-musl";
-      hash = "sha256-hAka4gxl/MfUEg25fRvVfX/435x2Cft4HHjC671PWig=";
+      hash = "sha256-N8mFvp2J6MT0OzqgWUwSE+rCEtMK4rlSIfCP7IB1FdE=";
     };
     "aarch64-linux" = {
       asset = "codex-aarch64-unknown-linux-musl";
-      hash = "sha256-ufjvX5jkbO1Nu9N1akIj4+4pmkV/9IijMFvqRV2otbg=";
+      hash = "sha256-TQckPvSuZ4a4syHXrqP5vk4dLFl65UB+fBuYczNAgrI=";
     };
   };
   source =

--- a/pkgs/omp/default.nix
+++ b/pkgs/omp/default.nix
@@ -6,23 +6,23 @@
 }:
 
 let
-  version = "16.4.8";
+  version = "16.5.2";
   sources = {
     "x86_64-linux" = {
       asset = "omp-linux-x64";
-      hash = "sha256-zfB3XgW4jWP52mBt5ULMP8C+7fCoZLSsQvd3lh+GhEw=";
+      hash = "sha256-zCyKlY4JrcNDKGBVUXTXDxy84L6Khq9BP/3PLsGMsQ4=";
     };
     "aarch64-linux" = {
       asset = "omp-linux-arm64";
-      hash = "sha256-nOVX1ojLTTW6uiImJOt/RgFi4e8BDk5M8C8UIxLGacU=";
+      hash = "sha256-G14cxbHfVlvcnGioTNmJMqiAsrsqWvvCgQXimu5SzxE=";
     };
     "x86_64-darwin" = {
       asset = "omp-darwin-x64";
-      hash = "sha256-PocAgPRDgfbkhRA/+KgGds9GNUW0AN/HCdenS3q9yhs=";
+      hash = "sha256-dv7Oxayd4MblG3U1srDxKPrP3P62Sir5ZjBDmtHngv0=";
     };
     "aarch64-darwin" = {
       asset = "omp-darwin-arm64";
-      hash = "sha256-PaPT3RU6auZVyViRzQZtwAJE6cN+fJ8Yihl5FwRddEc=";
+      hash = "sha256-fl1Hh8hVVym8ueBAXga013LcSyHkAzCzs3Ge8iYYzLE=";
     };
   };
   source =


### PR DESCRIPTION
## Summary
- `omp` 16.4.8 → 16.5.2 and `codex` 0.144.1 → 0.144.4 via `scripts/update-pins.sh`
- `nix flake update` for all inputs; the nixpkgs bump moves `claude-code` 2.1.204 → 2.1.207
- `docs/omp/` wiki re-audited against v16.5.2 per its refresh checklist:
  - CLI help diffed old vs new binary: no subcommands added/removed; new `--prewalk`/`--no-prewalk`/`--prewalk-into` and `--plan-yolo`/`--plan-yolo-into` flags; `--max-time` now accepts duration suffixes
  - Release notes v16.5.0–v16.5.2 folded into the field guide radar (launch tool, org-scoped Anthropic credentials, provider-wide rate-limit header ingestion, `read`/`grep` selector removal)
  - All immutable-tag doc links verified to exist at v16.5.2

## Verification
- `nix flake check --show-trace`: all 77 checks pass on x86_64-linux, including omp-stack, omp-wrapper, omp-agent-references, omp-seed, and docs-links against the new binary
- CI runs the same checks natively on aarch64-linux and aarch64-darwin