### PR TITLE
docs: describe the docs-only CI fast path and ci-gate

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -383,4 +383,10 @@ fails the build instead of silently misrouting models.
 
 GitHub Actions runs the flake checks natively on x86_64 and aarch64 Linux and
 aarch64 macOS; platform-independent lints (docs-links, nixfmt, go-fmt) are
-emitted on x86_64-linux only to avoid duplicate work (#169).
+emitted on x86_64-linux only to avoid duplicate work (#169). Changes confined
+to `docs/**` and `README.md` skip the platform matrix entirely and run only
+the docs-links check; the sole required status check is the always-reporting
+`ci-gate` job, so a skipped matrix can never leave a pull request stuck on a
+missing check. Any other Markdown file counts as code because it can be a
+derivation input (deployed `agents/skills`, omp rules, the managed Claude
+policy).


### PR DESCRIPTION
Part of #169 — proof PR 1/3 for the docs fast path: touches only `docs/**`, so the platform matrix must skip, `docs-links` must run, and `ci-gate` (now the sole required check) must report green and unblock the merge.