### PR TITLE
code-tui: add contextual section controls

### DIFF
--- a/pkgs/code-tui/auth_test.go
+++ b/pkgs/code-tui/auth_test.go
@@ -75,6 +75,10 @@ func TestLoadAvailabilityUsesSelectedProfile(t *testing.T) {
 	}
 }
 
+// TestUsagePanelNamesWholeAuthCombination locks the #198 identity move: the
+// effective provider/account combination lives in the provider headings
+// ("Codex <account>", "Claude <account>") — a mixed profile reads correctly
+// with no standalone auth equation — and the switch cue says "switch profile".
 func TestUsagePanelNamesWholeAuthCombination(t *testing.T) {
 	m := model{
 		authProfiles: []authProfile{
@@ -84,11 +88,14 @@ func TestUsagePanelNamesWholeAuthCombination(t *testing.T) {
 		authIdx: 1,
 		avail:   availability{bucket: map[string]string{}, reset: map[string]int64{}},
 	}
-	panel := m.usagePanel()
-	for _, text := range []string{"auth", "mum", "Claude Mum", "Codex Alex", "switch"} {
+	panel := stripAnsi(m.usagePanel())
+	for _, text := range []string{"usage", "Claude Mum", "Codex Alex", "a switch profile"} {
 		if !strings.Contains(panel, text) {
 			t.Fatalf("usage panel missing %q: %q", text, panel)
 		}
+	}
+	if strings.Contains(panel, "auth ·") || strings.Contains(panel, " + ") {
+		t.Fatalf("usage panel must not repeat the auth equation: %q", panel)
 	}
 }
 

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -35,16 +35,20 @@ import (
 
 // ── keybindings (drive both input handling and the bubbles/help footer) ───────
 type keyMap struct {
-	Move, Change, Reset, Depth, Refresh, Auth, Collapse, Launch, Managed, Untrusted, Help, Quit key.Binding
+	Move, Change, Reset, Depth, Refresh, Auth, Collapse, Usage, Launch, Managed, Untrusted, Help, Quit key.Binding
 }
 
+// ShortHelp is a static single-line stand-in used only when measuring the
+// footer height for mode selection (which would otherwise recurse through the
+// state-derived compact help). The rendered compact line comes from
+// contextHelp, which derives its bindings from the live model state (#198).
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Move, k.Change, k.Reset, k.Auth, k.Launch, k.Managed, k.Untrusted, k.Help, k.Quit}
+	return []key.Binding{k.Move, k.Change, k.Reset, k.Help, k.Quit}
 }
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Move, k.Change, k.Reset},
-		{k.Depth, k.Refresh, k.Auth, k.Collapse},
+		{k.Depth, k.Refresh, k.Auth, k.Collapse, k.Usage},
 		{k.Launch, k.Managed, k.Untrusted, k.Help, k.Quit},
 	}
 }
@@ -55,8 +59,9 @@ var keys = keyMap{
 	Reset:     key.NewBinding(key.WithKeys("d"), key.WithHelp("d", gReset+" defaults")),
 	Depth:     key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "primary ⇄ full chains")),
 	Refresh:   key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh usage")),
-	Auth:      key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "switch auth")),
-	Collapse:  key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "collapse")),
+	Auth:      key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "switch profile")),
+	Collapse:  key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "show/hide routing")),
+	Usage:     key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "show/hide usage")),
 	Launch:    key.NewBinding(key.WithKeys("enter"), key.WithHelp("⏎", "launch")),
 	Managed:   key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "managed omp")),
 	Untrusted: key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "sandbox")),
@@ -95,6 +100,10 @@ var (
 	stWarn   = clikit.StWarn
 	stBrk    = clikit.StBrk
 	stStruck = clikit.StStruck
+
+	// stKey renders an inline key cue (r, a, s, p) — visually secondary but
+	// readable against the background, per the section-chrome convention.
+	stKey = lipgloss.NewStyle().Foreground(lipgloss.Color(cHead))
 
 	// layout + meter primitives now live in cli-kit
 	padLeft    = clikit.PadLeft
@@ -849,6 +858,7 @@ func (m model) genConfigYAML() string {
 //	medium    — generator-dominant: the list full width on top (primary), then
 //	            Routing and Usage side by side in a secondary row, with Usage's
 //	            provider groups stacked vertically inside its narrower column
+//	            (Routing takes the whole row while ‹s› hides Usage)
 //	collapsed — narrow/short or ‹p›: one full-width panel at a time (list, or
 //	            routing w/ showResult) — the Generator stays usable instead of
 //	            compressing every section into an unreadable split
@@ -940,7 +950,7 @@ func (m model) mode() int {
 // a usable generator column above the full-width Usage footer. Shorter than
 // this, keeping every section visible would compress them all — shed instead.
 func (m model) wideMinH() int {
-	return topGap + genColMinH + m.footerH(true)
+	return topGap + genColMinH + m.footerH(!m.hideUsage)
 }
 
 // mediumMinH stacks the generator over the secondary Routing+Usage row (at its
@@ -952,6 +962,9 @@ func (m model) mediumMinH() int {
 // mediumMinW: the secondary row must seat a useful routing viewport beside the
 // measured usage column without clipping either.
 func (m model) mediumMinW() int {
+	if m.hideUsage {
+		return routingMinW
+	}
 	return routingMinW + m.usageColW()
 }
 
@@ -1044,7 +1057,10 @@ func (m model) previewDims() (int, int) {
 // routingColW is the medium secondary row's routing share: whatever the
 // measured usage column leaves free.
 func (m model) routingColW() int {
-	w := m.w - m.usageColW()
+	w := m.w
+	if !m.hideUsage {
+		w -= m.usageColW()
+	}
 	if w < routingMinW {
 		w = routingMinW
 	}
@@ -1109,9 +1125,10 @@ type model struct {
 	avail     availability
 	glyphs    map[string]string
 
-	depth      int // 0 lead · 1 full
-	collapse   bool
+	depth      int  // 0 lead · 1 full
+	collapse   bool // p: hide the Routing section
 	showResult bool // in collapsed mode: show the preview full-width
+	hideUsage  bool // s: hide the Usage section (#198); fetch state keeps running unseen
 
 	facets []facet
 	fcur   int
@@ -1240,58 +1257,92 @@ func shortWin(l string) string {
 	return l
 }
 
-// refreshLine shows either the live countdown to the next auto-refresh or, while
-// a fetch is in flight, a refreshing marker — plus the manual-refresh hint.
-func (m *model) refreshLine() string {
-	if m.fetching {
-		return stDim.Render("  usage · ") + stWarn.Render(gReset+" refreshing…")
+// usageCtrlLine is the Usage chrome's action row: the refresh status/countdown
+// with its manual-refresh cue, then the profile-switch cue (omitted when only
+// one auth profile exists). The identity itself lives in the provider group
+// headings, so no separate auth equation remains (#198). A profile-switch
+// error stays attached here — next to the control that caused it.
+func (m *model) usageCtrlLine() string {
+	var parts []string
+	if m.usageCmd != "" {
+		switch {
+		case !m.avail.ok && (m.fetching || m.nextRefresh.IsZero()):
+			parts = append(parts, stDim.Render(m.spin.View()+" fetching usage…"))
+		case m.fetching:
+			parts = append(parts, stWarn.Render(gReset+" refreshing…"))
+		default:
+			rem := time.Until(m.nextRefresh)
+			if rem < 0 {
+				rem = 0
+			}
+			s := int(rem.Seconds())
+			parts = append(parts,
+				stDim.Render(fmt.Sprintf("next refresh %d:%02d · ", s/60, s%60))+
+					stKey.Render("r")+stDim.Render(" now"))
+		}
 	}
-	rem := time.Until(m.nextRefresh)
-	if rem < 0 {
-		rem = 0
-	}
-	s := int(rem.Seconds())
-	return stDim.Render(fmt.Sprintf("  usage · next refresh %d:%02d · ", s/60, s%60)) +
-		lipgloss.NewStyle().Foreground(lipgloss.Color(cHead)).Render("r") + stDim.Render(" now")
-}
-
-func (m *model) authLine() string {
-	p := m.activeAuthProfile()
-	label := lipgloss.NewStyle().Foreground(lipgloss.Color(cGreen)).Bold(true).Render(p.Label)
-	claude := lipgloss.NewStyle().Foreground(lipgloss.Color("#ff9f52")).Render("Claude " + p.Claude)
-	codex := lipgloss.NewStyle().Foreground(lipgloss.Color("#62a7ff")).Render("Codex " + p.Codex)
-	line := stDim.Render("   auth · ") + label + stDim.Render("  ") + claude + stDim.Render(" + ") + codex
 	if len(m.authProfiles) > 1 {
-		line += stDim.Render("  ·  ") + lipgloss.NewStyle().Foreground(lipgloss.Color(cHead)).Render("a") + stDim.Render(" switch")
+		parts = append(parts, stKey.Render("a")+stDim.Render(" switch profile"))
 	}
+	if len(parts) == 0 {
+		return ""
+	}
+	line := "  " + strings.Join(parts, stDim.Render("  ·  "))
 	if m.authErr != "" {
 		line += "\n" + stBrk.Render("  profile switch failed: "+m.authErr)
 	}
 	return line
 }
 
+// providerHeading names a provider usage group by its effective identity —
+// "Codex <account>" / "Claude <account>", derived from the active auth
+// profile — so mixed profiles (Claude Mum + Codex Alex) read correctly with
+// no prose equation, in text rather than color alone.
+func providerHeading(prov string, p authProfile) string {
+	col, name, acct := "#62a7ff", "Codex", p.Codex
+	if prov == "anthropic" {
+		col, name, acct = "#ff9f52", "Claude", p.Claude
+	}
+	if acct != "" {
+		name += " " + acct
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(col)).Bold(true).Render(name)
+}
+
+// identityLines renders the effective provider/account headings on their own —
+// the loading and error states keep the active identity visible even before
+// any usage rows exist.
+func (m *model) identityLines() string {
+	p := m.activeAuthProfile()
+	return padLeft(providerHeading("openai-codex", p), gut) + "\n" +
+		padLeft(providerHeading("anthropic", p), gut)
+}
+
 // usagePanel is the composition-agnostic Usage band sized for the current
 // terminal width — the wide layout's full-width footer form.
 func (m *model) usagePanel() string { return m.usagePanelFor(m.w) }
 
-// usagePanelFor renders auth + refresh + provider usage, laying provider groups
-// side by side only when w seats every column; w <= 0 forces the vertical stack
-// (the medium layout's narrow usage column).
+// usagePanelFor renders the first-class Usage section: the pilled title with
+// its local hide cue, the refresh/switch control row, and the per-provider
+// usage groups headed by the effective provider/account identity. Provider
+// groups sit side by side only when w seats every column; w <= 0 forces the
+// vertical stack (the medium layout's narrow usage column).
 func (m *model) usagePanelFor(w int) string {
-	auth := m.authLine()
+	out := padLeft(m.pill("usage")+"  "+stKey.Render("s")+stDim.Render(" · hide"), gut) + "\n"
+	if ctrl := m.usageCtrlLine(); ctrl != "" {
+		out += "\n" + ctrl
+	}
+	p := m.activeAuthProfile()
 	if !m.avail.ok {
-		if m.usageCmd == "" {
-			return auth
+		out += "\n" + m.identityLines()
+		if m.usageCmd != "" && !m.fetching && !m.nextRefresh.IsZero() {
+			out += "\n" + stWarn.Render("  usage unavailable · authenticate with omp --profile "+p.ID)
 		}
-		if m.fetching || m.nextRefresh.IsZero() {
-			return auth + "\n" + stDim.Render("  "+m.spin.View()+" fetching usage…")
-		}
-		p := m.activeAuthProfile()
-		return auth + "\n" + stWarn.Render("  usage unavailable · authenticate with omp --profile "+p.ID)
+		return out
 	}
 	if len(m.avail.wins) == 0 {
-		p := m.activeAuthProfile()
-		return auth + "\n" + stWarn.Render("  no provider usage · authenticate with omp --profile "+p.ID)
+		return out + "\n" + m.identityLines() + "\n" +
+			stWarn.Render("  no provider usage · authenticate with omp --profile "+p.ID)
 	}
 	wins := append([]usageWin(nil), m.avail.wins...)
 	provOrder := func(p string) int {
@@ -1320,16 +1371,12 @@ func (m *model) usagePanelFor(w int) string {
 	})
 	blocks := map[string][]string{}
 	var order []string
-	for _, w := range wins {
-		if _, ok := blocks[w.prov]; !ok {
-			order = append(order, w.prov)
-			pcol, pname := "#62a7ff", "Codex"
-			if w.prov == "anthropic" {
-				pcol, pname = "#ff9f52", "Claude"
-			}
-			blocks[w.prov] = []string{padLeft(lipgloss.NewStyle().Foreground(lipgloss.Color(pcol)).Bold(true).Render(pname), gut)}
+	for _, win := range wins {
+		if _, ok := blocks[win.prov]; !ok {
+			order = append(order, win.prov)
+			blocks[win.prov] = []string{padLeft(providerHeading(win.prov, p), gut)}
 		}
-		blocks[w.prov] = append(blocks[w.prov], m.usageRow(w))
+		blocks[win.prov] = append(blocks[win.prov], m.usageRow(win))
 	}
 	if cl := m.creditLine(); cl != "" {
 		if b, ok := blocks["openai-codex"]; ok {
@@ -1337,34 +1384,40 @@ func (m *model) usagePanelFor(w int) string {
 		}
 	}
 	// side-by-side when there's horizontal room, else stacked. colW must fit the
-	// widest row (label · bar · pct · ↻reset · note) without wrapping the note.
-	const colW = 49
+	// widest row (label · bar · pct · ↻reset · note) without wrapping the note;
+	// a long account name widens the column instead of truncating the identity.
+	colW := 49
+	for _, prov := range order {
+		if hw := lipgloss.Width(blocks[prov][0]) + 2; hw > colW {
+			colW = hw
+		}
+	}
 	if w > 0 && len(order) > 1 && w >= colW*len(order) {
 		var cols []string
-		for _, p := range order {
-			cols = append(cols, lipgloss.NewStyle().Width(colW).Render(strings.Join(blocks[p], "\n")))
+		for _, prov := range order {
+			cols = append(cols, lipgloss.NewStyle().Width(colW).Render(strings.Join(blocks[prov], "\n")))
 		}
-		return auth + "\n" + m.refreshLine() + "\n" + lipgloss.JoinHorizontal(lipgloss.Top, cols...)
+		return out + "\n" + lipgloss.JoinHorizontal(lipgloss.Top, cols...)
 	}
 	var lines []string
-	for i, p := range order {
+	for i, prov := range order {
 		if i > 0 {
 			lines = append(lines, "") // blank line between provider groups
 		}
-		lines = append(lines, blocks[p]...)
+		lines = append(lines, blocks[prov]...)
 	}
-	return auth + "\n" + m.refreshLine() + "\n" + strings.Join(lines, "\n")
+	return out + "\n" + strings.Join(lines, "\n")
 }
 
-// usageColumn is the medium layout's right-hand Usage section: a pinned pill
-// head over the usage panel with provider groups forced into a vertical stack —
-// the column is deliberately too narrow for side-by-side groups.
+// usageColumn is the medium layout's right-hand Usage section: the panel with
+// provider groups forced into a vertical stack — the column is deliberately
+// too narrow for side-by-side groups. The panel carries its own title chrome.
 func (m model) usageColumn() string {
-	return padLeft(m.pill("usage"), gut) + "\n\n" + m.usagePanelFor(0)
+	return m.usagePanelFor(0)
 }
 
 // usageColW is the medium usage column's measured width: the widest rendered
-// line of the stacked panel (auth, refresh, bars, notes) — measured, not guessed.
+// line of the stacked panel (title, controls, bars, notes) — measured, not guessed.
 func (m model) usageColW() int {
 	return lipgloss.Width(m.usageColumn())
 }
@@ -1374,6 +1427,9 @@ func (m model) usageColW() int {
 // that is taller — medium only engages when neither column needs clipping.
 func (m model) secondaryMinH() int {
 	h := prevChromeRows + minRouteRows
+	if m.hideUsage {
+		return h
+	}
 	if u := lipgloss.Height(m.usageColumn()); u > h {
 		h = u
 	}
@@ -1483,7 +1539,7 @@ func (m *model) footer() string {
 			parts = append(parts, rule, p)
 		}
 	}
-	parts = append(parts, rule, "  "+m.help.View(keys))
+	parts = append(parts, rule, "  "+m.help.View(m.contextHelp()))
 	return strings.Join(parts, "\n")
 }
 
@@ -1493,6 +1549,9 @@ func (m *model) footer() string {
 // Generator stays usable first — fetch state and the refresh cadence keep
 // running unseen, and nothing is refetched when it reappears.
 func (m *model) usageInFooter() bool {
+	if m.hideUsage {
+		return false
+	}
 	switch m.sizeMode() {
 	case sizeWide:
 		return true
@@ -1501,6 +1560,90 @@ func (m *model) usageInFooter() bool {
 	default:
 		return false
 	}
+}
+
+// routingShown reports whether the Routing section (and so its title-local
+// p · hide cue) is on screen in the current composition.
+func (m model) routingShown() bool {
+	if m.collapse {
+		return false
+	}
+	if m.mode() == modeCollapsed {
+		return m.showResult
+	}
+	return true
+}
+
+// usageShown reports whether the Usage panel is rendered anywhere — the
+// wide/collapsed footer band or medium's secondary column. Narrow sheds it
+// regardless of the s toggle.
+func (m model) usageShown() bool {
+	if m.hideUsage {
+		return false
+	}
+	return m.usageInFooter() || m.mode() == modeMedium
+}
+
+// usageCanShow reports whether restoring Usage would actually render it — the
+// compact footer must never advertise a recovery action the narrow layout
+// would immediately shed anyway.
+func (m model) usageCanShow() bool {
+	t := m
+	t.hideUsage = false
+	return t.usageShown()
+}
+
+// generatorShown: the Generator (and its launch footer advertising ⏎/m/u) is
+// visible in every composition except the narrow routing-full-screen swap.
+func (m model) generatorShown() bool {
+	return !(m.mode() == modeCollapsed && !m.collapse && m.showResult)
+}
+
+// helpKeys is the state-derived key map handed to the bubbles help view: the
+// compact line lists only what contextHelp selected, while ? always exposes
+// the complete static reference.
+type helpKeys struct {
+	short []key.Binding
+	full  [][]key.Binding
+}
+
+func (h helpKeys) ShortHelp() []key.Binding  { return h.short }
+func (h helpKeys) FullHelp() [][]key.Binding { return h.full }
+
+// contextHelp derives the compact footer from the model state (#198):
+//   - navigation, reset, full-help discovery, and quit are always offered;
+//   - a hidden section contributes its recovery action (show routing/usage) —
+//     usage only when the current terminal could actually seat it again;
+//   - profile switching and manual refresh surface only while the Usage
+//     chrome that normally advertises them is off screen, and only when they
+//     can run (an alternate profile exists; no fetch already in flight);
+//   - the launch trio surfaces only while the Generator launch footer is
+//     hidden (the narrow routing-full-screen swap).
+//
+// Everything else lives in visible section chrome or behind ?.
+func (m model) contextHelp() helpKeys {
+	short := []key.Binding{keys.Move, keys.Change, keys.Reset}
+	if !m.routingShown() {
+		short = append(short, key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "show routing")))
+	}
+	if m.hideUsage && m.usageCanShow() {
+		short = append(short, key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "show usage")))
+	}
+	// Keep full-help discovery and quit ahead of optional contextual actions:
+	// bubbles truncates a compact line from the right on narrow terminals.
+	short = append(short, keys.Help, keys.Quit)
+	if !m.usageShown() {
+		if len(m.authProfiles) > 1 {
+			short = append(short, keys.Auth)
+		}
+		if m.usageCmd != "" && !m.fetching {
+			short = append(short, keys.Refresh)
+		}
+	}
+	if !m.generatorShown() {
+		short = append(short, keys.Launch, keys.Managed, keys.Untrusted)
+	}
+	return helpKeys{short: short, full: keys.FullHelp()}
 }
 
 func (m *model) relayout() {
@@ -1567,6 +1710,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			default:
 				m.collapse = true // split/stacked: hide the preview, list full-screen
 			}
+			m.relayout()
+		case "s":
+			// Usage collapse (#198): a pure display toggle. Fetch state and the
+			// refresh cadence keep running unseen; nothing is refetched on
+			// restore, and the freed rows reallocate to the active composition.
+			m.hideUsage = !m.hideUsage
 			m.relayout()
 		case "?":
 			m.help.ShowAll = !m.help.ShowAll
@@ -1757,22 +1906,24 @@ func (m model) sectionHead() string {
 	return padLeft(m.sectionTitle(), gut) + "\n\n"
 }
 
-// prevChromeRows is the preview column's pinned chrome around the scrolling
-// viewport: the pill head above (headRows) plus a blank + the fallback-display
-// hint below.
-const prevChromeRows = headRows + 2
+// prevChromeRows is the Routing column's pinned chrome above the scrolling
+// viewport: the title row with its local collapse cue, the fallback-display
+// cue beneath it, and a blank separator.
+const prevChromeRows = headRows + 1
 
-// previewColumn assembles the right column: the pinned "routing" pill head, the
-// scrolling routing viewport, and the pinned fallback-display hint. The hint's
-// show/hide wording makes clear that f only changes what is DISPLAYED — the
-// launched profile always keeps its fallback chains.
+// previewColumn assembles the Routing section: the pinned title row carrying
+// the section-local collapse cue (p · hide), the fallback-display cue directly
+// beneath it — Routing chrome, not a detached bottom row (#198) — then the
+// scrolling routing viewport. The f wording makes clear it only changes what
+// is DISPLAYED: the launched profile always keeps its fallback chains.
 func (m model) previewColumn() string {
 	verb := "show"
 	if m.depth == 1 {
 		verb = "hide"
 	}
-	return m.pill("routing") + "\n\n" + m.vp.View() + "\n\n" +
-		stDim.Render("f · "+verb+" fallback chains")
+	return m.pill("routing") + "  " + stKey.Render("p") + stDim.Render(" · hide") + "\n" +
+		stKey.Render("f") + stDim.Render(" · "+verb+" fallback chains") + "\n\n" +
+		m.vp.View()
 }
 
 // leftColumn renders the pinned section head plus the scrolling list body, the
@@ -1802,9 +1953,12 @@ func (m model) mediumContent(bodyH int) string {
 	// over-wide line onto an extra physical row and break the row's height.
 	routing := lipgloss.NewStyle().Width(rw).MaxHeight(secH).Render(
 		lipgloss.NewStyle().MaxWidth(rw).Render(padLeft(m.previewColumn(), gut)))
-	usage := lipgloss.NewStyle().MaxWidth(m.w - rw).MaxHeight(secH).Render(m.usageColumn())
-	return lipgloss.JoinVertical(lipgloss.Left, top, div,
-		lipgloss.JoinHorizontal(lipgloss.Top, routing, usage))
+	sec := routing
+	if !m.hideUsage {
+		usage := lipgloss.NewStyle().MaxWidth(m.w - rw).MaxHeight(secH).Render(m.usageColumn())
+		sec = lipgloss.JoinHorizontal(lipgloss.Top, routing, usage)
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, top, div, sec)
 }
 
 func (m model) View() string {

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	clikit "cli-kit"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -417,9 +419,12 @@ func TestApplyAdvisorFableMain(t *testing.T) {
 	}
 }
 
-// TestPreviewColumn locks the right column's shape: a pinned "routing" pill on
-// top, no settings-summary line (the dials are visible on the left), and the
-// pinned f cue at the bottom worded as a DISPLAY toggle (show/hide).
+// TestPreviewColumn locks the Routing section's shape (#198): the title row
+// carries the section-local collapse cue (p · hide), the fallback-display cue
+// sits directly beneath the title as Routing chrome (worded as a show/hide
+// DISPLAY toggle) rather than on a detached bottom row, and no baked
+// settings-summary line reaches the preview (the dials are visible on the
+// left).
 func TestPreviewColumn(t *testing.T) {
 	id := comboID(defaultSel())
 	m := model{
@@ -434,15 +439,18 @@ func TestPreviewColumn(t *testing.T) {
 	m.vp = viewport.New(60, 6)
 	m.syncPreview()
 	plain := stripAnsi(m.previewColumn())
-	if !strings.Contains(plain, "routing") {
-		t.Errorf("preview column must carry the routing pill, got:\n%s", plain)
-	}
 	if strings.Contains(plain, "fallback on") || strings.Contains(plain, "thinking medium ·") {
 		t.Errorf("the baked settings-summary line must not reach the preview, got:\n%s", plain)
 	}
-	rows := strings.Split(strings.TrimRight(plain, "\n"), "\n")
-	if last := strings.TrimSpace(rows[len(rows)-1]); last != "f · show fallback chains" {
-		t.Errorf("bottom hint = %q, want %q", last, "f · show fallback chains")
+	rows := strings.Split(plain, "\n")
+	if !strings.Contains(rows[0], "routing") || !strings.Contains(rows[0], "p · hide") {
+		t.Errorf("title row must carry the routing pill and its local collapse cue, got %q", rows[0])
+	}
+	if strings.TrimSpace(rows[1]) != "f · show fallback chains" {
+		t.Errorf("fallback cue must sit under the title as chrome, got %q", rows[1])
+	}
+	if tail := strings.TrimSpace(rows[len(rows)-1]); strings.Contains(tail, "fallback") {
+		t.Errorf("no detached bottom hint row may remain, got %q", tail)
 	}
 	m.depth = 1
 	if plain := stripAnsi(m.previewColumn()); !strings.Contains(plain, "f · hide fallback chains") {
@@ -638,8 +646,13 @@ func TestResponsiveCompositions(t *testing.T) {
 	if lineIndex(lines, "generator") < 0 {
 		t.Errorf("narrow: the generator must stay usable")
 	}
-	if lineIndex(lines, "routing") >= 0 || lineIndex(lines, "% used") >= 0 {
+	// The shed routing SECTION (its p · hide title chrome) must be gone; the
+	// compact footer instead carries the recovery cue.
+	if lineIndex(lines, "p · hide") >= 0 || lineIndex(lines, "% used") >= 0 {
 		t.Errorf("narrow: secondary sections must be shed, not compressed:\n%s", strings.Join(lines, "\n"))
+	}
+	if lineIndex(lines, "show routing") < 0 {
+		t.Errorf("narrow: the compact footer must offer the routing recovery cue:\n%s", strings.Join(lines, "\n"))
 	}
 	assertLayoutInvariants(t, m, "narrow")
 
@@ -647,7 +660,7 @@ func TestResponsiveCompositions(t *testing.T) {
 	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
 	m = nm.(model)
 	lines = strings.Split(stripAnsi(m.View()), "\n")
-	if lineIndex(lines, "routing") < 0 || lineIndex(lines, "generator") >= 0 {
+	if lineIndex(lines, "routing", "p · hide") < 0 || lineIndex(lines, "generator") >= 0 {
 		t.Errorf("narrow+p: want the routing panel full width instead of the generator:\n%s", strings.Join(lines, "\n"))
 	}
 	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
@@ -927,4 +940,487 @@ func TestWheelThroughUpdate(t *testing.T) {
 	if cmd != nil || m.fcur != 1 || !reflect.DeepEqual(m.sel, sel) {
 		t.Fatal("non-wheel mouse traffic must be ignored")
 	}
+}
+
+// ── usage identity · collapsible sections · contextual help (#198) ──────────
+
+// press drives one rune keypress through Update.
+func press(t *testing.T, m model, k string) (model, tea.Cmd) {
+	t.Helper()
+	nm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)})
+	return nm.(model), cmd
+}
+
+// multiProfileModel is layoutModel with a second (mixed) auth profile, so the
+// switch cue and profile-dependent help rules engage.
+func multiProfileModel() model {
+	m := layoutModel()
+	m.authProfiles = []authProfile{
+		{ID: "default", Label: "mine", Claude: "Alex", Codex: "Alex"},
+		{ID: "mum", Label: "mum", Claude: "Mum", Codex: "Alex"},
+	}
+	return m
+}
+
+// shortDescs returns the compact help line's action descriptions — the
+// state-derived contract, independent of footer width truncation.
+func shortDescs(m model) []string {
+	var out []string
+	for _, b := range m.contextHelp().ShortHelp() {
+		out = append(out, b.Help().Desc)
+	}
+	return out
+}
+
+func hasDesc(descs []string, want string) bool {
+	for _, d := range descs {
+		if d == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestUsageHeadingsNameEffectiveProfile locks the identity move: provider
+// group headings carry the effective account ("Codex <account>",
+// "Claude <account>") for every supported profile combination — including
+// mixed profiles — and the standalone auth equation is gone.
+func TestUsageHeadingsNameEffectiveProfile(t *testing.T) {
+	cases := []struct {
+		name          string
+		claude, codex string
+	}{
+		{"alex/alex", "Alex", "Alex"},
+		{"mum/alex mixed", "Mum", "Alex"},
+		{"mum/mum", "Mum", "Mum"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := layoutModel()
+			m.authProfiles = []authProfile{{ID: "p", Label: "p", Claude: tc.claude, Codex: tc.codex}}
+			lines := strings.Split(stripAnsi(m.usagePanel()), "\n")
+			codexHead := lineIndex(lines, "Codex "+tc.codex)
+			claudeHead := lineIndex(lines, "Claude "+tc.claude)
+			if codexHead < 0 || claudeHead < 0 {
+				t.Fatalf("provider headings must name the effective accounts:\n%s", strings.Join(lines, "\n"))
+			}
+			if trimmed := strings.TrimSpace(lines[codexHead]); trimmed != "Codex "+tc.codex {
+				t.Errorf("Codex heading must be a standalone group title, got %q", trimmed)
+			}
+			if lineIndex(lines, "auth ·") >= 0 || lineIndex(lines, "Claude "+tc.claude+" + ") >= 0 {
+				t.Errorf("the standalone auth equation must be gone:\n%s", strings.Join(lines, "\n"))
+			}
+			if lines[0] == "" || !strings.Contains(lines[0], "usage") || !strings.Contains(lines[0], "s · hide") {
+				t.Errorf("usage must open with its first-class title and local hide cue, got %q", lines[0])
+			}
+		})
+	}
+}
+
+// TestUsageSwitchCue: `a switch profile` sits after `r now` in the control
+// row when an alternate profile exists, and disappears everywhere when only
+// one auth profile is configured.
+func TestUsageSwitchCue(t *testing.T) {
+	m := multiProfileModel()
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	lines := strings.Split(stripAnsi(m.usagePanel()), "\n")
+	ctrl := lineIndex(lines, "next refresh", "r now", "a switch profile")
+	if ctrl < 0 {
+		t.Fatalf("refresh and switch must share the usage control row:\n%s", strings.Join(lines, "\n"))
+	}
+	row := lines[ctrl]
+	if strings.Index(row, "r now") > strings.Index(row, "a switch profile") {
+		t.Errorf("switch cue must come after the refresh cue: %q", row)
+	}
+
+	single := layoutModel()
+	single = resize(t, single, wide.w, wide.h)
+	if view := stripAnsi(single.View()); strings.Contains(view, "switch profile") {
+		t.Errorf("single-profile: the switch cue must be omitted everywhere:\n%s", view)
+	}
+}
+
+// TestUsageLoadingErrorStates: the loading, refreshing, unavailable, and
+// switch-failure states each keep the effective identity visible and replace
+// only the status — errors stay attached to the Usage section.
+func TestUsageLoadingErrorStates(t *testing.T) {
+	m := layoutModel()
+
+	loading := m
+	loading.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
+	loading.fetching = true
+	panel := stripAnsi(loading.usagePanel())
+	for _, want := range []string{"fetching usage…", "Codex Alex", "Claude Alex"} {
+		if !strings.Contains(panel, want) {
+			t.Errorf("loading: panel missing %q:\n%s", want, panel)
+		}
+	}
+	if strings.Contains(panel, "usage unavailable") {
+		t.Errorf("loading must not read as an error:\n%s", panel)
+	}
+
+	refreshing := m
+	refreshing.fetching = true
+	panel = stripAnsi(refreshing.usagePanel())
+	for _, want := range []string{"refreshing…", "Codex Alex", "Claude Alex", "% used"} {
+		if !strings.Contains(panel, want) {
+			t.Errorf("refreshing: panel missing %q:\n%s", want, panel)
+		}
+	}
+	if strings.Contains(panel, "next refresh") {
+		t.Errorf("refreshing must replace the countdown, not stack on it:\n%s", panel)
+	}
+
+	failed := m
+	failed.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
+	panel = stripAnsi(failed.usagePanel())
+	for _, want := range []string{"usage unavailable · authenticate with omp --profile default", "Codex Alex", "Claude Alex"} {
+		if !strings.Contains(panel, want) {
+			t.Errorf("unavailable: panel missing %q:\n%s", want, panel)
+		}
+	}
+
+	switchErr := multiProfileModel()
+	switchErr.authErr = "state write denied"
+	panel = stripAnsi(switchErr.usagePanel())
+	if !strings.Contains(panel, "profile switch failed: state write denied") {
+		t.Errorf("a switch failure must stay attached to the usage section:\n%s", panel)
+	}
+}
+
+// TestSectionToggleCombinations walks every routing × usage visibility combo
+// on a wide terminal: local hide cues live in the section titles, hidden
+// sections surface their recovery cue in the compact footer instead, no
+// toggle ever triggers a fetch, and every combination keeps the frame
+// invariants.
+func TestSectionToggleCombinations(t *testing.T) {
+	m := multiProfileModel()
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	availBefore := m.avail
+
+	assertCombo := func(label string, wantRouting, wantUsage bool) {
+		t.Helper()
+		view := stripAnsi(m.View())
+		lines := strings.Split(view, "\n")
+		if got := lineIndex(lines, "p · hide") >= 0; got != wantRouting {
+			t.Errorf("%s: routing chrome visible = %v, want %v:\n%s", label, got, wantRouting, view)
+		}
+		if got := lineIndex(lines, "s · hide") >= 0; got != wantUsage {
+			t.Errorf("%s: usage chrome visible = %v, want %v:\n%s", label, got, wantUsage, view)
+		}
+		if got := lineIndex(lines, "% used") >= 0; got != wantUsage {
+			t.Errorf("%s: usage rows visible = %v, want %v", label, got, wantUsage)
+		}
+		descs := shortDescs(m)
+		if got := hasDesc(descs, "show routing"); got == wantRouting {
+			t.Errorf("%s: compact help offers show routing = %v with routing visible = %v", label, got, wantRouting)
+		}
+		if got := hasDesc(descs, "show usage"); got == wantUsage {
+			t.Errorf("%s: compact help offers show usage = %v with usage visible = %v", label, got, wantUsage)
+		}
+		if got := hasDesc(descs, "switch profile"); got == wantUsage {
+			t.Errorf("%s: compact help repeats/misses switch profile (got %v) with usage visible = %v", label, got, wantUsage)
+		}
+		if m.fetching || !reflect.DeepEqual(m.avail, availBefore) {
+			t.Errorf("%s: a display toggle mutated fetch state", label)
+		}
+		assertLayoutInvariants(t, m, label)
+	}
+
+	assertCombo("both visible", true, true)
+
+	var cmd tea.Cmd
+	m, cmd = press(t, m, "s")
+	if cmd != nil {
+		t.Fatal("hiding usage must never produce a command")
+	}
+	assertCombo("usage hidden", true, false)
+
+	m, cmd = press(t, m, "p")
+	if cmd != nil {
+		t.Fatal("hiding routing must never produce a command")
+	}
+	assertCombo("both hidden", false, false)
+
+	m, _ = press(t, m, "s")
+	assertCombo("routing hidden", false, true)
+
+	m, _ = press(t, m, "p")
+	assertCombo("both restored", true, true)
+}
+
+// TestCompactHelpDerivation locks the state-derived footer rules: chrome-
+// visible actions never repeat in the compact line, hidden sections add their
+// recovery cue, refresh hides while a fetch is in flight or unusable, the
+// launch trio surfaces only when the generator's launch footer is off screen,
+// and the usage recovery cue never advertises a restore the narrow layout
+// would immediately shed.
+func TestCompactHelpDerivation(t *testing.T) {
+	m := multiProfileModel()
+	wide, _, narrow, _ := layoutSizes(t, m)
+
+	m = resize(t, m, wide.w, wide.h)
+	descs := shortDescs(m)
+	for _, d := range []string{"move", "change", "switch profile", "refresh usage", "managed omp", "sandbox", "launch", "show routing", "show usage"} {
+		got := hasDesc(descs, d)
+		want := d == "move" || d == "change"
+		if got != want {
+			t.Errorf("wide compact help: %q shown = %v, want %v (descs %v)", d, got, want, descs)
+		}
+	}
+	if !hasDesc(descs, "more") || !hasDesc(descs, "quit") {
+		t.Errorf("full-help discovery and quit must always be offered: %v", descs)
+	}
+
+	m = resize(t, m, narrow.w, narrow.h)
+	descs = shortDescs(m)
+	for _, d := range []string{"show routing", "switch profile", "refresh usage"} {
+		if !hasDesc(descs, d) {
+			t.Errorf("narrow compact help missing %q: %v", d, descs)
+		}
+	}
+	if hasDesc(descs, "show usage") {
+		t.Errorf("narrow sheds usage by size, not by state — no show-usage cue: %v", descs)
+	}
+	ordered := strings.Join(descs, "|")
+	for _, optional := range []string{"switch profile", "refresh usage"} {
+		if strings.Index(ordered, "more") > strings.Index(ordered, optional) ||
+			strings.Index(ordered, "quit") > strings.Index(ordered, optional) {
+			t.Errorf("narrow compact help must prioritize more/quit before %q: %v", optional, descs)
+		}
+	}
+
+	fetching := m
+	fetching.fetching = true
+	if hasDesc(shortDescs(fetching), "refresh usage") {
+		t.Error("refresh must hide from compact help while a fetch is in flight")
+	}
+	noCmd := m
+	noCmd.usageCmd = ""
+	if hasDesc(shortDescs(noCmd), "refresh usage") {
+		t.Error("refresh must hide from compact help when no usage command exists")
+	}
+
+	// narrow + p: routing full-screen hides the generator launch footer.
+	swapped, _ := press(t, m, "p")
+	descs = shortDescs(swapped)
+	for _, d := range []string{"launch", "managed omp", "sandbox"} {
+		if !hasDesc(descs, d) {
+			t.Errorf("routing-full-screen compact help missing %q: %v", d, descs)
+		}
+	}
+	if hasDesc(descs, "show routing") {
+		t.Errorf("routing is visible full-screen — no recovery cue: %v", descs)
+	}
+
+	// A terminal too narrow to ever seat usage must not advertise its restore.
+	tiny := multiProfileModel()
+	tiny.hideUsage = true
+	tiny = resize(t, tiny, routingMinW-3, 40)
+	if hasDesc(shortDescs(tiny), "show usage") {
+		t.Error("show usage must not be offered when restoring could not render it")
+	}
+}
+
+// TestFullHelpComplete: ? always exposes every binding — including both
+// section toggles — regardless of what the compact footer dropped, and the
+// full keymap stays conflict-free (u keeps the sandbox; s is the usage key).
+func TestFullHelpComplete(t *testing.T) {
+	m := multiProfileModel()
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	m.hideUsage = true
+	m.collapse = true
+	m.help.ShowAll = true
+	foot := stripAnsi(m.footer())
+	for _, d := range []string{"move", "change", "defaults", "primary ⇄ full chains", "refresh usage", "switch profile", "show/hide routing", "show/hide usage", "launch", "managed omp", "sandbox", "quit"} {
+		if !strings.Contains(foot, d) {
+			t.Errorf("full help missing %q:\n%s", d, foot)
+		}
+	}
+
+	seen := map[string]string{}
+	for _, group := range keys.FullHelp() {
+		for _, b := range group {
+			for _, k := range b.Keys() {
+				if prev, dup := seen[k]; dup {
+					t.Errorf("key %q bound to both %q and %q", k, prev, b.Help().Desc)
+				}
+				seen[k] = b.Help().Desc
+			}
+		}
+	}
+	if got := keys.Usage.Keys(); len(got) != 1 || got[0] != "s" {
+		t.Errorf("usage toggle key = %v, want [s]", got)
+	}
+	if got := keys.Untrusted.Keys(); len(got) != 1 || got[0] != "u" {
+		t.Errorf("sandbox must keep u, got %v", got)
+	}
+	if got := keys.Collapse.Keys(); len(got) != 1 || got[0] != "p" {
+		t.Errorf("routing toggle must keep p, got %v", got)
+	}
+}
+
+// TestLongAccountLabelsWidthInvariant: over-long account names widen the
+// measured usage column (shifting the breakpoints) instead of overflowing or
+// truncating the identity, at every representative terminal size.
+func TestLongAccountLabelsWidthInvariant(t *testing.T) {
+	const longName = "Alexander-Maximilian-Extremely-Long-Name"
+	m := layoutModel()
+	m.authProfiles = []authProfile{{ID: "long", Label: "long", Claude: longName, Codex: longName}}
+	wideW := m.genRowWidth() + routingMinW
+	sizes := []termSize{
+		{wideW + 30, 40},
+		{m.mediumMinW() + 2, 40},
+		{m.mediumMinW() - 10, 40},
+		{45, 40},
+		{wideW + 30, 12},
+	}
+	for _, s := range sizes {
+		m = resize(t, m, s.w, s.h)
+		label := fmt.Sprintf("long labels %dx%d", s.w, s.h)
+		assertLayoutInvariants(t, m, label)
+		view := stripAnsi(m.View())
+		if strings.Contains(view, "% used") && !strings.Contains(view, "Codex "+longName) {
+			t.Errorf("%s: visible usage must keep the full account identity:\n%s", label, view)
+		}
+	}
+}
+
+// TestSectionStatePreservation: routing/usage visibility survives resizes,
+// background refreshes, auth switches, and PromptBox proposal round-trips;
+// restoring routing recovers its prior scroll; restoring usage refetches
+// nothing.
+func TestSectionStatePreservation(t *testing.T) {
+	m := multiProfileModel()
+	m.authState = filepath.Join(t.TempDir(), "nested", "selected")
+	wide, medium, narrow, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	m.hideUsage = true
+	m.collapse = true
+
+	for _, s := range []termSize{medium, narrow, wide} {
+		m = resize(t, m, s.w, s.h)
+		if !m.hideUsage || !m.collapse {
+			t.Fatalf("resize to %dx%d mutated section visibility", s.w, s.h)
+		}
+		assertLayoutInvariants(t, m, fmt.Sprintf("hidden sections %dx%d", s.w, s.h))
+	}
+
+	nm, _ := m.Update(usageMsg{profile: "default", avail: m.avail})
+	m = nm.(model)
+	if !m.hideUsage || !m.collapse {
+		t.Fatal("a background refresh mutated section visibility")
+	}
+
+	m, cmd := press(t, m, "a")
+	if cmd == nil {
+		t.Fatal("an auth switch must trigger a usage fetch")
+	}
+	if !m.hideUsage || !m.collapse {
+		t.Fatal("an auth switch mutated section visibility")
+	}
+	if m.activeAuthProfile().ID != "mum" {
+		t.Fatalf("auth switch did not advance the profile: %q", m.activeAuthProfile().ID)
+	}
+	m.fetching = false
+	m.avail = multiProfileModel().avail
+	if panel := stripAnsi(m.usagePanel()); !strings.Contains(panel, "Claude Mum") {
+		t.Errorf("usage headings must follow the switched profile:\n%s", panel)
+	}
+
+	nm, _ = m.Update(clikit.ActionsProposedMsg{})
+	m = nm.(model)
+	nm, _ = m.Update(clikit.ActionsRevertedMsg{})
+	m = nm.(model)
+	if !m.hideUsage || !m.collapse {
+		t.Fatal("a PromptBox proposal round-trip mutated section visibility")
+	}
+
+	// Restoring routing recovers the prior scroll position.
+	sc := layoutModel()
+	id := comboID(defaultSel())
+	rows := []string{"  thinking medium · fallback on · advisor on"}
+	for i := range 40 {
+		rows = append(rows, fmt.Sprintf("    role%02d     gpt-5.6-terra:medium", i))
+	}
+	sc.generated[id] = rows
+	sc = resize(t, sc, wide.w, wide.h)
+	sc.vp.SetYOffset(6)
+	sc, _ = press(t, sc, "p")
+	sc, _ = press(t, sc, "p")
+	if sc.vp.YOffset != 6 {
+		t.Fatalf("routing restore lost the scroll position: YOffset = %d, want 6", sc.vp.YOffset)
+	}
+
+	// Restoring usage refetches nothing: same rows, no command, no fetch.
+	u := layoutModel()
+	u = resize(t, u, wide.w, wide.h)
+	before := stripAnsi(u.View())
+	u, cmd = press(t, u, "s")
+	if cmd != nil {
+		t.Fatal("hiding usage must not produce a command")
+	}
+	u, cmd = press(t, u, "s")
+	if cmd != nil || u.fetching {
+		t.Fatal("restoring usage must not refetch")
+	}
+	if after := stripAnsi(u.View()); after != before {
+		t.Fatalf("usage restore must reproduce the exact prior band:\n--- before ---\n%s\n--- after ---\n%s", before, after)
+	}
+}
+
+// TestCollapseReallocation: hiding a section hands its rows to the active
+// composition immediately — medium's secondary row shrinks to routing-only at
+// full width and the generator absorbs the slack; wide returns the usage band
+// rows to the body; a narrow terminal gains the medium secondary row once the
+// usage column no longer needs seating.
+func TestCollapseReallocation(t *testing.T) {
+	m := layoutModel()
+	wide, medium, narrow, _ := layoutSizes(t, m)
+
+	m = resize(t, m, medium.w, medium.h+8)
+	gen0, sec0 := m.mediumSplit(m.contentH())
+	m, _ = press(t, m, "s")
+	if m.mode() != modeMedium {
+		t.Fatalf("hiding usage at medium width must stay medium, mode = %d", m.mode())
+	}
+	gen1, sec1 := m.mediumSplit(m.contentH())
+	if sec1 >= sec0 || gen1 <= gen0 {
+		t.Errorf("medium reallocation: secondary %d→%d, generator %d→%d — generator must absorb the freed rows", sec0, sec1, gen0, gen1)
+	}
+	if got := m.routingColW(); got != m.w {
+		t.Errorf("routing must span the full secondary row when usage hides: %d, want %d", got, m.w)
+	}
+	assertLayoutInvariants(t, m, "medium usage hidden")
+	m, _ = press(t, m, "s")
+	if gen2, sec2 := m.mediumSplit(m.contentH()); gen2 != gen0 || sec2 != sec0 {
+		t.Errorf("restore must return the original split: got %d/%d, want %d/%d", gen2, sec2, gen0, gen0)
+	}
+
+	w := layoutModel()
+	w = resize(t, w, wide.w, wide.h)
+	ch0 := w.contentH()
+	w, _ = press(t, w, "s")
+	if ch1 := w.contentH(); ch1 <= ch0 {
+		t.Errorf("wide: hiding the usage band must return its rows to the body: %d → %d", ch0, ch1)
+	}
+	assertLayoutInvariants(t, w, "wide usage hidden")
+
+	n := layoutModel()
+	n = resize(t, n, narrow.w, narrow.h)
+	if n.mode() != modeCollapsed {
+		t.Fatalf("fixture: %dx%d must start collapsed", narrow.w, narrow.h)
+	}
+	n, _ = press(t, n, "s")
+	if n.mode() != modeMedium {
+		t.Fatalf("narrow: freeing the usage column must let routing return, mode = %d", n.mode())
+	}
+	lines := strings.Split(stripAnsi(n.View()), "\n")
+	if lineIndex(lines, "routing", "p · hide") < 0 {
+		t.Errorf("narrow with usage hidden: the routing section must reappear:\n%s", strings.Join(lines, "\n"))
+	}
+	assertLayoutInvariants(t, n, "narrow usage hidden")
 }


### PR DESCRIPTION
## Summary
- make Usage a first-class section with profile-derived `Codex <account>` and `Claude <account>` headings
- replace the repetitive auth equation with refresh and optional profile-switch controls in Usage chrome
- move Routing hide and fallback-chain controls into its title chrome
- add conflict-free `s` show/hide Usage behavior while preserving `u` for sandbox and `p` for Routing
- derive compact help from current layout, visibility, profile count, loading state, and actionable controls; keep `?` complete
- prioritize section recovery, full-help discovery, and quit before optional actions when narrow terminals truncate the compact line
- preserve section, scroll, auth, refresh, and responsive-layout state through toggles and reflow

## Regression coverage
- Alex/Alex, Mum/Alex, and Mum/Mum provider/account headings
- single-profile switch-cue omission
- loading, refreshing, unavailable, and profile-switch error states
- every Routing/Usage expanded-collapsed combination and responsive reallocation
- compact/full help derivation, keymap conflict freedom, and narrow-terminal action priority
- long account labels, width invariants, and section state preservation

## Verification
- `CGO_ENABLED=0 go test ./...` and `go vet ./...` in `pkgs/code-tui`
- `nix build .#code-tui`
- `nix build .#checks.x86_64-linux.go-fmt`
- tmux smoke at 150x44, 100x44, and 70x35 with Usage hidden, Routing hidden, both hidden, and full help
- truecolor tmux/freeze inspection of wide, medium, narrow, loading, refreshing, and error states; exact PUA glyph checks

Closes #198