### PR TITLE
ci: guard the docs-only fast path against derivation drift

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -106,15 +106,19 @@ jobs:
       - name: Check flake
         run: nix flake check --show-trace
 
-  # Docs-only fast path: Markdown is not fully inert — links are linted — so
-  # run just the docs-links check when the matrix is skipped. No store cache:
-  # the check only needs python3 from the binary cache.
+  # Docs-only fast path: Markdown is not fully inert — links are linted and
+  # docs can leak production facts — so build the two intentional whole-tree
+  # lints when the matrix is skipped, then guard the fast-path invariant
+  # itself: instantiate every check on every platform at base and head
+  # (evaluation-only, no builds) and fail if the docs change altered any
+  # other derivation. No store cache: the lints only need python3 from the
+  # binary cache, and the guard never builds.
   docs-links:
     name: docs-links
     needs: changes
     if: needs.changes.outputs.code == 'false'
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -127,8 +131,15 @@ jobs:
           nix_conf: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check documentation links
-        run: nix build .#checks.x86_64-linux.docs-links --show-trace
+      - name: Check documentation links and production facts
+        run: nix build .#checks.x86_64-linux.docs-links .#checks.x86_64-linux.production-facts --show-trace
+
+      - name: Guard the fast-path dependency invariant
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --quiet --depth=1 origin "$BASE_SHA"
+          ./scripts/docs-drift-guard.sh "$BASE_SHA" "$(git rev-parse HEAD)"
 
   # Sole required status check (#169): the protect-main ruleset requires the
   # `ci-gate` context (flipped from the three platform names on 2026-07-15).

--- a/checks/docs-drift-guard.nix
+++ b/checks/docs-drift-guard.nix
@@ -1,0 +1,61 @@
+{ pkgs }:
+
+# Regression tests for the comparison logic of scripts/docs-drift-guard.sh
+# (the docs-only CI fast path invariant, #169). The eval mode needs a git
+# repository and network for flake inputs, so only the pure --compare mode
+# is testable in the sandbox; the eval mode is exercised by the docs-links
+# CI job on every docs-only pull request.
+pkgs.runCommand "check-docs-drift-guard"
+  {
+    nativeBuildInputs = [ pkgs.jq ];
+    guard = ../scripts/docs-drift-guard.sh;
+  }
+  ''
+    write() { printf '%s' "$2" > "$1"; }
+
+    base='{
+      "x86_64-linux": {"docs-links": "/nix/store/aaa-docs-links.drv", "production-facts": "/nix/store/aab-production-facts.drv", "agent-tools": "/nix/store/bbb-agent-tools.drv"},
+      "aarch64-linux": {"agent-tools": "/nix/store/ccc-agent-tools.drv"},
+      "aarch64-darwin": {"darwin-evaluation": "/nix/store/ddd-darwin.drv"}
+    }'
+    write base.json "$base"
+
+    expect_pass() {
+      bash "$guard" --compare base.json "$1" \
+        || { echo "FAIL: expected pass for $1"; exit 1; }
+    }
+    expect_fail() {
+      local report
+      if report="$(bash "$guard" --compare base.json "$1" 2>&1)"; then
+        echo "FAIL: expected drift failure for $1"; exit 1
+      fi
+      echo "$report" | grep -qF "$2" \
+        || { echo "FAIL: drift report for $1 missing '$2': $report"; exit 1; }
+    }
+
+    # Identical snapshots: clean.
+    write identical.json "$base"
+    expect_pass identical.json
+
+    # Only the intentional whole-tree lints drift (docs-links and
+    # production-facts scan documentation on purpose): clean.
+    write lints-only.json "$(jq '.["x86_64-linux"]["docs-links"] = "/nix/store/zzz-docs-links.drv"
+      | .["x86_64-linux"]["production-facts"] = "/nix/store/zzz-production-facts.drv"' <<< "$base")"
+    expect_pass lints-only.json
+
+    # A non-docs derivation drifts on the lint platform: blocked.
+    write x86-drift.json "$(jq '.["x86_64-linux"]["agent-tools"] = "/nix/store/zzz-agent-tools.drv"' <<< "$base")"
+    expect_fail x86-drift.json "x86_64-linux.agent-tools"
+
+    # Drift on a platform whose matrix leg would be skipped: blocked.
+    write darwin-drift.json "$(jq '.["aarch64-darwin"]["darwin-evaluation"] = "/nix/store/zzz-darwin.drv"' <<< "$base")"
+    expect_fail darwin-drift.json "aarch64-darwin.darwin-evaluation"
+
+    # A check appearing or disappearing is drift too.
+    write added-check.json "$(jq '.["aarch64-linux"]["new-check"] = "/nix/store/eee-new.drv"' <<< "$base")"
+    expect_fail added-check.json "aarch64-linux.new-check"
+    write removed-check.json "$(jq 'del(.["aarch64-linux"]["agent-tools"])' <<< "$base")"
+    expect_fail removed-check.json "aarch64-linux.agent-tools"
+
+    mkdir "$out"
+  ''

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -382,11 +382,19 @@ still exists in that unpacked set, so an upstream agent rename or removal
 fails the build instead of silently misrouting models.
 
 GitHub Actions runs the flake checks natively on x86_64 and aarch64 Linux and
-aarch64 macOS; platform-independent lints (docs-links, nixfmt, go-fmt) are
-emitted on x86_64-linux only to avoid duplicate work (#169). Changes confined
-to `docs/**` and `README.md` skip the platform matrix entirely and run only
-the docs-links check; the sole required status check is the always-reporting
-`ci-gate` job, so a skipped matrix can never leave a pull request stuck on a
-missing check. Any other Markdown file counts as code because it can be a
-derivation input (deployed `agents/skills`, omp rules, the managed Claude
-policy).
+aarch64 macOS; platform-independent lints (docs-links, production-facts,
+nixfmt, go-fmt) are emitted on x86_64-linux only to avoid duplicate work
+(#169). Changes confined to `docs/**` and `README.md` skip the platform
+matrix entirely and build only the two intentional whole-tree lints —
+docs-links and production-facts, which scan documentation on purpose; the
+sole required status check is the always-reporting `ci-gate` job, so a
+skipped matrix can never leave a pull request stuck on a missing check. Any
+other Markdown file counts as code because it can be a derivation input
+(deployed `agents/skills`, omp rules, the managed Claude policy). The fast
+path guards its own invariant: `scripts/docs-drift-guard.sh` instantiates
+every check on every CI platform at the pull request's base and head
+(evaluation-only, no builds) and fails if the docs change altered any
+derivation other than those two lints — so a `docs/**` path silently
+becoming a derivation input blocks the merge instead of skipping real
+verification. The guard's comparison logic is regression-tested by the
+`docs-drift-guard` flake check.

--- a/flake.nix
+++ b/flake.nix
@@ -595,7 +595,6 @@
           codex-seed = import ./checks/codex-seed.nix { inherit lib pkgs; };
           get-entrypoint = import ./checks/get-sh.nix { inherit pkgs; };
           omp-seed = import ./checks/omp-seed.nix { inherit lib pkgs; };
-          production-facts = import ./checks/production-facts.nix { inherit pkgs; };
           home-evaluation = homeEvaluation;
           host-registry = registryCheck;
           package-ownership = import ./checks/package-ownership.nix {
@@ -618,7 +617,12 @@
           # Platform-independent lints: their output is a pure function of the
           # source tree, so emitting them on every system just re-runs the same
           # work three times in CI. Keep them on one leg only (#169).
+          # docs-links and production-facts scan the whole tree (docs
+          # included); they are the two intentional exceptions the docs-only
+          # fast path builds directly and scripts/docs-drift-guard.sh excludes.
           docs-links = import ./checks/docs-links.nix { inherit lib pkgs; };
+          docs-drift-guard = import ./checks/docs-drift-guard.nix { inherit pkgs; };
+          production-facts = import ./checks/production-facts.nix { inherit pkgs; };
           go-fmt = import ./checks/go-fmt.nix { inherit lib pkgs; };
           nixfmt = import ./checks/nixfmt.nix { inherit lib pkgs; };
         }

--- a/scripts/docs-drift-guard.sh
+++ b/scripts/docs-drift-guard.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Guard the docs-only CI fast path invariant (#169): a change confined to
+# docs/** and README.md must not alter any Nix derivation other than the
+# intentional whole-tree lints (docs-links, production-facts), which scan
+# documentation on purpose and are built directly by the fast path. Any
+# other drift means skipping the platform matrix would silently skip real
+# verification, so the guard fails and ci-gate blocks the merge.
+#
+# The check is evaluation-only: it instantiates every flake check on every
+# CI platform (drvPath, no builds) at the base and head revisions and
+# compares the two maps. A derivation's drvPath hashes its entire source and
+# dependency graph, so indirect dependencies (filesets, imports, deployed
+# files) are covered by construction.
+#
+# Usage:
+#   docs-drift-guard.sh <base-rev> <head-rev>            eval + compare
+#   docs-drift-guard.sh --compare <base.json> <head.json>  compare only
+#
+# Snapshot JSON shape: { "<system>": { "<check>": "<drvPath>", ... }, ... }
+set -euo pipefail
+
+SYSTEMS=(x86_64-linux aarch64-linux aarch64-darwin)
+
+usage() {
+  sed -n 's/^# \{0,1\}//p' "$0" | sed -n '1,19p' >&2
+  exit 2
+}
+
+# Print drifted "<system>.<check>" entries between two snapshot files,
+# ignoring the intentional whole-tree lints (emitted on x86_64-linux only).
+# Exits 0 with no output when clean.
+drift_list() {
+  jq -rn --slurpfile base "$1" --slurpfile head "$2" '
+    def prune:
+      del(.["x86_64-linux"]["docs-links"], .["x86_64-linux"]["production-facts"]);
+    ($base[0] | prune) as $a
+    | ($head[0] | prune) as $b
+    | (($a | keys) + ($b | keys) | unique)[] as $sys
+    | ((($a[$sys] // {}) | keys) + (($b[$sys] // {}) | keys) | unique)[] as $chk
+    | select(($a[$sys][$chk]? // null) != ($b[$sys][$chk]? // null))
+    | "\($sys).\($chk)"
+  '
+}
+
+compare() {
+  local drift
+  drift="$(drift_list "$1" "$2")"
+  if [ -n "$drift" ]; then
+    echo "docs drift guard: documentation changes altered non-docs derivations:" >&2
+    while IFS= read -r entry; do echo "  $entry" >&2; done <<< "$drift"
+    echo "A docs/** or README.md path has become a derivation input; either" >&2
+    echo "move it out of the inert set in .github/workflows/nix.yml (classify" >&2
+    echo "job) or, for a new intentional whole-tree lint, add it to this" >&2
+    echo "script's exclusions and build it in the docs fast path." >&2
+    return 1
+  fi
+  echo "docs drift guard: no derivation drift outside the intentional whole-tree lints"
+}
+
+# Instantiate all checks for all CI systems at a revision. Uses a temporary
+# ref so the nix git fetcher can resolve commits (e.g. a PR base fetched by
+# sha) that no branch points at; shallow clones are supported.
+snapshot() {
+  local rev="$1" outfile="$2" repo sys first=1
+  repo="$(git rev-parse --show-toplevel)"
+  rev="$(git rev-parse "$rev^{commit}")"
+  git update-ref "refs/drift-guard/$rev" "$rev"
+  TEMP_REFS+=("refs/drift-guard/$rev")
+  {
+    printf '{'
+    for sys in "${SYSTEMS[@]}"; do
+      [ "$first" = 1 ] || printf ','
+      first=0
+      printf '"%s":' "$sys"
+      nix eval --json \
+        "git+file://$repo?rev=$rev&shallow=1&allRefs=1#checks.$sys" \
+        --apply 'checks: builtins.mapAttrs (_: drv: drv.drvPath) checks'
+    done
+    printf '}'
+  } > "$outfile"
+}
+
+TEMP_REFS=()
+WORKDIR=""
+cleanup() {
+  local ref
+  for ref in "${TEMP_REFS[@]}"; do
+    git update-ref -d "$ref" || true
+  done
+  [ -n "$WORKDIR" ] && rm -rf "$WORKDIR"
+}
+
+case "${1:-}" in
+--compare)
+  [ $# -eq 3 ] || usage
+  compare "$2" "$3"
+  ;;
+-h | --help | "")
+  usage
+  ;;
+*)
+  [ $# -eq 2 ] || usage
+  trap cleanup EXIT
+  WORKDIR="$(mktemp -d)"
+  echo "docs drift guard: instantiating checks at base $1" >&2
+  snapshot "$1" "$WORKDIR/base.json"
+  echo "docs drift guard: instantiating checks at head $2" >&2
+  snapshot "$2" "$WORKDIR/head.json"
+  compare "$WORKDIR/base.json" "$WORKDIR/head.json"
+  ;;
+esac


### PR DESCRIPTION
Follow-up to #188/#169: the docs fast path now tests its own soundness invariant instead of trusting the path classification.

## What

- **`scripts/docs-drift-guard.sh`**: for a docs-only PR, instantiates every flake check on all three CI platforms (`drvPath` — evaluation-only, no builds) at the PR base and head, and fails if the docs change altered any derivation other than the intentional whole-tree lints. `drvPath` hashes the entire source/dependency graph, so indirect and fileset-broad dependencies are covered by construction, not by grep.
- **`checks/docs-drift-guard.nix`** (x86_64-linux lint leg): regression-tests the comparison logic against fixtures — identical snapshots pass; lint-only drift passes; drift on the lint platform, on a skipped platform, and added/removed checks all fail with the offender named.
- **Workflow**: the `docs-links` job runs the guard after the lints; a drift failure fails the job → `ci-gate` blocks the merge.

## What the guard immediately caught

Running it on the real #189 docs-only pair flagged **`production-facts`** drifting on all three platforms: it greps the whole tree (`repo = ../.`) for leaked IPs/provider identifiers, so docs are *intentionally* its input — meaning the fast path was skipping a check that docs changes must run. Fixed at the source:

- `production-facts` moved to the x86_64-linux-only lint block (platform-independent; the drift was identical on all three systems).
- The docs fast path now **builds** both whole-tree lints (`docs-links`, `production-facts`) — a doc leaking an IP fails a docs-only PR.
- The guard excludes exactly those two; anything else drifting is a hard failure with remediation instructions.

(No leak slipped through the #189 window: #191's full matrix ran on the post-#189 tree and was green.)

## Verification

- Fixture check: `nix build .#checks.x86_64-linux.docs-drift-guard` green (7 cases).
- End-to-end positive: clean docs-only child commit of this branch → guard passes (~2m43s).
- End-to-end negative: scratch commit making a check consume `docs/agent-tools.md`, then editing that file → guard fails naming `x86_64-linux.scratch-docs-consumer` (~2m46s).
- `nix eval` confirms `production-facts` present only on x86_64-linux.
- actionlint, shellcheck, nixfmt clean.

## Tradeoffs / limits

- **Cost**: ~3 min of pure evaluation on one Linux runner per docs-only PR (6 instantiations: 3 systems × base+head). Still far below the 3-runner matrix incl. the 10×-billed darwin leg. Job timeout raised 15→30 min for slower runners.
- **Scope**: the guard covers `checks.*` — what CI actually builds. A docs path consumed only by a non-check output (a package no check references) would not be flagged; no such case exists today, and `nix flake check`'s build surface is exactly `checks`.
- **Lazy enforcement**: a *code* PR that introduces a docs-consuming derivation is not flagged at introduction time (matrix runs there anyway, nothing is skipped); the guard fires on the first docs-only PR that would actually be unsound, which is the moment that matters.
- **First-parent layout changes**: the guard compares base↔head of the same PR, so check-set refactors (like this PR's production-facts move) never false-positive future docs PRs.