### PR TITLE
Fix resume discovery for project-scoped OMP sessions

### DIFF
--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -539,8 +539,8 @@ in
             unset OMP_PROFILE PI_CODING_AGENT_DIR PI_CONFIG_DIR
             # A resume hint emitted by a profiled session is usable verbatim.
             resume_id=019f6386-bbf6-7000-8e5c-8d88e87e3907
-            mkdir -p "$HOME/.omp/profiles/mum/agent/sessions"
-            touch "$HOME/.omp/profiles/mum/agent/sessions/2026-07-15T02-06-42-166Z_$resume_id.jsonl"
+            mkdir -p "$HOME/.omp/profiles/mum/agent/sessions/-dotfiles"
+            touch "$HOME/.omp/profiles/mum/agent/sessions/-dotfiles/2026-07-15T02-06-42-166Z_$resume_id.jsonl"
             ${configuredStub}/bin/omp --resume "''${resume_id:0:12}" > "$TMPDIR/actual"
             printf '%s\n' --profile mum --resume "''${resume_id:0:12}" > "$TMPDIR/expected"
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
@@ -552,14 +552,14 @@ in
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
             default_id=029f6386-bbf6-7000-8e5c-8d88e87e3907
-            mkdir -p "$HOME/.omp/agent/sessions"
-            touch "$HOME/.omp/agent/sessions/2026-07-15T03-00-00-000Z_$default_id.jsonl"
+            mkdir -p "$HOME/.omp/agent/sessions/-project"
+            touch "$HOME/.omp/agent/sessions/-project/2026-07-15T03-00-00-000Z_$default_id.jsonl"
             ${configuredStub}/bin/omp --resume="$default_id" > "$TMPDIR/actual"
             printf '%s\n' "--resume=$default_id" > "$TMPDIR/expected"
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
-            mkdir -p "$HOME/.omp/profiles/mine/agent/sessions"
-            touch "$HOME/.omp/profiles/mine/agent/sessions/2026-07-15T04-00-00-000Z_$resume_id.jsonl"
+            mkdir -p "$HOME/.omp/profiles/mine/agent/sessions/-dotfiles"
+            touch "$HOME/.omp/profiles/mine/agent/sessions/-dotfiles/2026-07-15T04-00-00-000Z_$resume_id.jsonl"
             set +e
             ${configuredStub}/bin/omp -r"''${resume_id:0:12}" \
               > "$TMPDIR/ambiguous.out" 2> "$TMPDIR/ambiguous.err"

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -975,9 +975,9 @@ let
         config_root="$HOME/.omp"
         matched_default=false
         matched_profiles=()
-        shopt -s nullglob
+        shopt -s nullglob globstar
 
-        for session in "$config_root/agent/sessions/"*.jsonl; do
+        for session in "$config_root/agent/sessions"/**/*.jsonl; do
           session_id="''${session##*_}"
           session_id="''${session_id%.jsonl}"
           if [[ "$session_id" == "$resume_target"* ]]; then
@@ -989,7 +989,7 @@ let
         for profile_root in "$config_root/profiles/"*/agent/sessions; do
           profile="''${profile_root#"$config_root/profiles/"}"
           profile="''${profile%%/*}"
-          for session in "$profile_root/"*.jsonl; do
+          for session in "$profile_root"/**/*.jsonl; do
             session_id="''${session##*_}"
             session_id="''${session_id%.jsonl}"
             if [[ "$session_id" == "$resume_target"* ]]; then


### PR DESCRIPTION
## Summary

- search recursively below each OMP session root because upstream stores transcripts in project directories such as `sessions/-dotfiles/`
- update resume fixtures to reproduce the real on-disk layout for default and named profiles

Follow-up to #180 and #182. The original tests placed JSONL files directly in `sessions/`, so they did not cover upstream's actual project-scoped storage.

## Verification

- `nix build .#checks.x86_64-linux.omp-wrapper`
- `nix flake check`
- exact unqualified command against the real nested session, with profile/state environment variables removed, returned `RESUME_OK`:
  ```sh
  omp --resume 019f6386-bbf6-7000-8e5c-8d88e87e3907
  ```