### PR TITLE
ci: red proof — deliberately broken docs link (do not merge)

### DIFF
--- a/docs/red-proof-scratch.md
+++ b/docs/red-proof-scratch.md
@@ -1,0 +1,3 @@
+# Red proof
+
+This file exists only to prove the CI gate blocks a red run: [broken link](./does-not-exist.md).


### PR DESCRIPTION
Part of #169 — proof PR 3/3: docs-only change with a deliberately broken Markdown link. Expected: matrix skipped, docs-links FAILS, ci-gate FAILS, merge BLOCKED by the ruleset. Will be closed unmerged once the block is confirmed.