### PR TITLE
ci: record the ci-gate ruleset flip in the gate comment

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -130,10 +130,12 @@ jobs:
       - name: Check documentation links
         run: nix build .#checks.x86_64-linux.docs-links --show-trace
 
-  # Sole required status check (#169). Always reports, so a path-skipped
-  # matrix can never leave a pull request stuck on a missing check. Passes
-  # only when classification succeeded, nothing failed or was cancelled, and
-  # at least one real verification (matrix or docs-links) ran.
+  # Sole required status check (#169): the protect-main ruleset requires the
+  # `ci-gate` context (flipped from the three platform names on 2026-07-15).
+  # Always reports, so a path-skipped matrix can never leave a pull request
+  # stuck on a missing check. Passes only when classification succeeded,
+  # nothing failed or was cancelled, and at least one real verification
+  # (matrix or docs-links) ran.
   ci-gate:
     name: ci-gate
     needs: [changes, check, docs-links]


### PR DESCRIPTION
Part of #169 — proof PR 2/3 (code path after the ruleset flip): touches `.github/**`, so it classifies as code. Expected: full matrix runs, docs-links skipped, ci-gate green, and the merge is unblocked by ci-gate alone (the three platform contexts are no longer required).