### PR TITLE
code: show OpenAI reset counts and soonest expirations in usage box

### DIFF
--- a/pkgs/code-tui/auth_test.go
+++ b/pkgs/code-tui/auth_test.go
@@ -92,6 +92,71 @@ func TestUsagePanelNamesWholeAuthCombination(t *testing.T) {
 	}
 }
 
+const day = int64(86400)
+
+func TestCreditLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		credits resetCredits
+		want    string
+	}{
+		{"absent", resetCredits{}, ""},
+		{"count only", resetCredits{avail: 2}, "2 resets"},
+		{"singular", resetCredits{avail: 1, exp: []int64{3 * day}}, "1 reset · expiring in 3d"},
+		{"sorted ascending", resetCredits{avail: 3, exp: []int64{28 * day, 11 * day, 16 * day}}, "3 resets · expiring in 11d, 16d, 28d"},
+		{"capped at three soonest", resetCredits{avail: 5, exp: []int64{40 * day, 2 * day, 30 * day, 9 * day, 20 * day}}, "5 resets · expiring in 2d, 9d, 20d"},
+		{"rounds up to whole days", resetCredits{avail: 3, exp: []int64{1, day, day + 1}}, "3 resets · expiring in 1d, 1d, 2d"},
+		{"expired reads zero", resetCredits{avail: 0, exp: []int64{-5}}, "0 resets · expiring in 0d"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := model{avail: availability{credits: tt.credits}}
+			got := m.creditLine()
+			if tt.want == "" {
+				if got != "" {
+					t.Fatalf("creditLine() = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("creditLine() = %q, want it to contain %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUsagePanelShowsOpenAIResetCredits(t *testing.T) {
+	m := model{
+		authProfiles: []authProfile{{ID: "default", Label: "mine", Claude: "Alex", Codex: "Alex"}},
+		avail: availability{
+			ok:      true,
+			bucket:  map[string]string{},
+			reset:   map[string]int64{},
+			wins:    []usageWin{{label: "7 days", pct: 33, secs: 6 * day, dur: 7 * day, prov: "openai-codex"}},
+			credits: resetCredits{avail: 3, exp: []int64{28 * day, 11 * day, 16 * day}},
+		},
+	}
+	panel := m.usagePanel()
+	if !strings.Contains(panel, "3 resets · expiring in 11d, 16d, 28d") {
+		t.Fatalf("usage panel missing reset credits: %q", panel)
+	}
+}
+
+func TestUsagePanelWithoutResetCredits(t *testing.T) {
+	m := model{
+		authProfiles: []authProfile{{ID: "default", Label: "mine", Claude: "Alex", Codex: "Alex"}},
+		avail: availability{
+			ok:     true,
+			bucket: map[string]string{},
+			reset:  map[string]int64{},
+			wins:   []usageWin{{label: "7 days", pct: 33, secs: 6 * day, dur: 7 * day, prov: "openai-codex"}},
+		},
+	}
+	if panel := m.usagePanel(); strings.Contains(panel, "expiring") || strings.Contains(panel, "resets") {
+		t.Fatalf("usage panel unexpectedly mentions reset credits: %q", panel)
+	}
+}
+
 func TestWithOMPProfileOverridesForwardedProfile(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -219,11 +219,19 @@ type usageWin struct {
 	prov  string
 }
 
+// resetCredits tracks OpenAI reset credits: how many are currently available
+// and the seconds until each available credit expires (relative, unsorted).
+type resetCredits struct {
+	avail int
+	exp   []int64
+}
+
 type availability struct {
-	bucket map[string]string // bucket -> "ok" | "maxed" | "unauthed"
-	reset  map[string]int64
-	wins   []usageWin
-	ok     bool
+	bucket  map[string]string // bucket -> "ok" | "maxed" | "unauthed"
+	reset   map[string]int64
+	wins    []usageWin
+	credits resetCredits
+	ok      bool
 }
 
 func loadAvailability(cmd, profile string) availability {
@@ -253,6 +261,13 @@ func loadAvailability(cmd, profile string) availability {
 					DurationMs int64 `json:"durationMs"`
 				} `json:"window"`
 			} `json:"limits"`
+			ResetCredits struct {
+				AvailableCount int `json:"availableCount"`
+				Credits        []struct {
+					ExpiresAt string `json:"expiresAt"`
+					Status    string `json:"status"`
+				} `json:"credits"`
+			} `json:"resetCredits"`
 		} `json:"reports"`
 	}
 	if json.Unmarshal(out, &doc) != nil {
@@ -275,6 +290,17 @@ func loadAvailability(cmd, profile string) availability {
 				a.reset[bkt] = l.Window.ResetsAt/1000 - now
 			} else if a.bucket[bkt] != "maxed" {
 				a.bucket[bkt] = "ok"
+			}
+		}
+		if r.Provider == "openai-codex" {
+			a.credits.avail = r.ResetCredits.AvailableCount
+			for _, c := range r.ResetCredits.Credits {
+				if c.Status != "available" {
+					continue
+				}
+				if t, err := time.Parse(time.RFC3339, c.ExpiresAt); err == nil {
+					a.credits.exp = append(a.credits.exp, t.Unix()-now)
+				}
 			}
 		}
 	}
@@ -1175,6 +1201,11 @@ func (m *model) usagePanel() string {
 		}
 		blocks[w.prov] = append(blocks[w.prov], m.usageRow(w))
 	}
+	if cl := m.creditLine(); cl != "" {
+		if b, ok := blocks["openai-codex"]; ok {
+			blocks["openai-codex"] = append(b, cl)
+		}
+	}
 	// side-by-side when there's horizontal room, else stacked. colW must fit the
 	// widest row (label · bar · pct · ↻reset · note) without wrapping the note.
 	const colW = 49
@@ -1213,6 +1244,42 @@ func (m *model) usageRow(w usageWin) string {
 		reset = lipgloss.NewStyle().Foreground(lipgloss.Color("#c8d0dc")).Render(gReset + " " + fmtReset(w.secs))
 	}
 	return fmt.Sprintf("  %-9s %s %3d%% used  %s%s", shortWin(w.label), barStr(w.pct), w.pct, reset, note)
+}
+
+// creditLine renders the OpenAI reset-credit summary: the available count and
+// the days remaining until the three soonest credit expirations, ascending.
+func (m *model) creditLine() string {
+	c := m.avail.credits
+	if c.avail == 0 && len(c.exp) == 0 {
+		return ""
+	}
+	exp := append([]int64(nil), c.exp...)
+	sort.Slice(exp, func(i, j int) bool { return exp[i] < exp[j] })
+	if len(exp) > 3 {
+		exp = exp[:3]
+	}
+	noun := "resets"
+	if c.avail == 1 {
+		noun = "reset"
+	}
+	line := fmt.Sprintf("%d %s", c.avail, noun)
+	if len(exp) > 0 {
+		days := make([]string, len(exp))
+		for i, s := range exp {
+			days[i] = fmtDays(s)
+		}
+		line += " · expiring in " + strings.Join(days, ", ")
+	}
+	return "  " + stDim.Render(gReset+" "+line)
+}
+
+// fmtDays renders a relative duration as whole days remaining, rounding up so
+// a credit expiring later today still reads 1d.
+func fmtDays(s int64) string {
+	if s <= 0 {
+		return "0d"
+	}
+	return fmt.Sprintf("%dd", (s+86399)/86400)
 }
 
 func (m *model) syncPreview() {


### PR DESCRIPTION
Closes #177

Adds an OpenAI reset-credit summary line to the `code` CLI usage box: the number of available resets and the days remaining until the three soonest credit expirations, sorted ascending and capped at 3.

## Data availability

`omp usage --json` exposes reset info on the `openai-codex` report as `resetCredits: { availableCount, credits: [{ grantedAt, expiresAt, status }] }`. `availableCount` is the count of resets available (the API does not report resets *used*, so the line shows the available count); expirations come from `expiresAt` of `status == "available"` credits. Days round **up** (`fmtDays`), so a credit expiring later today reads `1d`.

## Implementation

- `loadAvailability` additionally parses `resetCredits` into a new `resetCredits{avail, exp}` field on `availability` (relative seconds, same convention as `usageWin.secs`).
- `usagePanel` appends a dim `creditLine()` to the Codex block: `↻︎ 3 resets · expiring in 11d, 16d, 28d`. Rendered only when credit data exists; panel is byte-identical otherwise.
- Table-driven tests cover sorting, cap at 3, day rounding (ceil), singular/plural, and absence.

## Visual smoke (tmux capture, 150x44, truecolor env per docs/tui-verification.md)

With fixture credits expiring in 11.5d / 16.2d / 28.7d:

```
  Codex                                            Claude
  7d        ███░░░░░░░  33% used  ↻︎ 6d16h          5h        ███░░░░░░░  29% used  ↻︎ 2h23m
  7d spark  ░░░░░░░░░░   0% used  ↻︎ 6d16h  idle    7d        ████░░░░░░  41% used  ↻︎ 4d4h
  ↻︎ 3 resets · expiring in 12d, 17d, 29d
```

Without `resetCredits` in the JSON the panel renders unchanged (verified with a second capture; no `resets` line, no layout shift). No row exceeds the 150-col pane; `git diff` audited to confirm no PUA-glyph lines were rewritten.
