### PR TITLE
agent-tools: add tmux, freeze, and render fonts for TUI verification

### DIFF
--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -1422,4 +1422,40 @@ in
 
             mkdir "$out"
       '';
+
+  # The terminal-viewing stack from the tui-visual-verification skill (#163):
+  # tmux drives and captures the TUI under test, charm-freeze renders the ANSI
+  # capture to PNG with the pinned render fonts. Exercise the whole pipeline so
+  # a missing tool, a renamed nixpkgs attribute, or a dropped font file fails
+  # the flake instead of the first agent verification run.
+  agent-tools-terminal-viewing =
+    pkgs.runCommand "check-agent-tools-terminal-viewing"
+      {
+        nativeBuildInputs = [
+          pkgs.charm-freeze
+          pkgs.tmux
+        ];
+      }
+      ''
+        tmux -V
+        freeze --version
+
+        # The exact font files the profile installs and freeze is pointed at.
+        test -f ${pkgs.jetbrains-mono}/share/fonts/truetype/JetBrainsMono-Regular.ttf
+        test -f ${pkgs.nerd-fonts.symbols-only}/share/fonts/truetype/NerdFonts/Symbols/SymbolsNerdFontMono-Regular.ttf
+
+        # Render a truecolor frame carrying a Nerd Font PUA glyph end to end,
+        # with the fonts exposed the way a user profile exposes them.
+        export HOME="$TMPDIR"
+        export XDG_DATA_HOME="$TMPDIR/share"
+        mkdir -p "$XDG_DATA_HOME/fonts"
+        ln -s ${pkgs.jetbrains-mono}/share/fonts/truetype/*.ttf "$XDG_DATA_HOME/fonts/"
+        ln -s ${pkgs.nerd-fonts.symbols-only}/share/fonts/truetype/NerdFonts/Symbols/*.ttf "$XDG_DATA_HOME/fonts/"
+        printf '\x1b[38;2;255;95;175mpill \xee\x82\xb6 glyph\x1b[0m\n' > frame.ansi
+        freeze --language ansi frame.ansi -o frame.png \
+          --font.family "JetBrains Mono,Symbols Nerd Font Mono"
+        test -s frame.png
+
+        mkdir "$out"
+      '';
 }

--- a/docs/package-ownership.md
+++ b/docs/package-ownership.md
@@ -13,7 +13,9 @@ from the server composition.
 - `development` contains cross-repository Nix and shell quality tools. It does
   not provide application language versions.
 - `agent-tools` owns Claude Code, Codex, OMP, their launch adapters,
-  tmux, and the Linux isolation backend. Authentication, sessions, trust, and
+  tmux, the Linux isolation backend, and the TUI-verification render stack
+  (charm-freeze plus the JetBrains Mono and Nerd Font symbols render fonts,
+  exposed through user fontconfig). Authentication, sessions, trust, and
   caches remain mutable and harness-owned outside derivations.
 - `desktop`, `mobile`, `media`, `containers`, and `security` are explicit host
   capabilities. Container daemons and Homebrew application state remain
@@ -72,12 +74,12 @@ or capability. The shared Nix store deduplicates identical dependencies across
 hosts and workspaces; a binary cache can be added without changing ownership.
 
 At the pinned 2026-07-08 nixpkgs revision, the portable x86_64-linux server
-profile delivers 37 top-level packages and measures 2,376,988,648 NAR bytes
-across 406 store paths. Its enforced ceilings are 40 packages, 2,617,245,696
+profile delivers 41 top-level packages and measures 2,430,232,848 NAR bytes
+across 409 store paths. Its enforced ceilings are 45 packages, 2,617,245,696
 bytes, and 450 paths. The profile deliberately excludes development, containers, security,
 media, mobile, and desktop capabilities; it therefore contains neither
 workstation language stacks, container clients, nor antivirus software. The
-aarch64 ceilings are 40
+aarch64 ceilings are 45
 packages, 2.5 GiB, and 500 paths and are enforced by the native CI runner. See
 [Portable Home Manager profiles](portable-profiles.md) for the manifest schema
 and pin/update workflow.

--- a/docs/tui-verification.md
+++ b/docs/tui-verification.md
@@ -9,8 +9,10 @@ empty strings.
 
 The toolchain: **tmux** (drive + capture, authoritative), **charm-freeze**
 (deterministic PNG renders), with ttyd/vhs as live-viewing alternatives.
-Packaging these into the managed agent tool suite is tracked in
-[issue #163](https://github.com/atyrode/dotfiles/issues/163).
+tmux, charm-freeze, and the render fonts (JetBrains Mono + Nerd Font symbols)
+ship in the managed agent tool suite — the `agent-tools` capability
+([issue #163](https://github.com/atyrode/dotfiles/issues/163)); ttyd/vhs stay
+on-demand `nix shell` tools because that stack is flaky in agent sandboxes.
 
 ## 0. Fix the environment first — it silently degrades color
 
@@ -70,15 +72,16 @@ To actually *look* at a frame (colors, pills, contrast), render the ANSI
 capture to PNG with `freeze` — no server, no browser, no client sizing:
 
 ```console
-$ nix shell nixpkgs#charm-freeze -c \
-    freeze --language ansi /tmp/frame.ansi -o /tmp/frame.png \
+$ freeze --language ansi /tmp/frame.ansi -o /tmp/frame.png \
     --font.family "JetBrains Mono,Symbols Nerd Font Mono"
 ```
 
 With the truecolor env from §0, the PNG reproduces the authored hex colors
-exactly (24-bit SGR bypasses freeze's ANSI theme palette). Install the fonts
-once where freeze runs (`nixpkgs#jetbrains-mono`,
-`nixpkgs#nerd-fonts.symbols-only` → `~/.local/share/fonts` + `fc-cache -f`).
+exactly (24-bit SGR bypasses freeze's ANSI theme palette). freeze and both
+fonts are installed by the `agent-tools` capability with user fontconfig
+enabled; on an unmanaged machine, `nix shell nixpkgs#charm-freeze` and drop
+`nixpkgs#jetbrains-mono` + `nixpkgs#nerd-fonts.symbols-only` into
+`~/.local/share/fonts` (then `fc-cache -f`).
 
 Known limitations:
 

--- a/home/profiles/agent-tools.nix
+++ b/home/profiles/agent-tools.nix
@@ -8,10 +8,21 @@
 
   atyrode.agentTools.enable = true;
 
+  # Terminal-viewing stack for the tui-visual-verification skill (#163): tmux
+  # drives and captures the TUI under test, charm-freeze renders the ANSI
+  # capture to PNG, and the two fonts make those renders faithful (JetBrains
+  # Mono for text, Nerd Font symbols for PUA glyphs). ttyd/vhs are deliberately
+  # left out: that stack proved flaky in agent sandboxes and remains an
+  # on-demand `nix shell` tool for live watching only.
+  fonts.fontconfig.enable = true;
+
   home.packages =
     (with pkgs; [
+      charm-freeze
       claude-code
       codex
+      jetbrains-mono
+      nerd-fonts.symbols-only
       tmux
     ])
     ++ lib.optionals pkgs.stdenv.isLinux [ pkgs.bubblewrap ];

--- a/inventory/packages.json
+++ b/inventory/packages.json
@@ -23,11 +23,11 @@
     "owner": "agent-tools",
     "deliveryLayer": "home-manager and repository overlays",
     "selectedBy": ["agent-tools"],
-    "consumer": "Claude Code, Codex, and OMP isolation",
+    "consumer": "Claude Code, Codex, OMP isolation, and TUI verification",
     "versionOwner": "pinned nixpkgs or repository package derivation",
     "mutableState": "separate harness-owned auth, sessions, MCP state, and caches under the user home",
     "closureClass": "large",
-    "packages": ["bubblewrap", "claude-code", "codex", "omp-configured", "tmux"]
+    "packages": ["bubblewrap", "charm-freeze", "claude-code", "codex", "jetbrains-mono", "nerd-fonts-symbols-only", "omp-configured", "tmux"]
   },
   {
     "owner": "desktop",

--- a/inventory/server-profile.json
+++ b/inventory/server-profile.json
@@ -16,6 +16,7 @@
     "bat",
     "btop",
     "bubblewrap",
+    "charm-freeze",
     "claude-code",
     "codex",
     "direnv",
@@ -25,8 +26,10 @@
     "fzf",
     "gh",
     "git",
+    "jetbrains-mono",
     "jq",
     "mise",
+    "nerd-fonts-symbols-only",
     "omp-configured",
     "ripgrep",
     "tmux",
@@ -95,12 +98,12 @@
     "aarch64-linux": {
       "maxNarBytes": 2684354560,
       "maxStorePaths": 500,
-      "maxTopLevelPackages": 40
+      "maxTopLevelPackages": 45
     },
     "x86_64-linux": {
       "maxNarBytes": 2617245696,
       "maxStorePaths": 450,
-      "maxTopLevelPackages": 40
+      "maxTopLevelPackages": 45
     }
   },
   "systemOwned": [


### PR DESCRIPTION
Closes #163

Adds the terminal-viewing stack from the `tui-visual-verification` skill to the managed agent tool suite (`agent-tools`, the owning layer per `docs/package-ownership.md`):

- **charm-freeze** — deterministic ANSI→PNG renders (`pkgs.charm-freeze`; verified as the correct nixpkgs attr, pname `charm-freeze`);
- **jetbrains-mono** + **nerd-fonts.symbols-only** — render fonts, exposed via `fonts.fontconfig.enable = true` in the capability profile;
- **tmux** was already owned and installed by `agent-tools`; no change needed there.

**ttyd/vhs deliberately skipped.** The issue marks them optional and documents that stack (ttyd + headless Chromium, which vhs drives underneath) as flaky in agent sandboxes; they stay on-demand `nix shell` tools per `docs/tui-verification.md` §3. With the mandatory items landed and the optionals explicitly declined for the reason the issue itself records, this closes #163.

Changes:
- `home/profiles/agent-tools.nix`: packages + user fontconfig.
- `checks/agent-tools.nix`: new `agent-tools-terminal-viewing` check exercising the whole pipeline in the sandbox — `tmux -V`, `freeze --version`, the exact font files, and an end-to-end truecolor ANSI frame carrying a Nerd Font PUA glyph rendered to PNG with `--font.family "JetBrains Mono,Symbols Nerd Font Mono"`.
- `inventory/packages.json`: the three packages recorded under the `agent-tools` owner.
- `inventory/server-profile.json`: the server composition includes `agent-tools`, so the three packages are now *required* there, and the top-level package ceiling is raised 40 → 45 on both architectures (fontconfig contributes two `dummy-fc-dir*` integration packages the count includes; the portable-profiles check already treats those as known integration noise). Measured x86_64 impact: 37 → 41 top-level packages, 2,376,988,648 → 2,430,232,848 NAR bytes (+~51 MiB, ceiling 2,617,245,696), 406 → 409 store paths (ceiling 450).
- `docs/package-ownership.md`, `docs/tui-verification.md`: ownership bullet, refreshed closure figures, and packaging notes.

Verification (local, x86_64-linux):
- `nix build .#checks.x86_64-linux.agent-tools-terminal-viewing` — passes (renders the PNG in the sandbox).
- `nix build` of `package-ownership`, `system-boundary`, `server-profile`, `portable-profiles`, `home-evaluation`, `nixfmt`, `docs-links` — all pass.
- `nix flake check --no-build --all-systems` — all three platforms evaluate cleanly.
