### PR TITLE
docs: note the drift guard's evaluation cost

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -397,4 +397,6 @@ every check on every CI platform at the pull request's base and head
 derivation other than those two lints — so a `docs/**` path silently
 becoming a derivation input blocks the merge instead of skipping real
 verification. The guard's comparison logic is regression-tested by the
-`docs-drift-guard` flake check.
+`docs-drift-guard` flake check, and it adds roughly three minutes of pure
+evaluation to a docs-only pull request (six instantiations: three systems
+at base and head).


### PR DESCRIPTION
Part of the #192 rollout — docs-only PR that live-exercises the drift guard's CI path for the first time (base-sha fetch + shallow git+file evaluation on the runner). Expected: matrix skipped, docs-links job (lints + guard) green, ci-gate green.