### PR TITLE
code: default the model setting to smart

### DIFF
--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -539,8 +539,8 @@ in
             unset OMP_PROFILE PI_CODING_AGENT_DIR PI_CONFIG_DIR
             # A resume hint emitted by a profiled session is usable verbatim.
             resume_id=019f6386-bbf6-7000-8e5c-8d88e87e3907
-            mkdir -p "$HOME/.omp/profiles/mum/agent/sessions"
-            touch "$HOME/.omp/profiles/mum/agent/sessions/2026-07-15T02-06-42-166Z_$resume_id.jsonl"
+            mkdir -p "$HOME/.omp/profiles/mum/agent/sessions/-dotfiles"
+            touch "$HOME/.omp/profiles/mum/agent/sessions/-dotfiles/2026-07-15T02-06-42-166Z_$resume_id.jsonl"
             ${configuredStub}/bin/omp --resume "''${resume_id:0:12}" > "$TMPDIR/actual"
             printf '%s\n' --profile mum --resume "''${resume_id:0:12}" > "$TMPDIR/expected"
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
@@ -552,14 +552,14 @@ in
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
             default_id=029f6386-bbf6-7000-8e5c-8d88e87e3907
-            mkdir -p "$HOME/.omp/agent/sessions"
-            touch "$HOME/.omp/agent/sessions/2026-07-15T03-00-00-000Z_$default_id.jsonl"
+            mkdir -p "$HOME/.omp/agent/sessions/-project"
+            touch "$HOME/.omp/agent/sessions/-project/2026-07-15T03-00-00-000Z_$default_id.jsonl"
             ${configuredStub}/bin/omp --resume="$default_id" > "$TMPDIR/actual"
             printf '%s\n' "--resume=$default_id" > "$TMPDIR/expected"
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
-            mkdir -p "$HOME/.omp/profiles/mine/agent/sessions"
-            touch "$HOME/.omp/profiles/mine/agent/sessions/2026-07-15T04-00-00-000Z_$resume_id.jsonl"
+            mkdir -p "$HOME/.omp/profiles/mine/agent/sessions/-dotfiles"
+            touch "$HOME/.omp/profiles/mine/agent/sessions/-dotfiles/2026-07-15T04-00-00-000Z_$resume_id.jsonl"
             set +e
             ${configuredStub}/bin/omp -r"''${resume_id:0:12}" \
               > "$TMPDIR/ambiguous.out" 2> "$TMPDIR/ambiguous.err"

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -67,7 +67,7 @@ var keys = keyMap{
 // defaultSel returns a fresh copy of the generator's default facet selection —
 // used both to seed the model and to restore it via the reset key.
 func defaultSel() map[string]string {
-	return map[string]string{"lane": "mixed", "model": "normal", "thinking": "medium", "advisor": "glance", "spark": "on", "fable": "off", "main": "off", "fast": "off"}
+	return map[string]string{"lane": "mixed", "model": "smart", "thinking": "medium", "advisor": "glance", "spark": "on", "fable": "off", "main": "off", "fast": "off"}
 }
 
 // ── palette ──────────────────────────────────────────────────────────────────

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -152,8 +152,8 @@ func TestComboID(t *testing.T) {
 }
 
 // TestDefaultSelValid guards the reset-to-defaults key (#119) against facet
-// drift: every default must name a real facet and a value that facet offers, and
-// every facet must be seeded exactly once.
+// drift: every default must name a real facet and a value that facet offers,
+// every facet must be seeded exactly once, and the model default is smart (#178).
 func TestDefaultSelValid(t *testing.T) {
 	facets := facetDefs(map[string]string{})
 	byKey := map[string][]string{}
@@ -180,6 +180,9 @@ func TestDefaultSelValid(t *testing.T) {
 		if !found {
 			t.Errorf("defaultSel[%q]=%q is not a valid value (allowed: %v)", k, v, values)
 		}
+	}
+	if def["model"] != "smart" {
+		t.Errorf(`defaultSel["model"] = %q, want "smart"`, def["model"])
 	}
 }
 

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -975,9 +975,9 @@ let
         config_root="$HOME/.omp"
         matched_default=false
         matched_profiles=()
-        shopt -s nullglob
+        shopt -s nullglob globstar
 
-        for session in "$config_root/agent/sessions/"*.jsonl; do
+        for session in "$config_root/agent/sessions"/**/*.jsonl; do
           session_id="''${session##*_}"
           session_id="''${session_id%.jsonl}"
           if [[ "$session_id" == "$resume_target"* ]]; then
@@ -989,7 +989,7 @@ let
         for profile_root in "$config_root/profiles/"*/agent/sessions; do
           profile="''${profile_root#"$config_root/profiles/"}"
           profile="''${profile%%/*}"
-          for session in "$profile_root/"*.jsonl; do
+          for session in "$profile_root"/**/*.jsonl; do
             session_id="''${session##*_}"
             session_id="''${session_id%.jsonl}"
             if [[ "$session_id" == "$resume_target"* ]]; then


### PR DESCRIPTION
Changes the default `model` setting for `code` from `normal` to `smart`, and extends TestDefaultSelValid to guard the new default. The set of valid model values is unchanged.

Closes #178