### PR TITLE
Fix profiled OMP session resume discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ atyrode doctor system # Audit system-owned operational prerequisites
 ### Agent Tools
 ```bash
 code          # Profile generator TUI: type a prompt or turn the facet dials
-omp           # Mutable user-owned OMP; unmanaged except the blocked update
+omp           # Mutable user-owned OMP; profile-aware resume, blocked update
 omp-managed   # Managed-layering launch target: defaults + policy over --config
 ompu          # Restricted launcher for deliberately untrusted repositories
 ```

--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -536,6 +536,38 @@ in
         literal
         EOF
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
+            unset OMP_PROFILE PI_CODING_AGENT_DIR PI_CONFIG_DIR
+            # A resume hint emitted by a profiled session is usable verbatim.
+            resume_id=019f6386-bbf6-7000-8e5c-8d88e87e3907
+            mkdir -p "$HOME/.omp/profiles/mum/agent/sessions"
+            touch "$HOME/.omp/profiles/mum/agent/sessions/2026-07-15T02-06-42-166Z_$resume_id.jsonl"
+            ${configuredStub}/bin/omp --resume "''${resume_id:0:12}" > "$TMPDIR/actual"
+            printf '%s\n' --profile mum --resume "''${resume_id:0:12}" > "$TMPDIR/expected"
+            diff -u "$TMPDIR/expected" "$TMPDIR/actual"
+
+            # Explicit state selection always wins, even when another profile
+            # contains the same resume target.
+            ${configuredStub}/bin/omp --profile mine --resume "$resume_id" > "$TMPDIR/actual"
+            printf '%s\n' --profile mine --resume "$resume_id" > "$TMPDIR/expected"
+            diff -u "$TMPDIR/expected" "$TMPDIR/actual"
+
+            default_id=029f6386-bbf6-7000-8e5c-8d88e87e3907
+            mkdir -p "$HOME/.omp/agent/sessions"
+            touch "$HOME/.omp/agent/sessions/2026-07-15T03-00-00-000Z_$default_id.jsonl"
+            ${configuredStub}/bin/omp --resume="$default_id" > "$TMPDIR/actual"
+            printf '%s\n' "--resume=$default_id" > "$TMPDIR/expected"
+            diff -u "$TMPDIR/expected" "$TMPDIR/actual"
+
+            mkdir -p "$HOME/.omp/profiles/mine/agent/sessions"
+            touch "$HOME/.omp/profiles/mine/agent/sessions/2026-07-15T04-00-00-000Z_$resume_id.jsonl"
+            set +e
+            ${configuredStub}/bin/omp -r"''${resume_id:0:12}" \
+              > "$TMPDIR/ambiguous.out" 2> "$TMPDIR/ambiguous.err"
+            ambiguous_status=$?
+            set -e
+            test "$ambiguous_status" -eq 2
+            grep -q 'matches sessions in multiple OMP state roots' "$TMPDIR/ambiguous.err"
+
 
             set +e
             ${configuredStub}/bin/omp update \

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -54,7 +54,7 @@ them together.
 
 | Command | Intended use | Configuration |
 | --- | --- | --- |
-| `omp` | Mutable daily driver; user-owned configuration | Whatever the operator's own OMP config selects; unmanaged apart from the blocked `update` |
+| `omp` | Mutable daily driver; user-owned configuration | Whatever the operator's own OMP config selects; unmanaged apart from the blocked `update` and profile-aware resume lookup |
 | `omp-managed` | The managed launch target: platform extensions, managed defaults, and enforced policy over a one-shot `--config`, with no preset overlay | Managed defaults and policy, plus the generated `--config` the generator passes |
 | `ompu` | Deliberately untrusted repositories | Dedicated state, sanitized credentials, restricted integrations, and isolated writing tasks |
 | `code` | The profile generator TUI (see below) | Always launches through `omp-managed`: Enter passes the generated profile as a one-shot `--config`; `m` runs the managed defaults with no overlay |
@@ -65,10 +65,14 @@ this document remains authoritative for `code`, `omp-managed`, and `ompu`.
 
 Plain `omp` executes upstream OMP directly: no extension, defaults, or policy
 overlay is injected, so its models, approvals, and interface belong to the
-operator's mutable configuration and can change on the fly. Only `omp update`
-is blocked, so nothing shadows the Nix-pinned binary. Its starting point is not
-empty, though: activation seeds the curated defaults from `omp/plain-seed.yml`
-into the writable configuration with local edits always winning; see
+operator's mutable configuration and can change on the fly. `omp update` is
+blocked so nothing shadows the Nix-pinned binary. For a UUID or UUID-prefix
+passed to `--resume`, the launcher searches the default and named-profile
+session roots and injects the sole matching profile; explicit profile/state
+selection always wins, and ambiguous matches require `--profile`. This repairs
+upstream's profile-free end-of-session resume hint without changing ordinary
+launches. Activation seeds the curated defaults from `omp/plain-seed.yml` into
+the writable configuration with local edits always winning; see
 [Seeded plain-omp defaults](#seeded-plain-omp-defaults).
 
 `omp-managed` is the managed launcher with no profile of its own. It layers the

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -936,7 +936,83 @@ let
         printf '%s\n' 'OMP is managed by Nix. Update the pinned derivation, then run zconf.' >&2
         exit 2
       fi
-      exec ${lib.getExe omp} "$@"
+
+      # Upstream's end-of-session hint omits the active profile, so make a bare
+      # UUID resume target profile-aware without changing explicit state choices.
+      args=( "$@" )
+      resume_target=""
+      explicit_state=false
+      for (( i = 0; i < ''${#args[@]}; i++ )); do
+        arg="''${args[$i]}"
+        case "$arg" in
+          --profile|--session-dir)
+            explicit_state=true
+            (( i += 1 ))
+            ;;
+          --profile=*|--session-dir=*)
+            explicit_state=true
+            ;;
+          --resume|-r)
+            if (( i + 1 < ''${#args[@]} )) && [[ "''${args[$((i + 1))]}" != -* ]]; then
+              resume_target="''${args[$((i + 1))]}"
+            fi
+            ;;
+          --resume=*)
+            resume_target="''${arg#--resume=}"
+            ;;
+          -r?*)
+            resume_target="''${arg#-r}"
+            ;;
+          --)
+            break
+            ;;
+        esac
+      done
+
+      if [[ -z "''${OMP_PROFILE:-}" && -z "''${PI_CODING_AGENT_DIR:-}" &&
+        -z "''${PI_CONFIG_DIR:-}" && "$explicit_state" == false &&
+        "$resume_target" =~ ^[0-9a-fA-F-]{8,36}$ ]]; then
+        config_root="$HOME/.omp"
+        matched_default=false
+        matched_profiles=()
+        shopt -s nullglob
+
+        for session in "$config_root/agent/sessions/"*.jsonl; do
+          session_id="''${session##*_}"
+          session_id="''${session_id%.jsonl}"
+          if [[ "$session_id" == "$resume_target"* ]]; then
+            matched_default=true
+            break
+          fi
+        done
+
+        for profile_root in "$config_root/profiles/"*/agent/sessions; do
+          profile="''${profile_root#"$config_root/profiles/"}"
+          profile="''${profile%%/*}"
+          for session in "$profile_root/"*.jsonl; do
+            session_id="''${session##*_}"
+            session_id="''${session_id%.jsonl}"
+            if [[ "$session_id" == "$resume_target"* ]]; then
+              matched_profiles+=( "$profile" )
+              break
+            fi
+          done
+        done
+
+        match_count=''${#matched_profiles[@]}
+        if [[ "$matched_default" == true ]]; then
+          (( match_count += 1 ))
+        fi
+        if (( match_count == 1 )) && [[ "$matched_default" == false ]]; then
+          args=( --profile "''${matched_profiles[0]}" "''${args[@]}" )
+        elif (( match_count > 1 )); then
+          printf 'Error: Resume target "%s" matches sessions in multiple OMP state roots; pass --profile explicitly.\n' \
+            "$resume_target" >&2
+          exit 2
+        fi
+      fi
+
+      exec ${lib.getExe omp} "''${args[@]}"
     '';
   };
   # The managed launcher: applies the platform extensions + managed defaults +


### PR DESCRIPTION
## Summary

- resolve UUID and UUID-prefix resume targets across default and named OMP profile session roots
- inject the sole matching profile while preserving explicit profile/state selections
- reject cross-root ambiguity instead of guessing
- document the narrow plain-launcher behavior and cover default, profiled, explicit, prefix, and ambiguous cases

Closes #180.

## Related worktree finding

The isolated-agent failure tracked in #181 was independent machine state, not the initially suspected Bun Git-environment behavior. OMP baseline capture reached a stale nested Claude worktree whose `.git` pointer referenced the repository's old `/home/alex/nix-dotfiles` path. That unregistered worktree was quarantined intact outside the checkout; a fresh isolated child then completed successfully. #181 is closed with the corrected diagnosis and verification.

## Verification

- `nix build .#checks.x86_64-linux.omp-wrapper`
- `nix flake check`
- actual profiled resume of `019f6386-bbf6-7000-8e5c-8d88e87e3907` through the built plain launcher with no explicit profile returned `RESUME_OK`
- fresh managed OMP session spawned an `isolated: true` child and returned `ISOLATION_OK`