### PR TITLE
code: Enter always launches the generated profile; mirror agent overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ ompu          # Restricted launcher for deliberately untrusted repositories
 ```
 
 `code` opens a TUI with a prompt→profile classifier on the local ollama daemon.
-Every trusted launch goes through `omp-managed`: Enter with nothing changed runs
-the managed defaults; type a prompt or move a dial and it generates a managed
-profile. The `u` key opens the `ompu` sandbox; plain `omp` is reached by typing
-`omp` directly. The model catalog lives in [`omp/models.yml`](omp/models.yml).
+Enter always launches the generated profile for the current facets through
+`omp-managed` — the untouched default combo is a profile like any other. The
+`m` key runs `omp-managed` on the managed defaults with no overlay, the `u`
+key opens the `ompu` sandbox, and plain `omp` is reached by typing `omp`
+directly. The model catalog lives in [`omp/models.yml`](omp/models.yml).
 
 OMP, shared skills, and mise are installed by `zconf`
 with the rest of the Home Manager profile. See

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -57,7 +57,7 @@ them together.
 | `omp` | Mutable daily driver; user-owned configuration | Whatever the operator's own OMP config selects; unmanaged apart from the blocked `update` |
 | `omp-managed` | The managed launch target: platform extensions, managed defaults, and enforced policy over a one-shot `--config`, with no preset overlay | Managed defaults and policy, plus the generated `--config` the generator passes |
 | `ompu` | Deliberately untrusted repositories | Dedicated state, sanitized credentials, restricted integrations, and isolated writing tasks |
-| `code` | The profile generator TUI (see below) | Always launches through `omp-managed`: a generated profile as a one-shot `--config`, or the managed defaults when nothing was asked for |
+| `code` | The profile generator TUI (see below) | Always launches through `omp-managed`: Enter passes the generated profile as a one-shot `--config`; `m` runs the managed defaults with no overlay |
 
 For discoverability beyond the wrapper contract, see the versioned
 [OMP feature wiki](omp/README.md). Its CLI tables describe plain upstream OMP;
@@ -134,12 +134,15 @@ There are three ways to leave the TUI — every trusted launch goes through
 `omp-managed`; plain `omp` is reached by typing `omp` directly, never via
 `code`:
 
-- **Enter with nothing changed** (no prompt, default dials) runs `omp-managed`
-  with no overlay — the managed defaults — inside the selected authentication
-  profile.
-- **Enter after typing a prompt or moving a dial** generates a managed routing
-  profile and launches it through `omp-managed` as a one-shot `--config`, with
-  the selected authentication profile and typed prompt carried into the session.
+- **Enter** always launches the generated routing profile for the current
+  facets through `omp-managed` as a one-shot `--config` — the untouched
+  default combo is a profile like any other — with the selected authentication
+  profile and any typed prompt carried into the session. The generated profile
+  carries `task.agentModelOverrides` mirroring its agent-backed roles, so
+  spawned task agents follow the generated routing instead of staying pinned
+  to the static managed defaults.
+- **`m`** runs `omp-managed` with no overlay — the managed defaults — inside
+  the selected authentication profile.
 - **`u`** opens the untrusted sandbox (`ompu`) for the current context; it never
   inherits the selected personal authentication profile.
 

--- a/docs/omp/README.md
+++ b/docs/omp/README.md
@@ -17,7 +17,7 @@ repository launchers are not interchangeable:
 | Invoke | Authentication and state | Configuration and policy |
 | --- | --- | --- |
 | `omp` | The selected OMP `--profile`, or OMP's default state root | Plain, mutable upstream configuration under `~/.omp`; no repository-managed policy is injected |
-| `code` | The `mine`/`mum` combination visible in its usage widget; press `a` to switch | Always launches through the managed layers: a generated routing profile with a prompt or changed dial, the managed defaults otherwise. Plain `omp` is never launched via `code` |
+| `code` | The `mine`/`mum` combination visible in its usage widget; press `a` to switch | Always launches through the managed layers: Enter runs the generated routing profile (including its task-agent model overrides), `m` runs the managed defaults with no overlay. Plain `omp` is never launched via `code` |
 | `omp-managed` | The selected OMP `--profile` | Injects the Nix-owned defaults, platform extensions, and enforced policy; maintenance subcommands bypass overlay injection but remain subject to repository intercepts/guards |
 | `ompu` | Always the fixed `untrusted` profile | Fixed credential-sanitized untrusted sandbox; does not inherit the personal profile selected in `code` |
 

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -35,17 +35,17 @@ import (
 
 // ── keybindings (drive both input handling and the bubbles/help footer) ───────
 type keyMap struct {
-	Move, Change, Reset, Depth, Refresh, Auth, Collapse, Launch, Untrusted, Help, Quit key.Binding
+	Move, Change, Reset, Depth, Refresh, Auth, Collapse, Launch, Managed, Untrusted, Help, Quit key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Move, k.Change, k.Reset, k.Auth, k.Launch, k.Untrusted, k.Help, k.Quit}
+	return []key.Binding{k.Move, k.Change, k.Reset, k.Auth, k.Launch, k.Managed, k.Untrusted, k.Help, k.Quit}
 }
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Move, k.Change, k.Reset},
 		{k.Depth, k.Refresh, k.Auth, k.Collapse},
-		{k.Launch, k.Untrusted, k.Help, k.Quit},
+		{k.Launch, k.Managed, k.Untrusted, k.Help, k.Quit},
 	}
 }
 
@@ -58,6 +58,7 @@ var keys = keyMap{
 	Auth:      key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "switch auth")),
 	Collapse:  key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "collapse")),
 	Launch:    key.NewBinding(key.WithKeys("enter"), key.WithHelp("⏎", "launch")),
+	Managed:   key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "managed omp")),
 	Untrusted: key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "sandbox")),
 	Help:      key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "more")),
 	Quit:      key.NewBinding(key.WithKeys("q", "esc", "ctrl+c"), key.WithHelp("q", "quit")),
@@ -749,12 +750,16 @@ func prefixed(model string) string {
 	return "openai-codex/" + model
 }
 
-// genConfigYAML reconstructs an omp config (modelRoles, fallback chains,
-// thinking, advisor, and the priority tier when fast is on) from the generated
-// routing block for the current facets — what Enter launches omp with.
+// genConfigYAML reconstructs an omp config (modelRoles, task-agent model
+// overrides for the ●-marked agent-backed roles, fallback chains, thinking,
+// advisor, and the priority tier when fast is on) from the generated routing
+// block for the current facets — what Enter launches omp with. The agent
+// overrides mirror the preview: without them the static managed defaults
+// would keep the five agent-backed types pinned regardless of the generated
+// profile (issue #173).
 func (m model) genConfigYAML() string {
 	rows := m.applyAdvisor(m.generated[comboID(m.sel)], m.sel["advisor"])
-	var mr, fc strings.Builder
+	var mr, fc, ao strings.Builder
 	advisorOn := false
 	for _, r := range rows {
 		f := strings.Fields(strings.ReplaceAll(r, "→", " "))
@@ -778,6 +783,11 @@ func (m model) genConfigYAML() string {
 		if role == "advisor" {
 			advisorOn = true
 		}
+		if i == 1 && role != "advisor" {
+			// ●-marked agent-backed role: mirror its lead route as the task-agent
+			// model override so spawned agents follow the generated profile.
+			ao.WriteString("    " + role + ": " + prefixed(models[0]) + "\n")
+		}
 		mr.WriteString("  " + role + ": " + prefixed(models[0]) + "\n")
 		if len(models) > 1 {
 			var fbs []string
@@ -790,6 +800,9 @@ func (m model) genConfigYAML() string {
 	var b strings.Builder
 	b.WriteString("modelRoles:\n" + mr.String())
 	b.WriteString("retry:\n  enabled: true\n  modelFallback: true\n  fallbackRevertPolicy: cooldown-expiry\n  fallbackChains:\n" + fc.String())
+	if ao.Len() > 0 {
+		b.WriteString("task:\n  agentModelOverrides:\n" + ao.String())
+	}
 	b.WriteString("defaultThinkingLevel: " + m.sel["thinking"] + "\n")
 	if advisorOn {
 		b.WriteString("advisor:\n  enabled: true\n")
@@ -882,40 +895,21 @@ func (m model) bodyLines() ([]string, int) {
 	return m.genLines()
 }
 
-// unmodified reports whether the generator is still untouched: every facet at its
-// default value and no prompt typed into the suggest box. Enter then launches
-// omp-managed with no overlay (the managed defaults) instead of building a
-// generated config.
-func (m model) unmodified() bool {
-	if m.firstPrompt != "" {
-		return false
-	}
-	for k, v := range defaultSel() {
-		if m.sel[k] != v {
-			return false
-		}
-	}
-	return true
-}
-
 // launchFooter is the cost/speed meters for the current facet combo plus the
 // enter-to-launch call to action — so the generator always shows what the choice
-// costs, how fast it is, and how Enter will launch it. The call to action tracks
-// the launch rule: an untouched generator runs omp-managed on the managed
-// defaults; any change launches the generated profile. The sandbox (u) key is
-// always offered.
+// costs, how fast it is, and how Enter will launch it. Enter always launches
+// the generated profile for the current facets (the untouched default combo is
+// a profile like any other); m runs omp-managed on the managed defaults with
+// no overlay, and the sandbox (u) key is always offered.
 func (m model) launchFooter() []string {
 	cs, ss := m.costScore(), m.speedScore()
 	cta := "⏎ launch generated profile"
-	if m.unmodified() {
-		cta = "⏎ run managed omp"
-	}
 	acc := lipgloss.NewStyle().Foreground(lipgloss.Color(m.accent())).Bold(true).Render("  " + cta)
 	return []string{
 		"",
 		m.meter("cost", "$", meterRamp[cs], cs), // dear → red, cheap → green
 		m.meter("speed", "»", meterRamp[6-ss], ss), // fast → green, slow → red
-		acc + stDim.Render("   u sandbox"),
+		acc + stDim.Render("   m managed omp · u sandbox"),
 	}
 }
 
@@ -991,7 +985,7 @@ type model struct {
 	fetching    bool      // a usage fetch is in flight (manual or auto)
 	nextRefresh time.Time // when the next auto-refresh fires
 
-	launchDefault   bool              // Enter on an untouched generator: run CODE_OMP with no overlay
+	launchManaged   bool              // m: run CODE_OMP with no overlay (the managed defaults)
 	launchUntrusted bool              // u: run the CODE_OMP_UNTRUSTED sandbox
 	genConfig       string            // generated config YAML to launch omp with (generator Enter)
 	firstPrompt     string            // prompt from the suggest box, forwarded as omp's first message
@@ -1360,15 +1354,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.vp.HalfViewUp() // scroll the preview (mouse capture is off, see main)
 		case "pgdown", "ctrl+d":
 			m.vp.HalfViewDown()
+		case "m":
+			// Managed-defaults omp: omp-managed with no generated overlay. The
+			// explicit keybind keeps every Enter launch a generated profile.
+			m.launchManaged = true
+			return m, tea.Quit
 		case "enter":
-			// An untouched generator (defaults, no prompt) just runs the user's bare
-			// default omp; any facet change or typed prompt launches the generated
-			// profile instead.
-			if m.unmodified() {
-				m.launchDefault = true
-			} else {
-				m.genConfig = m.genConfigYAML()
-			}
+			// Enter always launches the generated profile for the current facets —
+			// the untouched default combo is a generated profile like any other.
+			m.genConfig = m.genConfigYAML()
 			return m, tea.Quit
 		}
 
@@ -1676,10 +1670,9 @@ func main() {
 		// The sandbox owns the fixed `untrusted` profile and must never inherit the
 		// selected personal auth state.
 		execForward("CODE_OMP_UNTRUSTED", "ompu", fm.firstPrompt, "")
-	case fm.launchDefault:
-		// Nothing was generated — run omp-managed on the managed defaults inside
-		// the selected auth profile. Every trusted code launch goes through the
-		// managed layers; plain omp is reached by typing `omp` directly.
+	case fm.launchManaged:
+		// m — omp-managed on the managed defaults, no generated overlay, inside
+		// the selected auth profile. Plain omp is reached by typing `omp` directly.
 		execForward("CODE_OMP", "omp-managed", fm.firstPrompt, profile)
 	case fm.genConfig != "":
 		launchGenerated(fm.genConfig, fm.firstPrompt, profile)

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -225,21 +226,73 @@ func TestCycleFacetClearsMain(t *testing.T) {
 	}
 }
 
-// TestUnmodified locks the launch decision: an untouched generator (defaults, no
-// prompt) is "unmodified" so Enter runs omp-managed on the managed defaults; any
-// changed facet or a typed prompt flips it, so Enter launches the generated
-// profile instead.
-func TestUnmodified(t *testing.T) {
-	if m := (model{sel: defaultSel()}); !m.unmodified() {
-		t.Errorf("defaults + no prompt should be unmodified (→ default omp)")
+// TestLaunchKeys locks the launch decision: Enter always launches the generated
+// profile for the current facets — even at defaults with no prompt — while m
+// requests omp-managed on the managed defaults with no generated overlay.
+func TestLaunchKeys(t *testing.T) {
+	rows := []string{
+		"    default    gpt-5.6-sol:high → gpt-5.6-terra:medium",
+		"  ● task       gpt-5.6-terra:medium",
 	}
-	m := model{sel: defaultSel()}
-	m.sel["model"] = "smart" // any facet off its default
-	if m.unmodified() {
-		t.Errorf("a changed facet should count as modified (→ generated profile)")
+	base := model{
+		sel:       defaultSel(),
+		generated: map[string][]string{comboID(defaultSel()): rows},
 	}
-	if m := (model{sel: defaultSel(), firstPrompt: "add a login endpoint"}); m.unmodified() {
-		t.Errorf("a typed prompt should count as modified even at defaults")
+
+	next, _ := base.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m := next.(model)
+	if m.genConfig == "" || m.launchManaged {
+		t.Errorf("Enter at defaults must launch a generated profile, got genConfig=%q launchManaged=%v", m.genConfig, m.launchManaged)
+	}
+
+	next, _ = base.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	m = next.(model)
+	if !m.launchManaged || m.genConfig != "" {
+		t.Errorf("m must request the managed defaults with no overlay, got genConfig=%q launchManaged=%v", m.genConfig, m.launchManaged)
+	}
+}
+
+// TestGenConfigYAMLAgentOverrides locks the #173 fix: every ●-marked
+// agent-backed role in the generated block is mirrored into
+// task.agentModelOverrides (so spawned agents follow the generated profile),
+// while unmarked roles and the advisor never are. Prompt-focused keystrokes
+// never reach the launch keybinds — clikit's promptbox owns that routing and
+// its tests live in cli-kit.
+func TestGenConfigYAMLAgentOverrides(t *testing.T) {
+	rows := []string{
+		"    default    gpt-5.6-sol:high",
+		"    plan       claude-fable-5:xhigh",
+		"  ● designer   claude-fable-5:xhigh → claude-sonnet-5:high",
+		"  ● librarian  gpt-5.6-sol:high",
+		"  ● reviewer   claude-fable-5:xhigh",
+		"  ● sonic      gpt-5.6-luna:minimal",
+		"  ● task       gpt-5.6-terra:medium",
+		"    smol       gpt-5.6-luna:low",
+	}
+	m := model{
+		sel:       defaultSel(),
+		generated: map[string][]string{comboID(defaultSel()): rows},
+	}
+	m.sel["advisor"] = "off"
+	got := m.genConfigYAML()
+
+	// The override block is emitted in row order with a fixed shape; assert it
+	// verbatim so any drift in keys, values, or nesting fails loudly.
+	want := "task:\n  agentModelOverrides:\n" +
+		"    designer: anthropic/claude-fable-5:xhigh\n" +
+		"    librarian: openai-codex/gpt-5.6-sol:high\n" +
+		"    reviewer: anthropic/claude-fable-5:xhigh\n" +
+		"    sonic: openai-codex/gpt-5.6-luna:minimal\n" +
+		"    task: openai-codex/gpt-5.6-terra:medium\n" +
+		"defaultThinkingLevel:"
+	if !strings.Contains(got, want) {
+		t.Errorf("generated config must mirror exactly the ● roles into agentModelOverrides, got:\n%s", got)
+	}
+	// Override entries are 4-space-indented; assert no non-agent role sneaks in.
+	for _, role := range []string{"plan", "smol", "default", "advisor"} {
+		if strings.Contains(got, "    "+role+": ") {
+			t.Errorf("non-agent role %q must not be overridden, got:\n%s", role, got)
+		}
 	}
 }
 

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1196,10 +1196,11 @@ let
       # in the host config. CODE_OLLAMA_ENDPOINT / CODE_EVAL_MODEL override the
       # daemon/model. The Bubble Tea usage widget owns the active OMP auth profile:
       # `a` switches it, usage is fetched from that profile, and every trusted launch
-      # receives the same --profile. Launch targets: ↵ runs through the managed
-      # layering (CODE_OMP) — the managed defaults when nothing was changed, the
-      # generated profile otherwise; `u` opens the fixed untrusted sandbox
-      # (CODE_OMP_UNTRUSTED). Plain omp is reached by typing `omp`, never via code.
+      # receives the same --profile. Launch targets: ↵ always runs the generated
+      # profile for the current facets through the managed layering (CODE_OMP);
+      # `m` runs the managed defaults with no overlay; `u` opens the fixed
+      # untrusted sandbox (CODE_OMP_UNTRUSTED). Plain omp is reached by typing
+      # `omp`, never via code.
 
       usage() {
         printf '%s\n' \
@@ -1212,9 +1213,9 @@ let
           '  code -h, --help      this help' \
           "" \
           'In the generator: type a prompt or adjust the dials, a switches the' \
-          'visible OMP auth combination, ? shows all keys, Enter launches through' \
-          'the managed layering (the managed defaults if nothing was changed, the' \
-          'generated profile otherwise), and u opens an untrusted sandbox.'
+          'visible OMP auth combination, ? shows all keys, Enter launches the' \
+          'generated profile through the managed layering, m runs the managed' \
+          'defaults with no overlay, and u opens an untrusted sandbox.'
       }
 
       case "''${1:-}" in


### PR DESCRIPTION
Closes the remaining generator gap in #173 and reworks the launch contract per operator direction.

## Changes

1. **Generated profiles now control task-agent routing.** `genConfigYAML` mirrors every ●-marked agent-backed role into `task.agentModelOverrides`, so the one-shot generated overlay outranks the static managed-default overrides and spawned agents follow the preview. Live reproduction that motivated this: `code` preview showed designer `fable:xhigh`, while `/agents` reported Effective `sonnet-5:medium` from the static override; with this change the generated override wins.
   - Why mirroring (issue Q1) and not dropping the static map (Q2): librarian/sonic declare the `@smol` alias and reviewer `@slow` in their upstream definitions, so without overrides those three collapse onto the smol/slow routes — the static defaults map is load-bearing for non-generated sessions and stays.
2. **Enter is uniform: it always launches the generated profile** for the current facets — the untouched default combo is a profile like any other. The `unmodified()`/`launchDefault` special case is retired.
3. **New `m` keybind** (shown next to `u sandbox` in the footer and in help) runs `omp-managed` on the managed defaults with no overlay — the explicit way to get a non-generated managed session. Plain `omp` remains reachable only by typing `omp`. Single-letter keybinds are inert while the prompt box is toggled (same routing as the existing `u`).

## Verification

- New `TestGenConfigYAMLAgentOverrides`: all five ● roles mirrored verbatim (keys, values, nesting); non-agent roles and the advisor asserted absent from the override block.
- New `TestLaunchKeys`: Enter at untouched defaults emits a generated config and no managed flag; `m` sets the managed flag and emits no config.
- `go test ./...` and `gofmt` clean; `nix flake check` all green (omp-wrapper/omp-stack rebuilt against the new wrapper text).

Scope note: no isolation-policy changes here — that work is #175.