### PR TITLE
code-tui: make responsive layouts live

### DIFF
--- a/pkgs/cli-kit/promptbox_test.go
+++ b/pkgs/cli-kit/promptbox_test.go
@@ -120,16 +120,29 @@ func TestHostMountsBoxForAskable(t *testing.T) {
 	}
 }
 
-type resizeApp struct{ width, height int }
+type resizeApp struct {
+	width, height int
+	resizes       []tea.WindowSizeMsg
+}
 
 func (resizeApp) Init() tea.Cmd { return nil }
 func (a resizeApp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if size, ok := msg.(tea.WindowSizeMsg); ok {
 		a.width, a.height = size.Width, size.Height
+		a.resizes = append(a.resizes, size)
 	}
 	return a, nil
 }
 func (resizeApp) View() string { return "" }
+
+type resizeAskableApp struct{ resizeApp }
+
+func (resizeAskableApp) Asker() Asker { return stubAsker{} }
+func (a resizeAskableApp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	next, cmd := a.resizeApp.Update(msg)
+	a.resizeApp = next.(resizeApp)
+	return a, cmd
+}
 
 func TestHostForwardsResizeToBareApp(t *testing.T) {
 	h := newHost(resizeApp{})
@@ -137,6 +150,69 @@ func TestHostForwardsResizeToBareApp(t *testing.T) {
 	got := next.(host).app.(resizeApp)
 	if got.width != 72 || got.height != 26 {
 		t.Fatalf("bare app size = %dx%d, want 72x26", got.width, got.height)
+	}
+}
+
+func TestHostForwardsEffectiveResizeWithPromptBoxInactive(t *testing.T) {
+	h := newHost(resizeAskableApp{})
+
+	for _, size := range []tea.WindowSizeMsg{
+		{Width: 72, Height: 26},
+		{Width: 80, Height: 26}, // width only
+		{Width: 80, Height: 26}, // unchanged
+		{Width: 80, Height: 30}, // height only
+		{Width: 80, Height: 30}, // unchanged
+	} {
+		next, _ := h.Update(size)
+		h = next.(host)
+	}
+
+	got := h.app.(resizeAskableApp).resizes
+	want := []tea.WindowSizeMsg{
+		{Width: 72, Height: 26},
+		{Width: 80, Height: 26},
+		{Width: 80, Height: 30},
+	}
+	assertResizeHistory(t, got, want)
+}
+
+func TestHostForwardsEffectiveResizeWithPromptBoxActive(t *testing.T) {
+	h := newHost(resizeAskableApp{})
+	next, _ := h.Update(tea.WindowSizeMsg{Width: 72, Height: 26})
+	h = next.(host)
+	next, _ = h.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	h = next.(host)
+
+	activeHeight := h.appH
+	for _, size := range []tea.WindowSizeMsg{
+		{Width: 80, Height: 26}, // width only
+		{Width: 80, Height: 26}, // unchanged
+		{Width: 80, Height: 30}, // height only
+		{Width: 80, Height: 30}, // unchanged
+	} {
+		next, _ = h.Update(size)
+		h = next.(host)
+	}
+
+	got := h.app.(resizeAskableApp).resizes
+	want := []tea.WindowSizeMsg{
+		{Width: 72, Height: 26},
+		{Width: 72, Height: activeHeight},
+		{Width: 80, Height: activeHeight},
+		{Width: 80, Height: activeHeight + 4},
+	}
+	assertResizeHistory(t, got, want)
+}
+
+func assertResizeHistory(t *testing.T, got, want []tea.WindowSizeMsg) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("resize history length = %d (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("resize[%d] = %+v, want %+v", i, got[i], want[i])
+		}
 	}
 }
 

--- a/pkgs/cli-kit/run.go
+++ b/pkgs/cli-kit/run.go
@@ -65,11 +65,12 @@ type host struct {
 	altScreen bool
 	mouse     bool
 	w, h      int
-	appH      int // height last handed to the app (see reflow); -1 until set
+	appW      int // width last handed to a capability app (see reflow); -1 until set
+	appH      int // height last handed to a capability app (see reflow); -1 until set
 }
 
 func newHost(app App) host {
-	h := host{app: app, toggleKey: "ctrl+o", appH: -1}
+	h := host{app: app, toggleKey: "ctrl+o", appW: -1, appH: -1}
 	askable, isAsk := app.(Askable)
 	commandable, isCmd := app.(Commandable)
 	if isAsk || isCmd {
@@ -167,9 +168,9 @@ func (h host) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return h, tea.Batch(cmd, h.reflow())
 }
 
-// reflow resizes the app to the rows left over above the box, sending it a
-// WindowSizeMsg only when that height actually changes so the app reflows in
-// place. When the box is closed the app gets the full height back.
+// reflow resizes the app to the space left over above the box, sending it a
+// WindowSizeMsg whenever either effective dimension changes. When the box is
+// closed the app gets the full height back.
 func (h *host) reflow() tea.Cmd {
 	if !h.hasBox || h.h == 0 {
 		return nil
@@ -180,10 +181,10 @@ func (h *host) reflow() tea.Cmd {
 			target = 0
 		}
 	}
-	if target == h.appH {
+	if h.w == h.appW && target == h.appH {
 		return nil
 	}
-	h.appH = target
+	h.appW, h.appH = h.w, target
 	var cmd tea.Cmd
 	h.app, cmd = h.app.Update(tea.WindowSizeMsg{Width: h.w, Height: target})
 	return cmd

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -844,13 +844,27 @@ func (m model) genConfigYAML() string {
 // ── model ────────────────────────────────────────────────────────────────────
 // layout modes, chosen from the terminal size (unless the user collapses):
 //
-//	split     — wide:            the focused list on the left, preview on the right
-//	stacked   — narrow but tall: list on top, preview stacked below it (full width)
-//	collapsed — narrow+short/‹p›: one full-width pane (list, or result w/ showResult)
+//	split     — wide:   the focused list on the left, routing preview on the
+//	            right, and Usage spanning the full bottom width
+//	medium    — generator-dominant: the list full width on top (primary), then
+//	            Routing and Usage side by side in a secondary row, with Usage's
+//	            provider groups stacked vertically inside its narrower column
+//	collapsed — narrow/short or ‹p›: one full-width panel at a time (list, or
+//	            routing w/ showResult) — the Generator stays usable instead of
+//	            compressing every section into an unreadable split
 const (
 	modeSplit = iota
-	modeStacked
+	modeMedium
 	modeCollapsed
+)
+
+// size classes behind mode(): derived from terminal cells and the measured
+// rendered minima of each section (#197) — never from pixels or a hard-coded
+// screenshot width.
+const (
+	sizeWide = iota
+	sizeMedium
+	sizeNarrow
 )
 
 // gut is the left gutter every panel shares, so the whole UI hangs off one
@@ -863,7 +877,20 @@ const (
 	headRows = 2
 	// the launch footer pinned under the list: blank + cost + speed + ⏎ launch.
 	launchFooterRows = 4
+	// routingMinW is the narrowest useful routing column: pane chrome plus room
+	// for a lead chain — below this a side-by-side routing panel stops earning
+	// its keep.
+	routingMinW = 33
+	// genMinRows is the fewest facet rows the generator list may be windowed to
+	// before the layout must shed secondary sections instead of compressing it.
+	genMinRows = 4
+	// minRouteRows is the fewest routing viewport rows worth pinning chrome around.
+	minRouteRows = 4
 )
+
+// genColMinH is the generator column's minimum useful height: the pinned head,
+// a windowed-but-usable slice of the facet list, and the pinned launch footer.
+const genColMinH = headRows + genMinRows + launchFooterRows
 
 // genRowWidth is the width needed to render the widest generator facet row (all
 // options) on a single line — the minimum for the left panel.
@@ -881,20 +908,63 @@ func (m model) genRowWidth() int {
 	return max + 2
 }
 
+// sizeMode classifies the terminal into the wide / medium / narrow-short
+// responsive classes. Widths compare against the measured generator row,
+// routing, and usage-column minima; heights against the chrome each composition
+// pins on screen — breakpoints track content needs, not screenshot numbers.
+func (m model) sizeMode() int {
+	if m.w >= m.genRowWidth()+routingMinW && m.h >= m.wideMinH() {
+		return sizeWide
+	}
+	if m.w >= m.mediumMinW() && m.h >= m.mediumMinH() {
+		return sizeMedium
+	}
+	return sizeNarrow
+}
+
 func (m model) mode() int {
 	if m.collapse {
 		return modeCollapsed
 	}
-	if m.w >= m.genRowWidth()+33 { // room for the list + a useful side preview
+	switch m.sizeMode() {
+	case sizeWide:
 		return modeSplit
+	case sizeMedium:
+		return modeMedium
+	default:
+		return modeCollapsed
 	}
-	// too narrow for side-by-side; stack the preview below the list if the
-	// terminal is tall enough to give the list, footer, and preview (with its
-	// pill head + fallback hint) a usable share, else collapse.
-	if m.bodyH() >= 19 {
-		return modeStacked
+}
+
+// wideMinH is the least height at which the wide composition stays readable:
+// a usable generator column above the full-width Usage footer. Shorter than
+// this, keeping every section visible would compress them all — shed instead.
+func (m model) wideMinH() int {
+	return topGap + genColMinH + m.footerH(true)
+}
+
+// mediumMinH stacks the generator over the secondary Routing+Usage row (at its
+// measured minimum) with Usage out of the footer.
+func (m model) mediumMinH() int {
+	return topGap + genColMinH + 1 + m.secondaryMinH() + m.footerH(false)
+}
+
+// mediumMinW: the secondary row must seat a useful routing viewport beside the
+// measured usage column without clipping either.
+func (m model) mediumMinW() int {
+	return routingMinW + m.usageColW()
+}
+
+// footerH measures the pinned footer for a composition directly from its parts
+// — mode selection depends on it, so it must not consult the mode itself.
+func (m model) footerH(withUsage bool) int {
+	h := 1 + lipgloss.Height("  "+m.help.View(keys))
+	if withUsage {
+		if p := m.usagePanel(); p != "" {
+			h += 1 + lipgloss.Height(p)
+		}
 	}
-	return modeCollapsed
+	return h
 }
 
 // bodyH is the height available above the pinned footer.
@@ -939,25 +1009,16 @@ func (m model) launchFooter() []string {
 	}
 }
 
-// stackedSplit divides the inner body height (minus the section head and the
-// 1-line divider) between the list and the preview: the list takes what its
-// content needs, capped at ~60% and floored so the preview keeps ≥ minPrev rows.
-func stackedSplit(bodyH, bodyLen int) (listH, prevH int) {
-	const sep, minPrev, minList = 1, 8, 3 // minPrev covers the preview chrome + ≥4 route rows
-	inner := bodyH - headRows - launchFooterRows - sep
-	listH = bodyLen
-	if c := inner * 3 / 5; listH > c {
-		listH = c
-	}
-	if listH > inner-minPrev {
-		listH = inner - minPrev
-	}
-	if listH < minList {
-		listH = minList
-	}
-	prevH = inner - listH
-	if prevH < minPrev {
-		prevH = minPrev
+// mediumSplit gives the Routing+Usage row only its measured minimum, then lets
+// the primary Generator absorb every remaining row. The medium height threshold
+// guarantees both sections fit; taller terminals therefore expand Generator
+// instead of leaving slack below the compact secondary content.
+func (m model) mediumSplit(bodyH int) (genH, secH int) {
+	secH = m.secondaryMinH()
+	genH = bodyH - 1 - secH
+	if genH < genColMinH {
+		genH = genColMinH
+		secH = bodyH - 1 - genH
 	}
 	return
 }
@@ -971,14 +1032,74 @@ func (m model) previewDims() (int, int) {
 	switch m.mode() {
 	case modeCollapsed:
 		return m.w - gut, bodyH - prevChromeRows
-	case modeStacked:
-		body, _ := m.bodyLines()
-		_, ph := stackedSplit(bodyH, len(body))
-		return m.w - gut, ph - prevChromeRows
+	case modeMedium:
+		_, secH := m.mediumSplit(bodyH)
+		return m.routingColW() - gut, secH - prevChromeRows
 	default: // split — the pane draws a border + prevPadL inside its width, so the
 		// viewport (what renderRoute wraps to) gets the inner text area, not the box.
 		return m.w - m.listW() - 3 - prevPadL, bodyH - prevChromeRows
 	}
+}
+
+// routingColW is the medium secondary row's routing share: whatever the
+// measured usage column leaves free.
+func (m model) routingColW() int {
+	w := m.w - m.usageColW()
+	if w < routingMinW {
+		w = routingMinW
+	}
+	return w
+}
+
+// ── trackpad / mouse wheel ───────────────────────────────────────────────────
+// The wheel drives the generator directly: vertical scroll moves the facet
+// selection, horizontal scroll changes the selected facet's value. Terminals
+// (and SSH) offer no haptic channel, so the "detent" is temporal: a wheelGate
+// axis-locks each gesture and rations steps, letting a trackpad fling or
+// diagonal jitter advance at most one controlled step while a single detented
+// wheel click still acts immediately.
+const (
+	wheelAxisNone = iota
+	wheelAxisV
+	wheelAxisH
+)
+
+// wheelIdle is the longest gap between wheel events that still reads as one
+// continuous gesture — a pause beyond it starts a fresh (immediate) step.
+// wheelRepeat rations further steps inside a held gesture, so a deliberate
+// continuous scroll advances at a controlled cadence instead of per event.
+const (
+	wheelIdle   = 200 * time.Millisecond
+	wheelRepeat = 300 * time.Millisecond
+)
+
+// wheelGate arbitrates raw wheel events into discrete facet steps.
+type wheelGate struct {
+	axis   int       // locked gesture axis (wheelAxisNone when idle)
+	last   time.Time // last event seen — orthogonal jitter keeps the lock alive
+	stepAt time.Time // last event that was allowed to act
+}
+
+// admit reports whether a wheel event on axis a at time t may act. The first
+// event after an idle pause acts immediately and locks the gesture to its
+// axis; while locked, orthogonal events are swallowed (diagonal jitter) and
+// same-axis events act only every wheelRepeat (burst resistance).
+func (g *wheelGate) admit(a int, t time.Time) bool {
+	fresh := g.axis == wheelAxisNone || t.Sub(g.last) > wheelIdle
+	g.last = t
+	if fresh {
+		g.axis = a
+		g.stepAt = t
+		return true
+	}
+	if a != g.axis {
+		return false
+	}
+	if t.Sub(g.stepAt) >= wheelRepeat {
+		g.stepAt = t
+		return true
+	}
+	return false
 }
 
 type model struct {
@@ -995,6 +1116,8 @@ type model struct {
 	facets []facet
 	fcur   int
 	sel    map[string]string
+
+	wheel wheelGate // trackpad/mouse wheel arbiter: axis lock + step resistance
 
 	vp       viewport.Model
 	spin     spinner.Model
@@ -1147,7 +1270,14 @@ func (m *model) authLine() string {
 	return line
 }
 
-func (m *model) usagePanel() string {
+// usagePanel is the composition-agnostic Usage band sized for the current
+// terminal width — the wide layout's full-width footer form.
+func (m *model) usagePanel() string { return m.usagePanelFor(m.w) }
+
+// usagePanelFor renders auth + refresh + provider usage, laying provider groups
+// side by side only when w seats every column; w <= 0 forces the vertical stack
+// (the medium layout's narrow usage column).
+func (m *model) usagePanelFor(w int) string {
 	auth := m.authLine()
 	if !m.avail.ok {
 		if m.usageCmd == "" {
@@ -1209,7 +1339,7 @@ func (m *model) usagePanel() string {
 	// side-by-side when there's horizontal room, else stacked. colW must fit the
 	// widest row (label · bar · pct · ↻reset · note) without wrapping the note.
 	const colW = 49
-	if len(order) > 1 && m.w >= colW*len(order) {
+	if w > 0 && len(order) > 1 && w >= colW*len(order) {
 		var cols []string
 		for _, p := range order {
 			cols = append(cols, lipgloss.NewStyle().Width(colW).Render(strings.Join(blocks[p], "\n")))
@@ -1224,6 +1354,30 @@ func (m *model) usagePanel() string {
 		lines = append(lines, blocks[p]...)
 	}
 	return auth + "\n" + m.refreshLine() + "\n" + strings.Join(lines, "\n")
+}
+
+// usageColumn is the medium layout's right-hand Usage section: a pinned pill
+// head over the usage panel with provider groups forced into a vertical stack —
+// the column is deliberately too narrow for side-by-side groups.
+func (m model) usageColumn() string {
+	return padLeft(m.pill("usage"), gut) + "\n\n" + m.usagePanelFor(0)
+}
+
+// usageColW is the medium usage column's measured width: the widest rendered
+// line of the stacked panel (auth, refresh, bars, notes) — measured, not guessed.
+func (m model) usageColW() int {
+	return lipgloss.Width(m.usageColumn())
+}
+
+// secondaryMinH is the medium secondary row's minimum height: routing's pinned
+// chrome plus a few useful route rows, or the full stacked usage column when
+// that is taller — medium only engages when neither column needs clipping.
+func (m model) secondaryMinH() int {
+	h := prevChromeRows + minRouteRows
+	if u := lipgloss.Height(m.usageColumn()); u > h {
+		h = u
+	}
+	return h
 }
 
 func (m *model) usageRow(w usageWin) string {
@@ -1282,7 +1436,20 @@ func fmtDays(s int64) string {
 	return fmt.Sprintf("%dd", (s+86399)/86400)
 }
 
+// syncPreview re-renders the routing content and jumps back to the top — for
+// content changes (facet cycling, depth, reset), where the old scroll offset
+// points at rows that no longer exist.
 func (m *model) syncPreview() {
+	m.syncPreviewAt(0)
+}
+
+// syncPreviewKeepScroll re-renders while preserving the scroll position where
+// still valid — resizes and background usage refreshes must never yank the view.
+func (m *model) syncPreviewKeepScroll() {
+	m.syncPreviewAt(m.vp.YOffset)
+}
+
+func (m *model) syncPreviewAt(yoff int) {
 	if !m.rdy || m.collapse {
 		return
 	}
@@ -1302,19 +1469,38 @@ func (m *model) syncPreview() {
 	// clip (don't wrap) to pane width — renderRoute already wrapped the chains.
 	content := lipgloss.NewStyle().MaxWidth(m.vp.Width).Render(b.String())
 	m.vp.SetContent(content)
-	m.vp.GotoTop()
+	m.vp.SetYOffset(yoff) // clamps into the new content and viewport height
 }
 
-// footer is the pinned bottom block: the usage panel (if any) then the controls
-// help, each under a rule. Built once here so relayout and View stay in sync.
+// footer is the pinned bottom block: the usage panel (when this composition
+// keeps Usage in the footer) then the controls help, each under a rule. Built
+// once here so relayout and View stay in sync.
 func (m *model) footer() string {
 	rule := stDim.Render(strings.Repeat("─", m.w))
 	var parts []string
-	if p := m.usagePanel(); p != "" {
-		parts = append(parts, rule, p)
+	if m.usageInFooter() {
+		if p := m.usagePanel(); p != "" {
+			parts = append(parts, rule, p)
+		}
 	}
 	parts = append(parts, rule, "  "+m.help.View(keys))
 	return strings.Join(parts, "\n")
+}
+
+// usageInFooter says where Usage lives: the wide layout keeps it as the
+// full-width bottom band; medium moves it into the secondary column (back to
+// the footer while ‹p› hides that row); narrow/short hides it entirely so the
+// Generator stays usable first — fetch state and the refresh cadence keep
+// running unseen, and nothing is refetched when it reappears.
+func (m *model) usageInFooter() bool {
+	switch m.sizeMode() {
+	case sizeWide:
+		return true
+	case sizeMedium:
+		return m.collapse
+	default:
+		return false
+	}
 }
 
 func (m *model) relayout() {
@@ -1332,7 +1518,7 @@ func (m *model) relayout() {
 	} else {
 		m.vp.Width, m.vp.Height = pw, ph
 	}
-	m.syncPreview()
+	m.syncPreviewKeepScroll()
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -1361,6 +1547,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			var cmd tea.Cmd
 			m.spin, cmd = m.spin.Update(msg)
 			return m, cmd
+		}
+	case tea.MouseMsg:
+		// Wheel → generator control (see wheelGate). The routing preview keeps
+		// its keyboard scrolling; wheel input deliberately owns facet steps.
+		if msg.Action == tea.MouseActionPress {
+			m.wheelStep(msg.Button, time.Now())
 		}
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -1460,6 +1652,31 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+// wheelStep translates an admitted wheel event into the matching facet action:
+// vertical scroll moves the selection, horizontal scroll changes the value.
+// Facet semantics stay untouched — these are the exact arrow-key handlers,
+// merely rationed by the wheelGate.
+func (m *model) wheelStep(b tea.MouseButton, t time.Time) {
+	switch b {
+	case tea.MouseButtonWheelUp:
+		if m.wheel.admit(wheelAxisV, t) {
+			m.moveUp()
+		}
+	case tea.MouseButtonWheelDown:
+		if m.wheel.admit(wheelAxisV, t) {
+			m.moveDown()
+		}
+	case tea.MouseButtonWheelLeft:
+		if m.wheel.admit(wheelAxisH, t) {
+			m.cycleFacet(-1)
+		}
+	case tea.MouseButtonWheelRight:
+		if m.wheel.admit(wheelAxisH, t) {
+			m.cycleFacet(1)
+		}
+	}
 }
 
 func (m *model) moveUp() {
@@ -1572,16 +1789,22 @@ func (m model) leftColumn(w, totalH int) string {
 	return m.sectionHead() + list + "\n" + footer
 }
 
-// stackedContent is the narrow-but-tall layout: head + list on top, a full-width
-// divider, then the preview stacked below. The preview keeps its own viewport, so
-// it scrolls (mouse wheel) independently of the list above it.
-func (m model) stackedContent(bodyH int) string {
-	body, _ := m.bodyLines()
-	listH, prevH := stackedSplit(bodyH, len(body))
-	top := m.leftColumn(m.w, headRows+listH+launchFooterRows)
+// mediumContent is the generator-dominant layout: the full-width facet list on
+// top (primary), a divider, then Routing and Usage side by side in a secondary
+// row. Routing keeps its own scrolling viewport; Usage stacks its provider
+// groups vertically inside the measured-width right column.
+func (m model) mediumContent(bodyH int) string {
+	genH, secH := m.mediumSplit(bodyH)
+	top := m.leftColumn(m.w, genH)
 	div := stDim.Render(strings.Repeat("─", m.w))
-	preview := lipgloss.NewStyle().MaxHeight(prevH).Render(padLeft(m.previewColumn(), gut))
-	return lipgloss.JoinVertical(lipgloss.Left, top, div, preview)
+	rw := m.routingColW()
+	// clip each column before fixing its width — Width() alone would wrap any
+	// over-wide line onto an extra physical row and break the row's height.
+	routing := lipgloss.NewStyle().Width(rw).MaxHeight(secH).Render(
+		lipgloss.NewStyle().MaxWidth(rw).Render(padLeft(m.previewColumn(), gut)))
+	usage := lipgloss.NewStyle().MaxWidth(m.w - rw).MaxHeight(secH).Render(m.usageColumn())
+	return lipgloss.JoinVertical(lipgloss.Left, top, div,
+		lipgloss.JoinHorizontal(lipgloss.Top, routing, usage))
 }
 
 func (m model) View() string {
@@ -1594,13 +1817,13 @@ func (m model) View() string {
 	var content string
 	switch m.mode() {
 	case modeCollapsed:
-		if m.showResult && m.w < 62 {
+		if m.showResult && !m.collapse {
 			content = padLeft(m.previewColumn(), gut)
 		} else {
 			content = m.leftColumn(m.w, ch)
 		}
-	case modeStacked:
-		content = m.stackedContent(ch)
+	case modeMedium:
+		content = m.mediumContent(ch)
 	default: // split
 		content = lipgloss.JoinHorizontal(lipgloss.Top,
 			m.leftColumn(m.listW(), ch),
@@ -1722,10 +1945,10 @@ func main() {
 		facets:       facetDefs(glyphs),
 		sel:          defaultSel(),
 	}
-	// No mouse capture: with mouse reporting on, the terminal routes every mouse
-	// event (right-click, selection, paste) to the app, breaking native terminal
-	// behaviour. The preview scrolls via pgup/pgdown / ctrl+u/ctrl+d instead.
-	final, err := clikit.Run(m, clikit.WithAltScreen())
+	// Cell-motion mouse reporting feeds the trackpad/wheel facet control (see
+	// wheelGate); it is the narrowest mode that carries wheel events. The
+	// preview still scrolls via pgup/pgdown / ctrl+u/ctrl+d.
+	final, err := clikit.Run(m, clikit.WithAltScreen(), clikit.WithMouseCellMotion())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "code:", err)
 		os.Exit(1)

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -442,5 +447,484 @@ func TestPreviewColumn(t *testing.T) {
 	m.depth = 1
 	if plain := stripAnsi(m.previewColumn()); !strings.Contains(plain, "f · hide fallback chains") {
 		t.Errorf("full-chain depth must flip the cue to hide, got:\n%s", plain)
+	}
+}
+
+// ── responsive layout (#197) ─────────────────────────────────────────────────
+
+// layoutModel builds a fully-populated model the way main() does — real facets,
+// a generated routing block, and usage windows for both providers — so layout
+// tests exercise the actual compositions rather than skeleton fixtures.
+func layoutModel() model {
+	glyphs := defaultGlyphs()
+	id := comboID(defaultSel())
+	rows := []string{
+		"  thinking medium · fallback on · advisor on",
+		"    default    gpt-5.6-terra:medium → gpt-5.6-luna:medium → claude-sonnet-5:medium",
+		"  ● task       gpt-5.6-terra:medium → gpt-5.6-luna:medium → claude-sonnet-5:medium",
+		"  ● scout      gpt-5.6-luna:low → claude-haiku-4-5:low",
+		"    advisor    claude-opus-4-5:high",
+		"    commit     gpt-5.6-luna:minimal",
+	}
+	return model{
+		generated: map[string][]string{id: rows},
+		avail: availability{
+			ok:     true,
+			bucket: map[string]string{},
+			reset:  map[string]int64{},
+			wins: []usageWin{
+				{label: "5 hours", pct: 12, secs: 3 * 3600, dur: 5 * 3600, prov: "openai-codex"},
+				{label: "7 days", pct: 33, secs: 6 * day, dur: 7 * day, prov: "openai-codex"},
+				{label: "5 hours", pct: 55, secs: 2 * 3600, dur: 5 * 3600, prov: "anthropic"},
+				{label: "7 days", pct: 61, secs: 5 * day, dur: 7 * day, prov: "anthropic"},
+			},
+		},
+		usageCmd:     "omp usage --json",
+		authProfiles: []authProfile{{ID: "default", Label: "mine", Claude: "Alex", Codex: "Alex"}},
+		spin:         spinner.New(),
+		help:         help.New(),
+		glyphs:       glyphs,
+		facets:       facetDefs(glyphs),
+		sel:          defaultSel(),
+		nextRefresh:  time.Now().Add(refreshEvery),
+	}
+}
+
+// resize drives a live tea.WindowSizeMsg through Update and asserts the one
+// hard rule of #197 resizing: it must never produce a command (no fetches).
+func resize(t *testing.T, m model, w, h int) model {
+	t.Helper()
+	nm, cmd := m.Update(tea.WindowSizeMsg{Width: w, Height: h})
+	if cmd != nil {
+		t.Fatalf("resize to %dx%d produced a command — resizes must never trigger fetches", w, h)
+	}
+	return nm.(model)
+}
+
+type termSize struct{ w, h int }
+
+// layoutSizes derives representative wide/medium/narrow/short terminal sizes
+// from the model's own measured breakpoints (terminal cells, never pixels), so
+// the tests keep tracking content needs if the rendered minima ever grow.
+func layoutSizes(t *testing.T, m model) (wide, medium, narrow, short termSize) {
+	t.Helper()
+	wideW := m.genRowWidth() + routingMinW
+	if m.mediumMinW()+6 >= wideW {
+		t.Fatalf("fixture drift: medium width %d overlaps the wide threshold %d", m.mediumMinW()+6, wideW)
+	}
+	wide = termSize{wideW + 20, 40}
+	medium = termSize{m.mediumMinW() + 6, 40}
+	narrow = termSize{m.mediumMinW() - 10, 40}
+	short = termSize{wideW + 20, 10}
+	return
+}
+
+// assertLayoutInvariants checks the frame guarantees every composition must
+// hold: no line wider than the terminal (it would auto-wrap), total height in
+// bounds, full-width rules never broken mid-line, and the help footer pinned
+// to the very last row.
+func assertLayoutInvariants(t *testing.T, m model, label string) {
+	t.Helper()
+	view := stripAnsi(m.View())
+	lines := strings.Split(view, "\n")
+	if got := len(lines); got > m.h {
+		t.Errorf("%s: view is %d rows for a %d-row terminal", label, got, m.h)
+	}
+	for i, l := range lines {
+		if w := lipgloss.Width(l); w > m.w {
+			t.Errorf("%s: line %d is %d cells wide (terminal %d) — would auto-wrap: %q", label, i, w, m.w, l)
+		}
+		if strings.HasPrefix(l, "─") { // horizontal rules span exactly the terminal
+			if strings.TrimRight(l, " ") != strings.Repeat("─", m.w) {
+				t.Errorf("%s: rule on line %d does not span the full width: %q", label, i, l)
+			}
+		}
+	}
+	if last := lines[len(lines)-1]; !strings.Contains(last, "move") {
+		t.Errorf("%s: help footer not pinned to the last row: %q", label, last)
+	}
+}
+
+// lineIndex returns the first view line containing every needle, or -1.
+func lineIndex(lines []string, needles ...string) int {
+	for i, l := range lines {
+		ok := true
+		for _, n := range needles {
+			if !strings.Contains(l, n) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestResponsiveCompositions locks the #197 hierarchy: wide keeps Generator and
+// Routing side by side over a full-width Usage band (provider groups side by
+// side); medium is generator-dominant — the list full width on top, Routing and
+// Usage sharing a secondary row, Usage's provider groups stacked vertically;
+// narrow and short show one usable panel at a time, Generator first, instead of
+// compressing every section.
+func TestResponsiveCompositions(t *testing.T) {
+	m := layoutModel()
+	wide, medium, narrow, short := layoutSizes(t, m)
+
+	m = resize(t, m, wide.w, wide.h)
+	if m.mode() != modeSplit {
+		t.Fatalf("wide %dx%d: mode = %d, want split", wide.w, wide.h, m.mode())
+	}
+	lines := strings.Split(stripAnsi(m.View()), "\n")
+	if lineIndex(lines, "generator", "routing") < 0 {
+		t.Errorf("wide: generator and routing pills must share a row:\n%s", strings.Join(lines, "\n"))
+	}
+	sideBySide := false
+	for _, l := range lines {
+		if strings.Count(l, "% used") > 1 {
+			sideBySide = true
+		}
+	}
+	if !sideBySide {
+		t.Errorf("wide: usage provider groups must sit side by side in the bottom band:\n%s", strings.Join(lines, "\n"))
+	}
+	assertLayoutInvariants(t, m, "wide")
+
+	m = resize(t, m, medium.w, medium.h)
+	if m.mode() != modeMedium {
+		t.Fatalf("medium %dx%d: mode = %d, want medium", medium.w, medium.h, m.mode())
+	}
+	lines = strings.Split(stripAnsi(m.View()), "\n")
+	gen := lineIndex(lines, "generator")
+	sec := lineIndex(lines, "routing", "usage")
+	launch := lineIndex(lines, "launch generated profile")
+	if gen < 0 || sec < 0 || launch < 0 {
+		t.Fatalf("medium: missing generator (%d), secondary row (%d), or launch footer (%d):\n%s", gen, sec, launch, strings.Join(lines, "\n"))
+	}
+	if lineIndex(lines, "generator", "routing") >= 0 {
+		t.Errorf("medium: generator must own its full-width row, not share it with routing")
+	}
+	if !(gen < launch && launch < sec) {
+		t.Errorf("medium: want generator (%d) over its launch footer (%d) over the routing+usage row (%d)", gen, launch, sec)
+	}
+	for i, l := range lines {
+		if strings.Count(l, "% used") > 1 {
+			t.Errorf("medium: usage provider groups must stack vertically, found side-by-side row %d: %q", i, l)
+		}
+	}
+	if lineIndex(lines, "% used") < 0 {
+		t.Errorf("medium: usage rows must be visible in the secondary column")
+	}
+	baseGenH, baseSecH := m.mediumSplit(m.contentH())
+	if want := m.secondaryMinH(); baseSecH != want {
+		t.Errorf("medium: secondary row height = %d, want measured minimum %d", baseSecH, want)
+	}
+	tall := resize(t, m, medium.w, medium.h+8)
+	tallGenH, tallSecH := tall.mediumSplit(tall.contentH())
+	if tallSecH != baseSecH {
+		t.Errorf("tall medium: secondary row grew from %d to %d instead of staying content-sized", baseSecH, tallSecH)
+	}
+	if tallGenH != baseGenH+8 {
+		t.Errorf("tall medium: generator grew from %d to %d, want %d", baseGenH, tallGenH, baseGenH+8)
+	}
+	assertLayoutInvariants(t, m, "medium")
+
+	m = resize(t, m, narrow.w, narrow.h)
+	if m.mode() != modeCollapsed {
+		t.Fatalf("narrow %dx%d: mode = %d, want collapsed", narrow.w, narrow.h, m.mode())
+	}
+	lines = strings.Split(stripAnsi(m.View()), "\n")
+	if lineIndex(lines, "generator") < 0 {
+		t.Errorf("narrow: the generator must stay usable")
+	}
+	if lineIndex(lines, "routing") >= 0 || lineIndex(lines, "% used") >= 0 {
+		t.Errorf("narrow: secondary sections must be shed, not compressed:\n%s", strings.Join(lines, "\n"))
+	}
+	assertLayoutInvariants(t, m, "narrow")
+
+	// ‹p› swaps to the routing panel — one full panel at a time.
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	m = nm.(model)
+	lines = strings.Split(stripAnsi(m.View()), "\n")
+	if lineIndex(lines, "routing") < 0 || lineIndex(lines, "generator") >= 0 {
+		t.Errorf("narrow+p: want the routing panel full width instead of the generator:\n%s", strings.Join(lines, "\n"))
+	}
+	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	m = nm.(model)
+
+	m = resize(t, m, short.w, short.h)
+	if m.mode() != modeCollapsed {
+		t.Fatalf("short %dx%d: mode = %d, want collapsed", short.w, short.h, m.mode())
+	}
+	lines = strings.Split(stripAnsi(m.View()), "\n")
+	if lineIndex(lines, "generator") < 0 {
+		t.Errorf("short: the generator must stay usable")
+	}
+	if lineIndex(lines, "% used") >= 0 {
+		t.Errorf("short: the usage band must be shed to preserve generator rows")
+	}
+	assertLayoutInvariants(t, m, "short")
+}
+
+// TestModeThresholdEdges locks the exact measured breakpoints: one cell or row
+// under a threshold flips the composition immediately on the resize itself —
+// no extra keypress, tick, or second message.
+func TestModeThresholdEdges(t *testing.T) {
+	m := layoutModel()
+	wideW := m.genRowWidth() + routingMinW
+
+	m = resize(t, m, wideW, 40)
+	if m.mode() != modeSplit {
+		t.Fatalf("at the wide width threshold: mode = %d, want split", m.mode())
+	}
+	m = resize(t, m, wideW-1, 40)
+	if m.mode() != modeMedium {
+		t.Fatalf("one cell under the wide threshold: mode = %d, want medium", m.mode())
+	}
+	m = resize(t, m, wideW, 40)
+	if m.mode() != modeSplit {
+		t.Fatalf("back across the wide threshold: mode = %d, want split", m.mode())
+	}
+
+	hEdge := m.wideMinH()
+	m = resize(t, m, wideW, hEdge)
+	if m.mode() != modeSplit {
+		t.Fatalf("at the wide height threshold %d: mode = %d, want split", hEdge, m.mode())
+	}
+	m = resize(t, m, wideW, hEdge-1)
+	if m.mode() == modeSplit {
+		t.Fatalf("one row under the wide height threshold %d must leave the split", hEdge)
+	}
+
+	mediumW := m.mediumMinW() + 6
+	m = resize(t, m, mediumW, 40)
+	if m.mode() != modeMedium {
+		t.Fatalf("medium width %d: mode = %d, want medium", mediumW, m.mode())
+	}
+	mEdge := m.mediumMinH()
+	m = resize(t, m, mediumW, mEdge)
+	if m.mode() != modeMedium {
+		t.Fatalf("at the medium height threshold %d: mode = %d, want medium", mEdge, m.mode())
+	}
+	m = resize(t, m, mediumW, mEdge-1)
+	if m.mode() != modeCollapsed {
+		t.Fatalf("one row under the medium height threshold %d: mode = %d, want collapsed", mEdge, m.mode())
+	}
+	m = resize(t, m, m.mediumMinW()-1, 40)
+	if m.mode() != modeCollapsed {
+		t.Fatalf("one cell under the medium width threshold: mode = %d, want collapsed", m.mode())
+	}
+}
+
+// TestRepeatedResizeCrossingsPreserveState resizes back and forth across every
+// threshold repeatedly and asserts the whole interactive state — selection,
+// cursor, depth, collapse, auth, usage fetch identity — rides along untouched,
+// and that the routing viewport offset always stays clamped to valid content.
+func TestRepeatedResizeCrossingsPreserveState(t *testing.T) {
+	m := layoutModel()
+	wide, medium, narrow, short := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+
+	m.fcur = 2
+	m.cycleFacet(1) // thinking: medium → high (facet semantics untouched)
+	m.depth = 1
+	m.syncPreview()
+	wantSel := map[string]string{}
+	for k, v := range m.sel {
+		wantSel[k] = v
+	}
+	wantNext := m.nextRefresh
+
+	steps := []struct {
+		termSize
+		mode int
+	}{
+		{medium, modeMedium},
+		{narrow, modeCollapsed},
+		{short, modeCollapsed},
+		{medium, modeMedium},
+		{wide, modeSplit},
+		{narrow, modeCollapsed},
+		{wide, modeSplit},
+	}
+	for round := range 3 {
+		for _, s := range steps {
+			m = resize(t, m, s.w, s.h)
+			label := fmt.Sprintf("round %d, %dx%d", round, s.w, s.h)
+			if m.mode() != s.mode {
+				t.Fatalf("%s: mode = %d, want %d immediately after the resize", label, m.mode(), s.mode)
+			}
+			if m.fcur != 2 || m.depth != 1 || m.collapse || m.showResult {
+				t.Fatalf("%s: cursor/depth/collapse state mutated: fcur=%d depth=%d collapse=%v showResult=%v", label, m.fcur, m.depth, m.collapse, m.showResult)
+			}
+			if !reflect.DeepEqual(m.sel, wantSel) {
+				t.Fatalf("%s: facet selection mutated: %v", label, m.sel)
+			}
+			if m.fetching || !m.nextRefresh.Equal(wantNext) {
+				t.Fatalf("%s: usage fetch state mutated: fetching=%v nextRefresh moved=%v", label, m.fetching, !m.nextRefresh.Equal(wantNext))
+			}
+			if m.authIdx != 0 {
+				t.Fatalf("%s: auth profile mutated: %d", label, m.authIdx)
+			}
+			maxOff := m.vp.TotalLineCount() - m.vp.Height
+			if maxOff < 0 {
+				maxOff = 0
+			}
+			if m.vp.YOffset < 0 || m.vp.YOffset > maxOff {
+				t.Fatalf("%s: viewport offset %d outside [0,%d]", label, m.vp.YOffset, maxOff)
+			}
+			assertLayoutInvariants(t, m, label)
+		}
+	}
+}
+
+// TestResizeScrollClamp: a scrolled routing viewport keeps its offset across a
+// width-only resize, and clamps (never dangles past the content) when a resize
+// shrinks the panel; a facet change still resets to the top.
+func TestResizeScrollClamp(t *testing.T) {
+	m := layoutModel()
+	id := comboID(defaultSel())
+	rows := []string{"  thinking medium · fallback on · advisor on"}
+	for i := range 40 {
+		rows = append(rows, fmt.Sprintf("    role%02d     gpt-5.6-terra:medium", i))
+	}
+	m.generated[id] = rows
+	wide, medium, narrow, _ := layoutSizes(t, m)
+
+	m = resize(t, m, wide.w, wide.h)
+	if m.vp.TotalLineCount() <= m.vp.Height {
+		t.Fatalf("fixture: routing content (%d lines) must overflow the viewport (%d rows)", m.vp.TotalLineCount(), m.vp.Height)
+	}
+	m.vp.SetYOffset(6)
+
+	m = resize(t, m, wide.w+8, wide.h) // width-only: offset survives
+	if m.vp.YOffset != 6 {
+		t.Fatalf("width-only resize moved the scroll: YOffset = %d, want 6", m.vp.YOffset)
+	}
+
+	m.vp.GotoBottom()
+	m = resize(t, m, medium.w, medium.h) // shrink: offset clamps into range
+	maxOff := m.vp.TotalLineCount() - m.vp.Height
+	if maxOff < 0 {
+		maxOff = 0
+	}
+	if m.vp.YOffset < 0 || m.vp.YOffset > maxOff {
+		t.Fatalf("shrink left a dangling offset %d outside [0,%d]", m.vp.YOffset, maxOff)
+	}
+	m = resize(t, m, narrow.w, narrow.h)
+	m = resize(t, m, wide.w, wide.h)
+
+	m.vp.SetYOffset(4)
+	m.cycleFacet(1) // content change: back to the top
+	if m.vp.YOffset != 0 {
+		t.Fatalf("facet change must reset the preview scroll, YOffset = %d", m.vp.YOffset)
+	}
+}
+
+// ── trackpad / wheel gating ──────────────────────────────────────────────────
+
+// TestWheelGate locks the temporal detent: the first event of a gesture acts
+// immediately (real wheel clicks feel instant), a rapid same-axis burst is
+// absorbed after that one step, orthogonal jitter inside the locked gesture
+// never leaks a step (and keeps the lock alive), a held scroll advances at the
+// controlled wheelRepeat cadence, and a pause re-arms an immediate step.
+func TestWheelGate(t *testing.T) {
+	t0 := time.Unix(1000, 0)
+	var g wheelGate
+
+	if !g.admit(wheelAxisV, t0) {
+		t.Fatal("first wheel event must act immediately")
+	}
+	for i := 1; i <= 30; i++ { // trackpad fling: 30 events over 150ms
+		if g.admit(wheelAxisV, t0.Add(time.Duration(i)*5*time.Millisecond)) {
+			t.Fatalf("burst event %d must be absorbed by the gate", i)
+		}
+	}
+	if g.admit(wheelAxisH, t0.Add(160*time.Millisecond)) {
+		t.Fatal("orthogonal jitter inside a vertical gesture must not act")
+	}
+	if g.admit(wheelAxisV, t0.Add(170*time.Millisecond)) {
+		t.Fatal("jitter must keep the lock alive — same-axis event still rationed")
+	}
+	if !g.admit(wheelAxisV, t0.Add(310*time.Millisecond)) {
+		t.Fatal("a held deliberate scroll must advance after wheelRepeat")
+	}
+	if g.admit(wheelAxisV, t0.Add(320*time.Millisecond)) {
+		t.Fatal("the cadence must re-arm after each granted step")
+	}
+	if !g.admit(wheelAxisH, t0.Add(700*time.Millisecond)) {
+		t.Fatal("after an idle pause a deliberate step on any axis must act immediately")
+	}
+	if g.axis != wheelAxisH {
+		t.Fatalf("gate must re-lock to the new axis, got %d", g.axis)
+	}
+}
+
+// TestWheelStepsFacets locks the wheel→facet mapping with a controlled clock:
+// vertical steps move the selection, horizontal steps change the focused
+// facet's value, bursts and diagonal jitter advance at most one step, and
+// later deliberate steps land after a pause. Facet semantics are the arrow-key
+// handlers verbatim.
+func TestWheelStepsFacets(t *testing.T) {
+	m := layoutModel()
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	t0 := time.Unix(1000, 0)
+
+	m.wheelStep(tea.MouseButtonWheelDown, t0)
+	if m.fcur != 1 {
+		t.Fatalf("wheel down must move the selection, fcur = %d", m.fcur)
+	}
+	for i := 1; i <= 20; i++ { // same-axis burst: at most that one step
+		m.wheelStep(tea.MouseButtonWheelDown, t0.Add(time.Duration(i)*5*time.Millisecond))
+	}
+	if m.fcur != 1 {
+		t.Fatalf("a wheel burst must advance one controlled step, fcur = %d", m.fcur)
+	}
+	sel := m.sel["model"]
+	for i := range 5 { // diagonal jitter during the vertical gesture
+		m.wheelStep(tea.MouseButtonWheelRight, t0.Add(120*time.Millisecond+time.Duration(i)*5*time.Millisecond))
+	}
+	if m.sel["model"] != sel {
+		t.Fatalf("diagonal jitter must not change facet values: model %q → %q", sel, m.sel["model"])
+	}
+
+	t1 := t0.Add(time.Second) // deliberate later gesture on the other axis
+	m.wheelStep(tea.MouseButtonWheelRight, t1)
+	if m.sel["model"] == sel {
+		t.Fatal("a deliberate horizontal step after a pause must change the value")
+	}
+	m.wheelStep(tea.MouseButtonWheelUp, t1.Add(time.Second))
+	if m.fcur != 0 {
+		t.Fatalf("wheel up must move the selection back, fcur = %d", m.fcur)
+	}
+}
+
+// TestWheelThroughUpdate verifies the wiring: a live tea.MouseMsg wheel press
+// reaches the gate (one immediate step, no command), and non-wheel mouse
+// traffic is ignored.
+func TestWheelThroughUpdate(t *testing.T) {
+	m := layoutModel()
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+
+	nm, cmd := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
+	m = nm.(model)
+	if cmd != nil {
+		t.Fatal("wheel input must never produce a command")
+	}
+	if m.fcur != 1 {
+		t.Fatalf("wheel press must step the selection, fcur = %d", m.fcur)
+	}
+
+	sel := map[string]string{}
+	for k, v := range m.sel {
+		sel[k] = v
+	}
+	nm, cmd = m.Update(tea.MouseMsg{Action: tea.MouseActionMotion, Button: tea.MouseButtonNone})
+	m = nm.(model)
+	if cmd != nil || m.fcur != 1 || !reflect.DeepEqual(m.sel, sel) {
+		t.Fatal("non-wheel mouse traffic must be ignored")
 	}
 }


### PR DESCRIPTION
## Summary
- forward effective width and height changes through the shared `cli-kit` PromptBox host
- replace the binary split/stack threshold with deliberate wide, generator-dominant medium, and safe narrow/short compositions
- let Generator absorb medium-layout vertical slack while compact Routing and vertically stacked Usage stay pinned below
- preserve routing scroll and all generator/auth/usage state across repeated reflow without refetching Usage
- add axis-locked, rate-limited vertical and horizontal wheel navigation for precise trackpad facet control

## Regression coverage
- width-only and height-only PromptBox-host resizes, active and inactive
- repeated wide/medium/narrow/short threshold crossings and state preservation
- viewport offset preservation and clamping
- width, height, border, clipping, pinned-footer, and no-auto-wrap invariants
- trackpad gesture bursts, axis jitter, controlled repeats, and Bubble Tea mouse wiring

## Verification
- `CGO_ENABLED=0 go test ./...` and `go vet ./...` in `pkgs/cli-kit`
- `CGO_ENABLED=0 go test ./...` and `go vet ./...` in `pkgs/code-tui`
- `nix build .#cli-kit .#code-tui .#atyrode-tui`
- `nix build .#checks.x86_64-linux.go-fmt`
- integrated tmux live-resize smoke: 150x44 → 100x44 (width only) → 70x35 → 150x12 and back
- truecolor tmux/freeze inspection at wide, medium, narrow, and short sizes; medium Generator expands over a content-sized secondary row
- injected SGR wheel events confirmed vertical facet movement, horizontal option changes, and resistance to a 30-event burst

Closes #197