### PR TITLE
code: always launch through omp-managed; pin seeder to default root

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ ompu          # Restricted launcher for deliberately untrusted repositories
 ```
 
 `code` opens a TUI with a prompt→profile classifier on the local ollama daemon.
-Enter with nothing changed runs your default `omp`; type a prompt or move a dial
-and it generates a managed profile, launching it through `omp-managed`. The `u`
-key opens the `ompu` sandbox. The model catalog lives in
-[`omp/models.yml`](omp/models.yml).
+Every trusted launch goes through `omp-managed`: Enter with nothing changed runs
+the managed defaults; type a prompt or move a dial and it generates a managed
+profile. The `u` key opens the `ompu` sandbox; plain `omp` is reached by typing
+`omp` directly. The model catalog lives in [`omp/models.yml`](omp/models.yml).
 
 OMP, shared skills, and mise are installed by `zconf`
 with the rest of the Home Manager profile. See

--- a/checks/omp-seed.nix
+++ b/checks/omp-seed.nix
@@ -71,6 +71,39 @@ pkgs.runCommand "check-omp-seed"
     [ -f "$config" ] || fail "first boot did not create config.yml"
     [ "$(stat -c '%a' "$config")" = "600" ] || fail "first boot config mode is not 600"
     [ "$(yq eval '.secrets.enabled' "$config")" = "true" ] || fail "first boot did not seed secrets.enabled"
+    [ "$(yq eval '.task.disabledAgents | length' "$config")" = "0" ] || fail "first boot did not seed empty disabledAgents"
+
+    # Scenario: a profile-scoped agent environment must never redirect the
+    # seeder. PI_CODING_AGENT_DIR points at a decoy profile root; apply must
+    # leave the decoy untouched and seed the default root anyway (issue #173:
+    # `atyrode apply` run from inside an omp session leaked the session's
+    # profile into the seeder).
+    export HOME="$TMPDIR/envleak"
+    decoy="$HOME/.omp/profiles/decoy/agent"
+    mkdir -p "$HOME" "$decoy"
+    printf 'setupVersion: 1\n' >"$decoy/config.yml"
+    decoy_before="$(cat "$decoy/config.yml")"
+    PI_CODING_AGENT_DIR="$decoy" atyrode-omp-seed apply >"$TMPDIR/envleak.log"
+    [ "$(cat "$decoy/config.yml")" = "$decoy_before" ] || fail "profile env redirected seeding into the decoy root"
+    [ -f "$HOME/.omp/agent/config.yml" ] || fail "profile env prevented seeding the default root"
+    PI_CODING_AGENT_DIR="$decoy" atyrode-omp-seed status --json >"$TMPDIR/envleak-status.json"
+    jq -e --arg cfg "$HOME/.omp/agent/config.yml" '.config == $cfg' "$TMPDIR/envleak-status.json" >/dev/null \
+      || fail "status honored the profile env instead of the default root"
+
+    # Scenario: a populated local list under a seeded empty-list key is a
+    # local edit — kept and reported as drift, never overwritten.
+    export HOME="$TMPDIR/listdrift"
+    mkdir -p "$HOME/.omp/agent"
+    config="$HOME/.omp/agent/config.yml"
+    cat >"$config" <<'YAML'
+    task:
+      disabledAgents:
+        - scout
+    YAML
+    atyrode-omp-seed apply >"$TMPDIR/listdrift.log"
+    [ "$(yq eval '.task.disabledAgents.[0]' "$config")" = "scout" ] || fail "populated disabledAgents was overwritten by the seed"
+    jq -e '.drift[] | select(.key == "task.disabledAgents")' \
+      "$HOME/.local/state/atyrode/omp-plain-seed/drift.json" >/dev/null || fail "populated disabledAgents not reported as drift"
 
     # Scenario: a local scalar blocks seed mappings — nothing may be
     # destroyed, the blocked leaves report drift, everything else seeds.

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -57,7 +57,7 @@ them together.
 | `omp` | Mutable daily driver; user-owned configuration | Whatever the operator's own OMP config selects; unmanaged apart from the blocked `update` |
 | `omp-managed` | The managed launch target: platform extensions, managed defaults, and enforced policy over a one-shot `--config`, with no preset overlay | Managed defaults and policy, plus the generated `--config` the generator passes |
 | `ompu` | Deliberately untrusted repositories | Dedicated state, sanitized credentials, restricted integrations, and isolated writing tasks |
-| `code` | The profile generator TUI (see below) | Generates a managed profile and launches it through `omp-managed`, or runs bare `omp` when nothing is asked for |
+| `code` | The profile generator TUI (see below) | Always launches through `omp-managed`: a generated profile as a one-shot `--config`, or the managed defaults when nothing was asked for |
 
 For discoverability beyond the wrapper contract, see the versioned
 [OMP feature wiki](omp/README.md). Its CLI tables describe plain upstream OMP;
@@ -130,11 +130,13 @@ open `omp --profile mum`, run `/login anthropic` with Mum's Claude identity, and
 run `/login openai-codex` with Alex's Codex identity. The existing `default`
 profile is the `mine` combination and remains the initial selection.
 
-There are three ways to leave the TUI:
+There are three ways to leave the TUI — every trusted launch goes through
+`omp-managed`; plain `omp` is reached by typing `omp` directly, never via
+`code`:
 
-- **Enter with nothing changed** (no prompt, default dials) runs bare `omp`
-  inside the selected authentication profile — you didn't ask for special
-  routing, so it launches your normal session with the visible identity pair.
+- **Enter with nothing changed** (no prompt, default dials) runs `omp-managed`
+  with no overlay — the managed defaults — inside the selected authentication
+  profile.
 - **Enter after typing a prompt or moving a dial** generates a managed routing
   profile and launches it through `omp-managed` as a one-shot `--config`, with
   the selected authentication profile and typed prompt carried into the session.
@@ -234,7 +236,10 @@ the writable machine configuration, so a "defaults that lose to local edits"
 layer cannot exist at launch time. Instead, `atyrode-omp-seed apply` runs
 during activation (after the legacy migration) and three-way merges the seed
 into `~/.omp/agent/config.yml` against the last-applied seed recorded in
-`~/.local/state/atyrode/omp-plain-seed/`:
+`~/.local/state/atyrode/omp-plain-seed/`. The seeder always targets that
+default state root — a caller's profile-scoped environment (for example
+`atyrode apply` run from inside an omp session) never redirects it, and named
+profile roots are never seeded:
 
 - a key the operator never touched is written and later follows repository
   updates;

--- a/docs/omp/README.md
+++ b/docs/omp/README.md
@@ -17,7 +17,7 @@ repository launchers are not interchangeable:
 | Invoke | Authentication and state | Configuration and policy |
 | --- | --- | --- |
 | `omp` | The selected OMP `--profile`, or OMP's default state root | Plain, mutable upstream configuration under `~/.omp`; no repository-managed policy is injected |
-| `code` | The `mine`/`mum` combination visible in its usage widget; press `a` to switch | With no generated input, launches plain `omp`; with a prompt or changed dial, launches a generated routing profile through the managed layers |
+| `code` | The `mine`/`mum` combination visible in its usage widget; press `a` to switch | Always launches through the managed layers: a generated routing profile with a prompt or changed dial, the managed defaults otherwise. Plain `omp` is never launched via `code` |
 | `omp-managed` | The selected OMP `--profile` | Injects the Nix-owned defaults, platform extensions, and enforced policy; maintenance subcommands bypass overlay injection but remain subject to repository intercepts/guards |
 | `ompu` | Always the fixed `untrusted` profile | Fixed credential-sanitized untrusted sandbox; does not inherit the personal profile selected in `code` |
 

--- a/omp/plain-seed.yml
+++ b/omp/plain-seed.yml
@@ -17,6 +17,11 @@ task:
     mode: auto
     merge: patch
   showResolvedModelBadge: true
+  # All bundled agents stay spawnable in plain omp. An unattributed machine
+  # edit once disabled all six (issue #173); seeding the empty list makes any
+  # future non-empty value surface as reviewable drift instead of silently
+  # killing subagent spawns.
+  disabledAgents: []
 
 # Sol for interactive work; cheap Luna/Terra routes for recurring background
 # roles so commit messages, titles, and subtasks never bill at the main tier.

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -4,8 +4,9 @@
 //
 //	CODE_GENERATED     : generated.plain (facet-grid blocks, keyed by combo id)
 //	CODE_USAGE         : optional command (space-split) that prints `omp usage --json`
-//	CODE_OMP           : the omp-managed executable — launches a generated profile
-//	CODE_OMP_DEFAULT   : the bare omp executable — launched when nothing is generated
+//	CODE_OMP           : the omp-managed executable — launches every trusted session:
+//	                     a generated profile as a one-shot --config, or the managed
+//	                     defaults when nothing was generated
 //	CODE_OMP_UNTRUSTED : the ompu sandbox executable — launched by the u key
 package main
 
@@ -882,8 +883,9 @@ func (m model) bodyLines() ([]string, int) {
 }
 
 // unmodified reports whether the generator is still untouched: every facet at its
-// default value and no prompt typed into the suggest box. Enter then launches the
-// bare default omp instead of building a generated config.
+// default value and no prompt typed into the suggest box. Enter then launches
+// omp-managed with no overlay (the managed defaults) instead of building a
+// generated config.
 func (m model) unmodified() bool {
 	if m.firstPrompt != "" {
 		return false
@@ -899,13 +901,14 @@ func (m model) unmodified() bool {
 // launchFooter is the cost/speed meters for the current facet combo plus the
 // enter-to-launch call to action — so the generator always shows what the choice
 // costs, how fast it is, and how Enter will launch it. The call to action tracks
-// the launch rule: an untouched generator runs the bare default omp; any change
-// launches the generated profile. The sandbox (u) key is always offered.
+// the launch rule: an untouched generator runs omp-managed on the managed
+// defaults; any change launches the generated profile. The sandbox (u) key is
+// always offered.
 func (m model) launchFooter() []string {
 	cs, ss := m.costScore(), m.speedScore()
 	cta := "⏎ launch generated profile"
 	if m.unmodified() {
-		cta = "⏎ run your default omp"
+		cta = "⏎ run managed omp"
 	}
 	acc := lipgloss.NewStyle().Foreground(lipgloss.Color(m.accent())).Bold(true).Render("  " + cta)
 	return []string{
@@ -988,7 +991,7 @@ type model struct {
 	fetching    bool      // a usage fetch is in flight (manual or auto)
 	nextRefresh time.Time // when the next auto-refresh fires
 
-	launchDefault   bool              // Enter on an untouched generator: run bare CODE_OMP_DEFAULT
+	launchDefault   bool              // Enter on an untouched generator: run CODE_OMP with no overlay
 	launchUntrusted bool              // u: run the CODE_OMP_UNTRUSTED sandbox
 	genConfig       string            // generated config YAML to launch omp with (generator Enter)
 	firstPrompt     string            // prompt from the suggest box, forwarded as omp's first message
@@ -1674,8 +1677,10 @@ func main() {
 		// selected personal auth state.
 		execForward("CODE_OMP_UNTRUSTED", "ompu", fm.firstPrompt, "")
 	case fm.launchDefault:
-		// Nothing was generated — run bare omp inside the selected auth profile.
-		execForward("CODE_OMP_DEFAULT", "omp", fm.firstPrompt, profile)
+		// Nothing was generated — run omp-managed on the managed defaults inside
+		// the selected auth profile. Every trusted code launch goes through the
+		// managed layers; plain omp is reached by typing `omp` directly.
+		execForward("CODE_OMP", "omp-managed", fm.firstPrompt, profile)
 	case fm.genConfig != "":
 		launchGenerated(fm.genConfig, fm.firstPrompt, profile)
 	}

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -226,8 +226,9 @@ func TestCycleFacetClearsMain(t *testing.T) {
 }
 
 // TestUnmodified locks the launch decision: an untouched generator (defaults, no
-// prompt) is "unmodified" so Enter runs the bare default omp; any changed facet
-// or a typed prompt flips it, so Enter launches the generated profile instead.
+// prompt) is "unmodified" so Enter runs omp-managed on the managed defaults; any
+// changed facet or a typed prompt flips it, so Enter launches the generated
+// profile instead.
 func TestUnmodified(t *testing.T) {
 	if m := (model{sel: defaultSel()}); !m.unmodified() {
 		t.Errorf("defaults + no prompt should be unmodified (→ default omp)")

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1165,7 +1165,6 @@ let
       omp_bin=${lib.escapeShellArg (lib.getExe omp)}
       export CODE_GENERATED=${generatedProfiles}/share/omp/generated.plain
       export CODE_OMP=${lib.getExe ompManaged}
-      export CODE_OMP_DEFAULT="$omp_bin"
       export CODE_OMP_UNTRUSTED=${lib.getExe ompUntrusted}
       export CODE_USAGE="$omp_bin usage --json"
       if [[ ! -v CODE_AUTH_PROFILES ]]; then
@@ -1197,10 +1196,10 @@ let
       # in the host config. CODE_OLLAMA_ENDPOINT / CODE_EVAL_MODEL override the
       # daemon/model. The Bubble Tea usage widget owns the active OMP auth profile:
       # `a` switches it, usage is fetched from that profile, and every trusted launch
-      # receives the same --profile. Launch targets: ↵ with no changes runs your
-      # selected bare omp (CODE_OMP_DEFAULT); a generated profile runs through the
-      # managed layering (CODE_OMP); `u` opens the fixed untrusted sandbox
-      # (CODE_OMP_UNTRUSTED).
+      # receives the same --profile. Launch targets: ↵ runs through the managed
+      # layering (CODE_OMP) — the managed defaults when nothing was changed, the
+      # generated profile otherwise; `u` opens the fixed untrusted sandbox
+      # (CODE_OMP_UNTRUSTED). Plain omp is reached by typing `omp`, never via code.
 
       usage() {
         printf '%s\n' \
@@ -1213,9 +1212,9 @@ let
           '  code -h, --help      this help' \
           "" \
           'In the generator: type a prompt or adjust the dials, a switches the' \
-          'visible OMP auth combination, ? shows all keys, Enter launches (your' \
-          'selected bare omp if nothing was changed, the generated profile' \
-          'otherwise), and u opens an untrusted sandbox.'
+          'visible OMP auth combination, ? shows all keys, Enter launches through' \
+          'the managed layering (the managed defaults if nothing was changed, the' \
+          'generated profile otherwise), and u opens an untrusted sandbox.'
       }
 
       case "''${1:-}" in

--- a/scripts/omp-seed.sh
+++ b/scripts/omp-seed.sh
@@ -23,7 +23,11 @@ snapshot_file="$state_root/last-applied.yml"
 report_file="$state_root/drift.json"
 dry_run="${AGENT_TOOLS_DRY_RUN:-0}"
 
-agent_dir="${PI_CODING_AGENT_DIR:-$HOME/.omp/agent}"
+# Always the default state root: the seed's target and its global drift state
+# are a pair. Honoring a caller's PI_CODING_AGENT_DIR (e.g. `atyrode apply` run
+# from inside a profile-scoped agent session) would audit — and seed — the
+# wrong profile's config against state recorded for the default root.
+agent_dir="$HOME/.omp/agent"
 
 transient_files=()
 cleanup() {


### PR DESCRIPTION
Addresses three of the findings in #173 (operator-approved directions):

## Changes

1. **`code` is now purely the managed surface.** Enter-with-nothing-changed launches `omp-managed` with no overlay (the managed defaults) instead of bare `omp`; plain `omp` is reached by typing `omp`, never via `code`. `CODE_OMP_DEFAULT` is retired; footer/help/docs updated. The mine/mum toggle continues to select only the auth/state root — same `--profile` mechanism, so logged-in credentials and sessions are untouched.
2. **The plain-omp seeder always targets the default state root.** A caller's `PI_CODING_AGENT_DIR` (e.g. `atyrode apply` run from inside a profile-scoped omp session) no longer redirects auditing or seeding — the mechanism behind the false 64-key drift wall and a latent wrong-profile write. New check scenario: a decoy profile root under `PI_CODING_AGENT_DIR` must stay byte-identical while the default root seeds, and `status` must report the default root.
3. **`plain-seed.yml` seeds `task.disabledAgents: []`.** All bundled agents stay spawnable in plain omp; any future non-empty value surfaces as reviewable drift instead of silently killing spawns. New check scenario: a populated local list is kept and reported as drift, never overwritten.

Explicitly *not* in this PR (follow-ups from #173): the generator/agent-override gap, the isolation mandate rework and the upstream `(null)` preflight bug, and the proposed code-owned isolation dial.

## Verification

- `nix flake check`: all 22 checks pass on x86_64-linux, including the extended `omp-seed` check and the omp wrapper/stack suites.
- `go test ./...` and `gofmt -l` clean for `code-tui`.

Note for this machine post-merge: the existing populated `disabledAgents` in `~/.omp/agent/config.yml` will surface as drift on the next `atyrode apply` — resolve it there (keep-or-reset review).