### PR TITLE
code-tui: refine section controls and state

### DIFF
--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -128,6 +128,12 @@ in
         grep -q 'a switches the' "$TMPDIR/code-help.txt"
         grep -q 'visible OMP auth combination' "$TMPDIR/code-help.txt"
         ! grep -q 'pick an OMP launcher' "$TMPDIR/code-help.txt"
+        # The managed generator owns private selection/auth state defaults while
+        # preserving both variables as caller-overridable wrapper inputs.
+        grep -Fq 'export CODE_AUTH_STATE="''${CODE_AUTH_STATE:-''${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/code-auth-profile}"' \
+          ${pkgs.omp-configured}/bin/code
+        grep -Fq 'export CODE_SELECTION_STATE="''${CODE_SELECTION_STATE:-''${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/code-generator-selection.json}"' \
+          ${pkgs.omp-configured}/bin/code
         test ! -e ${pkgs.omp-configured}/bin/pi
         test "$(
           find ${pkgs.omp-configured}/bin -mindepth 1 -maxdepth 1 -printf '%f\n' | sort | paste -sd, -

--- a/pkgs/code-tui/auth_test.go
+++ b/pkgs/code-tui/auth_test.go
@@ -77,7 +77,7 @@ func TestLoadAvailabilityUsesSelectedProfile(t *testing.T) {
 
 // TestUsagePanelNamesWholeAuthCombination locks the #198 identity move: the
 // effective provider/account combination lives in the provider headings
-// ("Codex <account>", "Claude <account>") — a mixed profile reads correctly
+// ("Codex (account)", "Claude (account)") — a mixed profile reads correctly
 // with no standalone auth equation — and the switch cue says "switch profile".
 func TestUsagePanelNamesWholeAuthCombination(t *testing.T) {
 	m := model{
@@ -89,7 +89,7 @@ func TestUsagePanelNamesWholeAuthCombination(t *testing.T) {
 		avail:   availability{bucket: map[string]string{}, reset: map[string]int64{}},
 	}
 	panel := stripAnsi(m.usagePanel())
-	for _, text := range []string{"usage", "Claude Mum", "Codex Alex", "a switch profile"} {
+	for _, text := range []string{"usage", "Claude (Mum)", "Codex (Alex)", "a switch profile"} {
 		if !strings.Contains(panel, text) {
 			t.Fatalf("usage panel missing %q: %q", text, panel)
 		}

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -4,6 +4,7 @@
 //
 //	CODE_GENERATED     : generated.plain (facet-grid blocks, keyed by combo id)
 //	CODE_USAGE         : optional command (space-split) that prints `omp usage --json`
+//	CODE_SELECTION_STATE: optional persisted generator facet choices; empty disables it
 //	CODE_OMP           : the omp-managed executable — launches every trusted session:
 //	                     a generated profile as a one-shot --config, or the managed
 //	                     defaults when nothing was generated
@@ -104,6 +105,16 @@ var (
 	// stKey renders an inline key cue (r, a, s, p) — visually secondary but
 	// readable against the background, per the section-chrome convention.
 	stKey = lipgloss.NewStyle().Foreground(lipgloss.Color(cHead))
+
+	// Title-local hotkey cues (d · defaults, p · hide, s · hide) are quieter
+	// than the footer help: terminals have no portable alpha, so these are
+	// dedicated pre-blended tokens — CHead/CDim mixed ~40% toward the app's
+	// dark backdrop — applied to the whole cue, key included. Pre-blending is
+	// used instead of ANSI faint because faint's dimming factor varies wildly
+	// across terminals (and would double-dim already-muted text). Footer
+	// recovery cues keep the brighter help styles for readability.
+	stCueKey = lipgloss.NewStyle().Foreground(lipgloss.Color("#646b76")) // CHead → backdrop
+	stCue    = lipgloss.NewStyle().Foreground(lipgloss.Color("#4f5768")) // CDim → backdrop
 
 	// layout + meter primitives now live in cli-kit
 	padLeft    = clikit.PadLeft
@@ -885,12 +896,17 @@ const (
 	gut      = 2
 	topGap   = 1
 	headRows = 2
-	// the launch footer pinned under the list: blank + cost + speed + ⏎ launch.
-	launchFooterRows = 4
+	// the launch footer pinned under the list: blank + cost + speed + blank +
+	// the ⏎ launch action on its own visually separated row.
+	launchFooterRows = 5
 	// routingMinW is the narrowest useful routing column: pane chrome plus room
 	// for a lead chain — below this a side-by-side routing panel stops earning
 	// its keep.
 	routingMinW = 33
+	// secSepW is the one-cell border column between medium's adjacent
+	// secondary panes (Routing left, Usage right) — visible separation, same
+	// stroke as the wide layout's routing pane border.
+	secSepW = 1
 	// genMinRows is the fewest facet rows the generator list may be windowed to
 	// before the layout must shed secondary sections instead of compressing it.
 	genMinRows = 4
@@ -960,12 +976,13 @@ func (m model) mediumMinH() int {
 }
 
 // mediumMinW: the secondary row must seat a useful routing viewport beside the
-// measured usage column without clipping either.
+// measured usage column — plus the one-cell separator between them — without
+// clipping either.
 func (m model) mediumMinW() int {
 	if m.hideUsage {
 		return routingMinW
 	}
-	return routingMinW + m.usageColW()
+	return routingMinW + secSepW + m.usageColW()
 }
 
 // footerH measures the pinned footer for a composition directly from its parts
@@ -1012,12 +1029,12 @@ func (m model) bodyLines() ([]string, int) {
 // no overlay, and the sandbox (u) key is always offered.
 func (m model) launchFooter() []string {
 	cs, ss := m.costScore(), m.speedScore()
-	cta := "⏎ launch generated profile"
-	acc := lipgloss.NewStyle().Foreground(lipgloss.Color(m.accent())).Bold(true).Render("  " + cta)
+	acc := lipgloss.NewStyle().Foreground(lipgloss.Color(m.accent())).Bold(true).Render("  ⏎ launch")
 	return []string{
 		"",
 		m.meter("cost", "$", meterRamp[cs], cs), // dear → red, cheap → green
 		m.meter("speed", "»", meterRamp[6-ss], ss), // fast → green, slow → red
+		"", // breathing room between the meters and the action row
 		acc + stDim.Render("   m managed omp · u sandbox"),
 	}
 }
@@ -1055,11 +1072,11 @@ func (m model) previewDims() (int, int) {
 }
 
 // routingColW is the medium secondary row's routing share: whatever the
-// measured usage column leaves free.
+// measured usage column (and the separator between the panes) leaves free.
 func (m model) routingColW() int {
 	w := m.w
 	if !m.hideUsage {
-		w -= m.usageColW()
+		w -= m.usageColW() + secSepW
 	}
 	if w < routingMinW {
 		w = routingMinW
@@ -1070,10 +1087,12 @@ func (m model) routingColW() int {
 // ── trackpad / mouse wheel ───────────────────────────────────────────────────
 // The wheel drives the generator directly: vertical scroll moves the facet
 // selection, horizontal scroll changes the selected facet's value. Terminals
-// (and SSH) offer no haptic channel, so the "detent" is temporal: a wheelGate
-// axis-locks each gesture and rations steps, letting a trackpad fling or
-// diagonal jitter advance at most one controlled step while a single detented
-// wheel click still acts immediately.
+// (and SSH) offer no haptic channel, so the "detent" is temporal — and HARD:
+// a wheelGate axis-locks each gesture and grants exactly ONE step per
+// gesture; every further event (same-axis repeats and diagonal jitter alike)
+// is swallowed until an idle pause releases the detent. A single detented
+// wheel click still acts immediately. The hard detent is scoped to the
+// generator: the Routing viewport scrolls continuously (see wheelInRouting).
 const (
 	wheelAxisNone = iota
 	wheelAxisV
@@ -1081,38 +1100,26 @@ const (
 )
 
 // wheelIdle is the longest gap between wheel events that still reads as one
-// continuous gesture — a pause beyond it starts a fresh (immediate) step.
-// wheelRepeat rations further steps inside a held gesture, so a deliberate
-// continuous scroll advances at a controlled cadence instead of per event.
-const (
-	wheelIdle   = 200 * time.Millisecond
-	wheelRepeat = 300 * time.Millisecond
-)
+// continuous gesture — only a pause beyond it (a release) re-arms the next
+// immediate step.
+const wheelIdle = 200 * time.Millisecond
 
 // wheelGate arbitrates raw wheel events into discrete facet steps.
 type wheelGate struct {
-	axis   int       // locked gesture axis (wheelAxisNone when idle)
-	last   time.Time // last event seen — orthogonal jitter keeps the lock alive
-	stepAt time.Time // last event that was allowed to act
+	axis int       // locked gesture axis (wheelAxisNone when idle)
+	last time.Time // last event seen — any event keeps the gesture (and lock) alive
 }
 
 // admit reports whether a wheel event on axis a at time t may act. The first
 // event after an idle pause acts immediately and locks the gesture to its
-// axis; while locked, orthogonal events are swallowed (diagonal jitter) and
-// same-axis events act only every wheelRepeat (burst resistance).
+// axis; everything else inside the gesture — orthogonal jitter and same-axis
+// repeats — is swallowed. There is no held-gesture repeat: the pointer must
+// pause (or lift) for wheelIdle before the next step.
 func (g *wheelGate) admit(a int, t time.Time) bool {
 	fresh := g.axis == wheelAxisNone || t.Sub(g.last) > wheelIdle
 	g.last = t
 	if fresh {
 		g.axis = a
-		g.stepAt = t
-		return true
-	}
-	if a != g.axis {
-		return false
-	}
-	if t.Sub(g.stepAt) >= wheelRepeat {
-		g.stepAt = t
 		return true
 	}
 	return false
@@ -1130,9 +1137,10 @@ type model struct {
 	showResult bool // in collapsed mode: show the preview full-width
 	hideUsage  bool // s: hide the Usage section (#198); fetch state keeps running unseen
 
-	facets []facet
-	fcur   int
-	sel    map[string]string
+	facets         []facet
+	fcur           int
+	sel            map[string]string
+	selectionState string // CODE_SELECTION_STATE; empty keeps standalone runs stateless
 
 	wheel wheelGate // trackpad/mouse wheel arbiter: axis lock + step resistance
 
@@ -1150,6 +1158,8 @@ type model struct {
 
 	fetching    bool      // a usage fetch is in flight (manual or auto)
 	nextRefresh time.Time // when the next auto-refresh fires
+	hadUsage    bool      // a successful fetch has landed — gates the one-time first-load bar fill
+	barAnim     int       // first-load fill frame (1..barAnimSteps-1 = partial); 0 = inactive, bars at full value
 
 	launchManaged   bool              // m: run CODE_OMP with no overlay (the managed defaults)
 	launchUntrusted bool              // u: run the CODE_OMP_UNTRUSTED sandbox
@@ -1181,6 +1191,25 @@ func fetchUsageCmd(cmd, profile string) tea.Cmd {
 		return nil
 	}
 	return func() tea.Msg { return usageMsg{profile: profile, avail: loadAvailability(cmd, profile)} }
+}
+
+// First-load bar fill: the one-time animation that grows each usage bar from
+// empty to its real value when the FIRST successful fetch replaces the loading
+// skeleton. A dedicated bounded tick sequence — barAnimSteps frames at
+// barAnimInterval (8 × 25ms = 200ms total) — renders every bar's fill at
+// step/steps of its target; labels and numbers are real from the first frame,
+// only the fill animates. Refreshes (manual, auto, or post-switch) never
+// re-run it, and each tick schedules nothing beyond the next frame.
+const (
+	barAnimSteps    = 8
+	barAnimInterval = 25 * time.Millisecond
+)
+
+// barAnimMsg advances the first-load fill to the given frame (2..barAnimSteps).
+type barAnimMsg struct{ step int }
+
+func barAnimCmd(step int) tea.Cmd {
+	return tea.Tick(barAnimInterval, func(time.Time) tea.Msg { return barAnimMsg{step} })
 }
 
 func (m model) Init() tea.Cmd {
@@ -1295,18 +1324,20 @@ func (m *model) usageCtrlLine() string {
 }
 
 // providerHeading names a provider usage group by its effective identity —
-// "Codex <account>" / "Claude <account>", derived from the active auth
-// profile — so mixed profiles (Claude Mum + Codex Alex) read correctly with
-// no prose equation, in text rather than color alone.
+// "Codex (account)" / "Claude (account)", derived from the active auth
+// profile — so mixed profiles (Claude (Mum) + Codex (Alex)) read correctly
+// with no prose equation, in text rather than color alone. The parenthesized
+// owner is dimmed so the provider name stays the heading's anchor.
 func providerHeading(prov string, p authProfile) string {
 	col, name, acct := "#62a7ff", "Codex", p.Codex
 	if prov == "anthropic" {
 		col, name, acct = "#ff9f52", "Claude", p.Claude
 	}
+	out := lipgloss.NewStyle().Foreground(lipgloss.Color(col)).Bold(true).Render(name)
 	if acct != "" {
-		name += " " + acct
+		out += " " + stDim.Render("("+acct+")")
 	}
-	return lipgloss.NewStyle().Foreground(lipgloss.Color(col)).Bold(true).Render(name)
+	return out
 }
 
 // identityLines renders the effective provider/account headings on their own —
@@ -1323,25 +1354,37 @@ func (m *model) identityLines() string {
 func (m *model) usagePanel() string { return m.usagePanelFor(m.w) }
 
 // usagePanelFor renders the first-class Usage section: the pilled title with
-// its local hide cue, the refresh/switch control row, and the per-provider
-// usage groups headed by the effective provider/account identity. Provider
-// groups sit side by side only when w seats every column; w <= 0 forces the
-// vertical stack (the medium layout's narrow usage column).
+// its local hide cue, the per-provider usage groups headed by the effective
+// provider/account identity, and the refresh/switch control row at the
+// section's bottom edge — below the content it governs. Provider groups sit
+// side by side only when w seats every column; w <= 0 forces the vertical
+// stack (the medium layout's narrow usage column).
 func (m *model) usagePanelFor(w int) string {
-	out := padLeft(m.pill("usage")+"  "+stKey.Render("s")+stDim.Render(" · hide"), gut) + "\n"
+	out := padLeft(m.pill("usage")+"  "+stCueKey.Render("s")+stCue.Render(" · hide"), gut) + "\n" +
+		"\n" + m.usageBodyFor(w)
 	if ctrl := m.usageCtrlLine(); ctrl != "" {
 		out += "\n" + ctrl
 	}
+	return out
+}
+
+// usageBodyFor renders the provider/account content between the pinned title
+// and the bottom control row: the identity-headed usage groups, or the
+// loading/unavailable identity block.
+func (m *model) usageBodyFor(w int) string {
 	p := m.activeAuthProfile()
 	if !m.avail.ok {
-		out += "\n" + m.identityLines()
+		if m.usageLoading() {
+			return m.skeletonBody(w, p)
+		}
+		out := m.identityLines()
 		if m.usageCmd != "" && !m.fetching && !m.nextRefresh.IsZero() {
 			out += "\n" + stWarn.Render("  usage unavailable · authenticate with omp --profile "+p.ID)
 		}
 		return out
 	}
 	if len(m.avail.wins) == 0 {
-		return out + "\n" + m.identityLines() + "\n" +
+		return m.identityLines() + "\n" +
 			stWarn.Render("  no provider usage · authenticate with omp --profile "+p.ID)
 	}
 	wins := append([]usageWin(nil), m.avail.wins...)
@@ -1383,9 +1426,16 @@ func (m *model) usagePanelFor(w int) string {
 			blocks["openai-codex"] = append(b, cl)
 		}
 	}
-	// side-by-side when there's horizontal room, else stacked. colW must fit the
-	// widest row (label · bar · pct · ↻reset · note) without wrapping the note;
-	// a long account name widens the column instead of truncating the identity.
+	return layoutGroups(w, order, blocks)
+}
+
+// layoutGroups arranges per-provider row blocks side by side when w seats
+// every measured column, else stacked with a blank line between groups —
+// shared by the real usage body and the loading skeleton so the two agree on
+// geometry and the first fetch never pops the layout. colW must fit the
+// widest row (label · bar · pct · ↻reset · note) without wrapping the note;
+// a long account name widens the column instead of truncating the identity.
+func layoutGroups(w int, order []string, blocks map[string][]string) string {
 	colW := 49
 	for _, prov := range order {
 		if hw := lipgloss.Width(blocks[prov][0]) + 2; hw > colW {
@@ -1397,7 +1447,7 @@ func (m *model) usagePanelFor(w int) string {
 		for _, prov := range order {
 			cols = append(cols, lipgloss.NewStyle().Width(colW).Render(strings.Join(blocks[prov], "\n")))
 		}
-		return out + "\n" + lipgloss.JoinHorizontal(lipgloss.Top, cols...)
+		return lipgloss.JoinHorizontal(lipgloss.Top, cols...)
 	}
 	var lines []string
 	for i, prov := range order {
@@ -1406,7 +1456,44 @@ func (m *model) usagePanelFor(w int) string {
 		}
 		lines = append(lines, blocks[prov]...)
 	}
-	return out + "\n" + strings.Join(lines, "\n")
+	return strings.Join(lines, "\n")
+}
+
+// usageLoading reports the initial-fetch state: a usage command exists but no
+// successful result has ever landed and one is pending (in flight, or queued
+// before the first tick) — the window where Usage shows the layout-stable
+// skeleton instead of popping from an identity stub to full provider groups.
+func (m *model) usageLoading() bool {
+	return m.usageCmd != "" && !m.avail.ok && (m.fetching || m.nextRefresh.IsZero())
+}
+
+// skeletonWins are the loading skeleton's placeholder windows: both supported
+// providers expose a 5-hour rolling window and a weekly window, so the
+// skeleton mirrors that standard shape — real labels, empty bars, dotted
+// placeholders — without fabricating numbers the fetch hasn't produced.
+var skeletonWins = [...]string{"5h", "7d"}
+
+// skeletonRow is a placeholder usage row: the real row's exact geometry with
+// an empty bar and ·· placeholders for the percentage and reset time.
+func skeletonRow(label string) string {
+	return fmt.Sprintf("  %-9s %s %s used  %s", label, barStr(0),
+		stDim.Render(" ··%"), stDim.Render(gReset+" ··"))
+}
+
+// skeletonBody is the pre-first-fetch Usage content: the provider/account
+// headings with generic placeholder window rows, laid out by the same group
+// logic as real data so the first result lands without a layout pop.
+func (m *model) skeletonBody(w int, p authProfile) string {
+	order := []string{"openai-codex", "anthropic"}
+	blocks := map[string][]string{}
+	for _, prov := range order {
+		rows := []string{padLeft(providerHeading(prov, p), gut)}
+		for _, label := range skeletonWins {
+			rows = append(rows, skeletonRow(label))
+		}
+		blocks[prov] = rows
+	}
+	return layoutGroups(w, order, blocks)
 }
 
 // usageColumn is the medium layout's right-hand Usage section: the panel with
@@ -1453,11 +1540,56 @@ func (m *model) usageRow(w usageWin) string {
 	} else if w.dur > 0 && w.secs*4 < w.dur {
 		reset = lipgloss.NewStyle().Foreground(lipgloss.Color("#c8d0dc")).Render(gReset + " " + fmtReset(w.secs))
 	}
-	return fmt.Sprintf("  %-9s %s %3d%% used  %s%s", shortWin(w.label), barStr(w.pct), w.pct, reset, note)
+	// During the one-time first-load fill only the bar is scaled toward its
+	// target; the label, percentage, and reset text are real from frame one.
+	pct := w.pct
+	if m.barAnim > 0 {
+		pct = pct * m.barAnim / barAnimSteps
+	}
+	return fmt.Sprintf("  %-9s %s %3d%% used  %s%s", shortWin(w.label), barStr(pct), w.pct, reset, note)
+}
+
+// Reset-credit expiry urgency tints: each individual expiry (`3d`, `12d`, …)
+// in the credit line is colored on a muted red→amber→green ramp so soon
+// expiries read as warnings and distant ones as headroom, while the icon,
+// count, and connecting prose stay dim. The palette is precomputed and
+// deliberately desaturated (no per-frame color math, no saturated alarm
+// colors inside a dim summary row); the day text itself stays sufficient
+// without color. Thresholds are whole days remaining, exactly as fmtDays
+// rounds them (up, so later-today = 1): ≤ creditUrgentDays is muted red,
+// ≤ creditSoonDays muted amber, anything later muted green.
+const (
+	creditUrgentDays = 3  // expiring within three days — spend it or lose it
+	creditSoonDays   = 10 // within ten days — plan around it
+)
+
+var (
+	stCreditUrgent = lipgloss.NewStyle().Foreground(lipgloss.Color("#b0716f")) // muted red
+	stCreditSoon   = lipgloss.NewStyle().Foreground(lipgloss.Color("#b39c6b")) // muted amber
+	stCreditSafe   = lipgloss.NewStyle().Foreground(lipgloss.Color("#85a883")) // muted green
+)
+
+// creditDayStyle picks the urgency tint for a credit expiring in s seconds,
+// bucketing on the same rounded-up whole days fmtDays renders — the color and
+// the text can never disagree about which side of a threshold an expiry is on.
+func creditDayStyle(s int64) lipgloss.Style {
+	d := int64(0)
+	if s > 0 {
+		d = (s + 86399) / 86400
+	}
+	switch {
+	case d <= creditUrgentDays:
+		return stCreditUrgent
+	case d <= creditSoonDays:
+		return stCreditSoon
+	default:
+		return stCreditSafe
+	}
 }
 
 // creditLine renders the OpenAI reset-credit summary: the available count and
-// the days remaining until the three soonest credit expirations, ascending.
+// the days remaining until the three soonest credit expirations, ascending —
+// each expiry tinted by creditDayStyle while the surrounding prose stays dim.
 func (m *model) creditLine() string {
 	c := m.avail.credits
 	if c.avail == 0 && len(c.exp) == 0 {
@@ -1472,15 +1604,15 @@ func (m *model) creditLine() string {
 	if c.avail == 1 {
 		noun = "reset"
 	}
-	line := fmt.Sprintf("%d %s", c.avail, noun)
+	line := stDim.Render(gReset + " " + fmt.Sprintf("%d %s", c.avail, noun))
 	if len(exp) > 0 {
 		days := make([]string, len(exp))
 		for i, s := range exp {
-			days[i] = fmtDays(s)
+			days[i] = creditDayStyle(s).Render(fmtDays(s))
 		}
-		line += " · expiring in " + strings.Join(days, ", ")
+		line += stDim.Render(" · expiring in ") + strings.Join(days, stDim.Render(", "))
 	}
-	return "  " + stDim.Render(gReset+" "+line)
+	return "  " + line
 }
 
 // fmtDays renders a relative duration as whole days remaining, rounding up so
@@ -1622,7 +1754,12 @@ func (h helpKeys) FullHelp() [][]key.Binding { return h.full }
 //
 // Everything else lives in visible section chrome or behind ?.
 func (m model) contextHelp() helpKeys {
-	short := []key.Binding{keys.Move, keys.Change, keys.Reset}
+	short := []key.Binding{keys.Move, keys.Change}
+	// The generator title advertises d · defaults itself; the compact line
+	// repeats it only while that chrome is off screen (routing full-screen).
+	if !m.generatorShown() {
+		short = append(short, keys.Reset)
+	}
 	if !m.routingShown() {
 		short = append(short, key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "show routing")))
 	}
@@ -1671,12 +1808,32 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.relayout()
 	case usageMsg:
 		if msg.profile != m.activeAuthProfile().ID {
-			return m, nil
+			return m, nil // stale profile: never applied, never starts the fill
 		}
+		first := !m.hadUsage && msg.avail.ok
 		m.avail = msg.avail
+		m.hadUsage = m.hadUsage || msg.avail.ok
 		m.fetching = false
 		m.nextRefresh = time.Now().Add(refreshEvery)
 		m.relayout()
+		if first {
+			// The first real data replaces the skeleton: run the one-time
+			// bounded bar fill. Refreshes never reach this branch again.
+			m.barAnim = 1
+			return m, barAnimCmd(2)
+		}
+	case barAnimMsg:
+		// Bounded and self-terminating: apply the frame, arm the next tick,
+		// and stop at the final step (barAnim 0 = inactive, bars at value).
+		if m.barAnim == 0 {
+			return m, nil
+		}
+		if msg.step >= barAnimSteps {
+			m.barAnim = 0
+			return m, nil
+		}
+		m.barAnim = msg.step
+		return m, barAnimCmd(msg.step + 1)
 	case refreshTickMsg:
 		// re-arm the 1s tick; auto-refresh once the interval elapses.
 		cmds := []tea.Cmd{tickCmd()}
@@ -1692,9 +1849,22 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 	case tea.MouseMsg:
-		// Wheel → generator control (see wheelGate). The routing preview keeps
-		// its keyboard scrolling; wheel input deliberately owns facet steps.
+		// Wheel dispatch by pointer position: inside the visible Routing pane
+		// the viewport owns vertical scrolling — continuous, ungated, clamped
+		// by the viewport itself, with horizontal wheel deliberately inert.
+		// Everywhere else the wheel drives the generator through the hard
+		// one-step-per-gesture detent (see wheelGate). Scrolling never touches
+		// the facet selection, so only real generator changes persist.
 		if msg.Action == tea.MouseActionPress {
+			if m.wheelInRouting(msg.X, msg.Y) {
+				switch msg.Button {
+				case tea.MouseButtonWheelUp:
+					m.vp.LineDown(1) // inverted: operator-confirmed trackpad direction
+				case tea.MouseButtonWheelDown:
+					m.vp.LineUp(1)
+				}
+				return m, nil
+			}
 			m.wheelStep(msg.Button, time.Now())
 		}
 	case tea.KeyMsg:
@@ -1722,6 +1892,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.relayout() // the taller/shorter footer changes the body height
 		case "d":
 			m.sel = defaultSel()
+			m.persistSelection()
 			m.syncPreview()
 		case "f":
 			m.depth = (m.depth + 1) % 2
@@ -1791,6 +1962,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Kept: the preview stays; remember the prompt for the launched session.
 		m.savedSel = nil
 		m.firstPrompt = msg.Prompt
+		m.persistSelection()
 
 	case clikit.ActionsRevertedMsg:
 		// Rejected: restore the pre-preview selection.
@@ -1803,27 +1975,52 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// wheelInRouting reports whether a pointer position (terminal cells, 0-based)
+// falls inside the visible Routing pane, whose viewport then owns vertical
+// wheel scrolling: the wide split's right pane, medium's lower-left pane, or
+// the narrow routing-only swap's full body. Hidden/collapsed routing claims
+// nothing, so the generator keeps the wheel everywhere else.
+func (m model) wheelInRouting(x, y int) bool {
+	if !m.routingShown() {
+		return false
+	}
+	ch := m.contentH()
+	switch m.mode() {
+	case modeCollapsed: // routing-only swap: the whole body is Routing
+		return y >= topGap && y < topGap+ch
+	case modeMedium: // the secondary row's left column, under the divider
+		genH, secH := m.mediumSplit(ch)
+		secTop := topGap + genH + 1
+		return y >= secTop && y < secTop+secH && x < m.routingColW()
+	default: // split: the right pane, from the list's right edge on
+		return y >= topGap && y < topGap+ch && x >= m.listW()
+	}
+}
+
 // wheelStep translates an admitted wheel event into the matching facet action:
 // vertical scroll moves the selection, horizontal scroll changes the value.
-// Facet semantics stay untouched — these are the exact arrow-key handlers,
-// merely rationed by the wheelGate.
+// The raw mapping is INVERTED on both axes — operator-confirmed trackpad
+// direction: WheelUp moves the selection down, WheelDown up; WheelLeft cycles
+// to the next (right) option, WheelRight to the previous. Arrow keys keep
+// their literal semantics; the handlers themselves are untouched and merely
+// rationed by the wheelGate.
 func (m *model) wheelStep(b tea.MouseButton, t time.Time) {
 	switch b {
 	case tea.MouseButtonWheelUp:
 		if m.wheel.admit(wheelAxisV, t) {
-			m.moveUp()
+			m.moveDown()
 		}
 	case tea.MouseButtonWheelDown:
 		if m.wheel.admit(wheelAxisV, t) {
-			m.moveDown()
+			m.moveUp()
 		}
 	case tea.MouseButtonWheelLeft:
 		if m.wheel.admit(wheelAxisH, t) {
-			m.cycleFacet(-1)
+			m.cycleFacet(1)
 		}
 	case tea.MouseButtonWheelRight:
 		if m.wheel.admit(wheelAxisH, t) {
-			m.cycleFacet(1)
+			m.cycleFacet(-1)
 		}
 	}
 }
@@ -1864,6 +2061,7 @@ func (m *model) cycleFacet(dir int) {
 		m.fcur = nv - 1
 	}
 	m.syncPreview()
+	m.persistSelection()
 }
 
 // prevPadL is the split preview pane's left padding. Width() counts it, so the
@@ -1900,30 +2098,32 @@ func (m model) sectionTitle() string {
 	return m.pill("generator")
 }
 
-// sectionHead is the gutter-inset title plus a blank separator (headRows tall);
-// it stays pinned above the scrolling facet list.
+// sectionHead is the gutter-inset title row — the pill plus its local
+// reset-to-defaults cue (d · defaults) — and a blank separator (headRows
+// tall); it stays pinned above the scrolling facet list.
 func (m model) sectionHead() string {
-	return padLeft(m.sectionTitle(), gut) + "\n\n"
+	return padLeft(m.sectionTitle()+"  "+stCueKey.Render("d")+stCue.Render(" · defaults"), gut) + "\n\n"
 }
 
-// prevChromeRows is the Routing column's pinned chrome above the scrolling
-// viewport: the title row with its local collapse cue, the fallback-display
-// cue beneath it, and a blank separator.
+// prevChromeRows is the Routing column's pinned chrome around the scrolling
+// viewport: the title row with its local collapse cue and a blank separator
+// above, plus the fallback-display cue pinned beneath the viewport.
 const prevChromeRows = headRows + 1
 
 // previewColumn assembles the Routing section: the pinned title row carrying
-// the section-local collapse cue (p · hide), the fallback-display cue directly
-// beneath it — Routing chrome, not a detached bottom row (#198) — then the
-// scrolling routing viewport. The f wording makes clear it only changes what
-// is DISPLAYED: the launched profile always keeps its fallback chains.
+// the section-local collapse cue (p · hide), the scrolling routing viewport,
+// then the fallback-display cue pinned at the section's bottom edge — bottom
+// chrome, where the chains it toggles end. The f wording makes clear it only
+// changes what is DISPLAYED: the launched profile always keeps its fallback
+// chains.
 func (m model) previewColumn() string {
 	verb := "show"
 	if m.depth == 1 {
 		verb = "hide"
 	}
-	return m.pill("routing") + "  " + stKey.Render("p") + stDim.Render(" · hide") + "\n" +
-		stKey.Render("f") + stDim.Render(" · "+verb+" fallback chains") + "\n\n" +
-		m.vp.View()
+	return m.pill("routing") + "  " + stCueKey.Render("p") + stCue.Render(" · hide") + "\n\n" +
+		m.vp.View() + "\n" +
+		stKey.Render("f") + stDim.Render(" · "+verb+" fallback chains")
 }
 
 // leftColumn renders the pinned section head plus the scrolling list body, the
@@ -1941,9 +2141,10 @@ func (m model) leftColumn(w, totalH int) string {
 }
 
 // mediumContent is the generator-dominant layout: the full-width facet list on
-// top (primary), a divider, then Routing and Usage side by side in a secondary
-// row. Routing keeps its own scrolling viewport; Usage stacks its provider
-// groups vertically inside the measured-width right column.
+// top (primary), a divider, then Routing (left) and Usage (right) side by side
+// in a secondary row, separated by a one-cell border column. Routing keeps its
+// own scrolling viewport; Usage stacks its provider groups vertically inside
+// the measured-width right column.
 func (m model) mediumContent(bodyH int) string {
 	genH, secH := m.mediumSplit(bodyH)
 	top := m.leftColumn(m.w, genH)
@@ -1955,8 +2156,10 @@ func (m model) mediumContent(bodyH int) string {
 		lipgloss.NewStyle().MaxWidth(rw).Render(padLeft(m.previewColumn(), gut)))
 	sec := routing
 	if !m.hideUsage {
-		usage := lipgloss.NewStyle().MaxWidth(m.w - rw).MaxHeight(secH).Render(m.usageColumn())
-		sec = lipgloss.JoinHorizontal(lipgloss.Top, routing, usage)
+		sep := lipgloss.NewStyle().Foreground(lipgloss.Color(cBord)).Render(
+			strings.TrimSuffix(strings.Repeat("│\n", secH), "\n"))
+		usage := lipgloss.NewStyle().MaxWidth(m.w - rw - secSepW).MaxHeight(secH).Render(m.usageColumn())
+		sec = lipgloss.JoinHorizontal(lipgloss.Top, routing, sep, usage)
 	}
 	return lipgloss.JoinVertical(lipgloss.Left, top, div, sec)
 }
@@ -2083,21 +2286,24 @@ func main() {
 	authProfiles := parseAuthProfiles(os.Getenv("CODE_AUTH_PROFILES"))
 	authState := os.Getenv("CODE_AUTH_STATE")
 	authIdx := selectedAuthIndex(authProfiles, authState)
+	facets := facetDefs(glyphs)
+	selectionState := os.Getenv("CODE_SELECTION_STATE")
 	m := model{
-		generated:    generated,
-		advisors:     parseAdvisors(generated["__advisors__"]),
-		facts:        parseFacts(generated["__models__"]),
-		avail:        availability{bucket: map[string]string{}, reset: map[string]int64{}},
-		usageCmd:     os.Getenv("CODE_USAGE"),
-		authProfiles: authProfiles,
-		authIdx:      authIdx,
-		authState:    authState,
-		fetching:     os.Getenv("CODE_USAGE") != "",
-		spin:         sp,
-		help:         help.New(),
-		glyphs:       glyphs,
-		facets:       facetDefs(glyphs),
-		sel:          defaultSel(),
+		generated:      generated,
+		advisors:       parseAdvisors(generated["__advisors__"]),
+		facts:          parseFacts(generated["__models__"]),
+		avail:          availability{bucket: map[string]string{}, reset: map[string]int64{}},
+		usageCmd:       os.Getenv("CODE_USAGE"),
+		authProfiles:   authProfiles,
+		authIdx:        authIdx,
+		authState:      authState,
+		fetching:       os.Getenv("CODE_USAGE") != "",
+		spin:           sp,
+		help:           help.New(),
+		glyphs:         glyphs,
+		facets:         facets,
+		sel:            loadSelectionState(selectionState, facets),
+		selectionState: selectionState,
 	}
 	// Cell-motion mouse reporting feeds the trackpad/wheel facet control (see
 	// wheelGate); it is the narrowest mode that carries wheel events. The

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -419,10 +419,10 @@ func TestApplyAdvisorFableMain(t *testing.T) {
 	}
 }
 
-// TestPreviewColumn locks the Routing section's shape (#198): the title row
-// carries the section-local collapse cue (p · hide), the fallback-display cue
-// sits directly beneath the title as Routing chrome (worded as a show/hide
-// DISPLAY toggle) rather than on a detached bottom row, and no baked
+// TestPreviewColumn locks the Routing section's shape: the title row carries
+// the section-local collapse cue (p · hide), the fallback-display cue is
+// pinned to the section's LAST row — bottom chrome under the viewport, no
+// longer top chrome — worded as a show/hide DISPLAY toggle, and no baked
 // settings-summary line reaches the preview (the dials are visible on the
 // left).
 func TestPreviewColumn(t *testing.T) {
@@ -446,11 +446,11 @@ func TestPreviewColumn(t *testing.T) {
 	if !strings.Contains(rows[0], "routing") || !strings.Contains(rows[0], "p · hide") {
 		t.Errorf("title row must carry the routing pill and its local collapse cue, got %q", rows[0])
 	}
-	if strings.TrimSpace(rows[1]) != "f · show fallback chains" {
-		t.Errorf("fallback cue must sit under the title as chrome, got %q", rows[1])
+	if strings.Contains(rows[0], "fallback") || strings.Contains(rows[1], "fallback") {
+		t.Errorf("the fallback cue must leave the top chrome, got %q / %q", rows[0], rows[1])
 	}
-	if tail := strings.TrimSpace(rows[len(rows)-1]); strings.Contains(tail, "fallback") {
-		t.Errorf("no detached bottom hint row may remain, got %q", tail)
+	if tail := strings.TrimSpace(rows[len(rows)-1]); tail != "f · show fallback chains" {
+		t.Errorf("the fallback cue must be pinned to the section's last row, got %q", tail)
 	}
 	m.depth = 1
 	if plain := stripAnsi(m.previewColumn()); !strings.Contains(plain, "f · hide fallback chains") {
@@ -606,7 +606,7 @@ func TestResponsiveCompositions(t *testing.T) {
 	lines = strings.Split(stripAnsi(m.View()), "\n")
 	gen := lineIndex(lines, "generator")
 	sec := lineIndex(lines, "routing", "usage")
-	launch := lineIndex(lines, "launch generated profile")
+	launch := lineIndex(lines, "⏎ launch")
 	if gen < 0 || sec < 0 || launch < 0 {
 		t.Fatalf("medium: missing generator (%d), secondary row (%d), or launch footer (%d):\n%s", gen, sec, launch, strings.Join(lines, "\n"))
 	}
@@ -837,11 +837,11 @@ func TestResizeScrollClamp(t *testing.T) {
 
 // ── trackpad / wheel gating ──────────────────────────────────────────────────
 
-// TestWheelGate locks the temporal detent: the first event of a gesture acts
-// immediately (real wheel clicks feel instant), a rapid same-axis burst is
-// absorbed after that one step, orthogonal jitter inside the locked gesture
-// never leaks a step (and keeps the lock alive), a held scroll advances at the
-// controlled wheelRepeat cadence, and a pause re-arms an immediate step.
+// TestWheelGate locks the HARD temporal detent: the first event of a gesture
+// acts immediately (real wheel clicks feel instant), then the gesture is
+// spent — same-axis repeats and orthogonal jitter alike are absorbed, with no
+// held-gesture repeat cadence — until an idle pause (a release) longer than
+// wheelIdle re-arms the next immediate step.
 func TestWheelGate(t *testing.T) {
 	t0 := time.Unix(1000, 0)
 	var g wheelGate
@@ -858,39 +858,43 @@ func TestWheelGate(t *testing.T) {
 		t.Fatal("orthogonal jitter inside a vertical gesture must not act")
 	}
 	if g.admit(wheelAxisV, t0.Add(170*time.Millisecond)) {
-		t.Fatal("jitter must keep the lock alive — same-axis event still rationed")
+		t.Fatal("jitter must keep the lock alive — the gesture stays spent")
 	}
-	if !g.admit(wheelAxisV, t0.Add(310*time.Millisecond)) {
-		t.Fatal("a held deliberate scroll must advance after wheelRepeat")
+	// A held continuous scroll NEVER advances again: events every 100ms keep
+	// the gesture alive for two more seconds without a single extra step.
+	last := t0.Add(170 * time.Millisecond)
+	for i := 1; i <= 20; i++ {
+		last = last.Add(100 * time.Millisecond)
+		if g.admit(wheelAxisV, last) {
+			t.Fatalf("a held gesture must never repeat (event %d)", i)
+		}
 	}
-	if g.admit(wheelAxisV, t0.Add(320*time.Millisecond)) {
-		t.Fatal("the cadence must re-arm after each granted step")
-	}
-	if !g.admit(wheelAxisH, t0.Add(700*time.Millisecond)) {
-		t.Fatal("after an idle pause a deliberate step on any axis must act immediately")
+	if !g.admit(wheelAxisH, last.Add(wheelIdle+50*time.Millisecond)) {
+		t.Fatal("after an idle release a deliberate step on any axis must act immediately")
 	}
 	if g.axis != wheelAxisH {
 		t.Fatalf("gate must re-lock to the new axis, got %d", g.axis)
 	}
 }
 
-// TestWheelStepsFacets locks the wheel→facet mapping with a controlled clock:
-// vertical steps move the selection, horizontal steps change the focused
-// facet's value, bursts and diagonal jitter advance at most one step, and
-// later deliberate steps land after a pause. Facet semantics are the arrow-key
-// handlers verbatim.
+// TestWheelStepsFacets locks the wheel→facet mapping with a controlled clock.
+// Both axes are INVERTED relative to the raw event names (operator-confirmed
+// trackpad direction): WheelUp moves the selection DOWN and WheelDown UP;
+// WheelLeft cycles to the NEXT (right) option and WheelRight to the previous.
+// Bursts and diagonal jitter still advance at most one step, and later
+// deliberate steps land after a pause. Arrow-key semantics are untouched.
 func TestWheelStepsFacets(t *testing.T) {
 	m := layoutModel()
 	wide, _, _, _ := layoutSizes(t, m)
 	m = resize(t, m, wide.w, wide.h)
 	t0 := time.Unix(1000, 0)
 
-	m.wheelStep(tea.MouseButtonWheelDown, t0)
+	m.wheelStep(tea.MouseButtonWheelUp, t0)
 	if m.fcur != 1 {
-		t.Fatalf("wheel down must move the selection, fcur = %d", m.fcur)
+		t.Fatalf("wheel UP must move the selection DOWN (inverted), fcur = %d", m.fcur)
 	}
 	for i := 1; i <= 20; i++ { // same-axis burst: at most that one step
-		m.wheelStep(tea.MouseButtonWheelDown, t0.Add(time.Duration(i)*5*time.Millisecond))
+		m.wheelStep(tea.MouseButtonWheelUp, t0.Add(time.Duration(i)*5*time.Millisecond))
 	}
 	if m.fcur != 1 {
 		t.Fatalf("a wheel burst must advance one controlled step, fcur = %d", m.fcur)
@@ -903,14 +907,26 @@ func TestWheelStepsFacets(t *testing.T) {
 		t.Fatalf("diagonal jitter must not change facet values: model %q → %q", sel, m.sel["model"])
 	}
 
-	t1 := t0.Add(time.Second) // deliberate later gesture on the other axis
-	m.wheelStep(tea.MouseButtonWheelRight, t1)
-	if m.sel["model"] == sel {
-		t.Fatal("a deliberate horizontal step after a pause must change the value")
-	}
-	m.wheelStep(tea.MouseButtonWheelUp, t1.Add(time.Second))
+	t1 := t0.Add(time.Second) // deliberate later vertical gesture, other direction
+	m.wheelStep(tea.MouseButtonWheelDown, t1)
 	if m.fcur != 0 {
-		t.Fatalf("wheel up must move the selection back, fcur = %d", m.fcur)
+		t.Fatalf("wheel DOWN must move the selection UP (inverted), fcur = %d", m.fcur)
+	}
+
+	// Horizontal pinning on the lane facet (fcur 0): mixed sits mid-list, so
+	// each direction lands on a distinct, unambiguous neighbour.
+	if m.sel["lane"] != "mixed" {
+		t.Fatalf("fixture: lane = %q, want mixed", m.sel["lane"])
+	}
+	t2 := t1.Add(time.Second)
+	m.wheelStep(tea.MouseButtonWheelLeft, t2)
+	if m.sel["lane"] != "claude-led" {
+		t.Fatalf("wheel LEFT must cycle to the NEXT (right) option (inverted): lane = %q, want claude-led", m.sel["lane"])
+	}
+	t3 := t2.Add(time.Second)
+	m.wheelStep(tea.MouseButtonWheelRight, t3)
+	if m.sel["lane"] != "mixed" {
+		t.Fatalf("wheel RIGHT must cycle to the PREVIOUS (left) option (inverted): lane = %q, want mixed", m.sel["lane"])
 	}
 }
 
@@ -922,13 +938,13 @@ func TestWheelThroughUpdate(t *testing.T) {
 	wide, _, _, _ := layoutSizes(t, m)
 	m = resize(t, m, wide.w, wide.h)
 
-	nm, cmd := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
+	nm, cmd := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelUp})
 	m = nm.(model)
 	if cmd != nil {
 		t.Fatal("wheel input must never produce a command")
 	}
 	if m.fcur != 1 {
-		t.Fatalf("wheel press must step the selection, fcur = %d", m.fcur)
+		t.Fatalf("wheel-up press must step the selection down (inverted), fcur = %d", m.fcur)
 	}
 
 	sel := map[string]string{}
@@ -999,12 +1015,12 @@ func TestUsageHeadingsNameEffectiveProfile(t *testing.T) {
 			m := layoutModel()
 			m.authProfiles = []authProfile{{ID: "p", Label: "p", Claude: tc.claude, Codex: tc.codex}}
 			lines := strings.Split(stripAnsi(m.usagePanel()), "\n")
-			codexHead := lineIndex(lines, "Codex "+tc.codex)
-			claudeHead := lineIndex(lines, "Claude "+tc.claude)
+			codexHead := lineIndex(lines, "Codex ("+tc.codex+")")
+			claudeHead := lineIndex(lines, "Claude ("+tc.claude+")")
 			if codexHead < 0 || claudeHead < 0 {
 				t.Fatalf("provider headings must name the effective accounts:\n%s", strings.Join(lines, "\n"))
 			}
-			if trimmed := strings.TrimSpace(lines[codexHead]); trimmed != "Codex "+tc.codex {
+			if trimmed := strings.TrimSpace(lines[codexHead]); trimmed != "Codex ("+tc.codex+")" {
 				t.Errorf("Codex heading must be a standalone group title, got %q", trimmed)
 			}
 			if lineIndex(lines, "auth ·") >= 0 || lineIndex(lines, "Claude "+tc.claude+" + ") >= 0 {
@@ -1051,7 +1067,7 @@ func TestUsageLoadingErrorStates(t *testing.T) {
 	loading.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
 	loading.fetching = true
 	panel := stripAnsi(loading.usagePanel())
-	for _, want := range []string{"fetching usage…", "Codex Alex", "Claude Alex"} {
+	for _, want := range []string{"fetching usage…", "Codex (Alex)", "Claude (Alex)"} {
 		if !strings.Contains(panel, want) {
 			t.Errorf("loading: panel missing %q:\n%s", want, panel)
 		}
@@ -1063,7 +1079,7 @@ func TestUsageLoadingErrorStates(t *testing.T) {
 	refreshing := m
 	refreshing.fetching = true
 	panel = stripAnsi(refreshing.usagePanel())
-	for _, want := range []string{"refreshing…", "Codex Alex", "Claude Alex", "% used"} {
+	for _, want := range []string{"refreshing…", "Codex (Alex)", "Claude (Alex)", "% used"} {
 		if !strings.Contains(panel, want) {
 			t.Errorf("refreshing: panel missing %q:\n%s", want, panel)
 		}
@@ -1075,7 +1091,7 @@ func TestUsageLoadingErrorStates(t *testing.T) {
 	failed := m
 	failed.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
 	panel = stripAnsi(failed.usagePanel())
-	for _, want := range []string{"usage unavailable · authenticate with omp --profile default", "Codex Alex", "Claude Alex"} {
+	for _, want := range []string{"usage unavailable · authenticate with omp --profile default", "Codex (Alex)", "Claude (Alex)"} {
 		if !strings.Contains(panel, want) {
 			t.Errorf("unavailable: panel missing %q:\n%s", want, panel)
 		}
@@ -1163,7 +1179,7 @@ func TestCompactHelpDerivation(t *testing.T) {
 
 	m = resize(t, m, wide.w, wide.h)
 	descs := shortDescs(m)
-	for _, d := range []string{"move", "change", "switch profile", "refresh usage", "managed omp", "sandbox", "launch", "show routing", "show usage"} {
+	for _, d := range []string{"move", "change", gReset + " defaults", "switch profile", "refresh usage", "managed omp", "sandbox", "launch", "show routing", "show usage"} {
 		got := hasDesc(descs, d)
 		want := d == "move" || d == "change"
 		if got != want {
@@ -1206,7 +1222,7 @@ func TestCompactHelpDerivation(t *testing.T) {
 	// narrow + p: routing full-screen hides the generator launch footer.
 	swapped, _ := press(t, m, "p")
 	descs = shortDescs(swapped)
-	for _, d := range []string{"launch", "managed omp", "sandbox"} {
+	for _, d := range []string{gReset + " defaults", "launch", "managed omp", "sandbox"} {
 		if !hasDesc(descs, d) {
 			t.Errorf("routing-full-screen compact help missing %q: %v", d, descs)
 		}
@@ -1283,7 +1299,7 @@ func TestLongAccountLabelsWidthInvariant(t *testing.T) {
 		label := fmt.Sprintf("long labels %dx%d", s.w, s.h)
 		assertLayoutInvariants(t, m, label)
 		view := stripAnsi(m.View())
-		if strings.Contains(view, "% used") && !strings.Contains(view, "Codex "+longName) {
+		if strings.Contains(view, "% used") && !strings.Contains(view, "Codex ("+longName+")") {
 			t.Errorf("%s: visible usage must keep the full account identity:\n%s", label, view)
 		}
 	}
@@ -1327,7 +1343,7 @@ func TestSectionStatePreservation(t *testing.T) {
 	}
 	m.fetching = false
 	m.avail = multiProfileModel().avail
-	if panel := stripAnsi(m.usagePanel()); !strings.Contains(panel, "Claude Mum") {
+	if panel := stripAnsi(m.usagePanel()); !strings.Contains(panel, "Claude (Mum)") {
 		t.Errorf("usage headings must follow the switched profile:\n%s", panel)
 	}
 
@@ -1423,4 +1439,489 @@ func TestCollapseReallocation(t *testing.T) {
 		t.Errorf("narrow with usage hidden: the routing section must reappear:\n%s", strings.Join(lines, "\n"))
 	}
 	assertLayoutInvariants(t, n, "narrow usage hidden")
+}
+
+// ── bottom-pinned section chrome · secondary separator · defaults cue ────────
+
+// TestRoutingFallbackCuePinned locks the moved fallback-display cue: it is
+// Routing BOTTOM chrome — the last body row, directly above the footer rule —
+// in the wide split, the medium secondary row, and the narrow routing-only
+// swap, always below the routing content it toggles.
+func TestRoutingFallbackCuePinned(t *testing.T) {
+	m := layoutModel()
+	wide, medium, narrow, _ := layoutSizes(t, m)
+
+	check := func(label string) {
+		t.Helper()
+		lines := strings.Split(stripAnsi(m.View()), "\n")
+		cue := lineIndex(lines, "f · show fallback chains")
+		title := lineIndex(lines, "routing", "p · hide")
+		route := lineIndex(lines, "scout") // a routing role row — generator has none
+		if cue < 0 || title < 0 || route < 0 {
+			t.Fatalf("%s: missing cue (%d), title (%d), or route content (%d):\n%s",
+				label, cue, title, route, strings.Join(lines, "\n"))
+		}
+		if !(title < route && route < cue) {
+			t.Errorf("%s: want title (%d) above routes (%d) above the cue (%d)", label, title, route, cue)
+		}
+		if want := m.bodyH() - 1; cue != want {
+			t.Errorf("%s: cue on line %d, want pinned to the last body row %d", label, cue, want)
+		}
+		if next := lines[cue+1]; !strings.HasPrefix(next, "─") {
+			t.Errorf("%s: the footer rule must sit directly under the pinned cue, got %q", label, next)
+		}
+	}
+
+	m = resize(t, m, wide.w, wide.h)
+	check("wide")
+	m = resize(t, m, medium.w, medium.h)
+	check("medium")
+	m = resize(t, m, narrow.w, narrow.h)
+	m, _ = press(t, m, "p") // narrow: swap to the routing-only panel
+	check("narrow routing-only")
+}
+
+// TestUsageCtrlRowPinned locks the moved refresh/profile control row: it is
+// Usage BOTTOM chrome — the panel's last row, below every provider heading and
+// usage bar — in the wide band and the medium column, and the loading /
+// switch-failure variants keep that ordering (the error stays attached under
+// the control that caused it).
+func TestUsageCtrlRowPinned(t *testing.T) {
+	m := multiProfileModel()
+	wide, medium, _, _ := layoutSizes(t, m)
+
+	assertCtrlLast := func(label, panel string) {
+		t.Helper()
+		lines := strings.Split(panel, "\n")
+		ctrl := lineIndex(lines, "r now", "a switch profile")
+		if ctrl < 0 {
+			t.Fatalf("%s: control row missing:\n%s", label, panel)
+		}
+		if ctrl != len(lines)-1 {
+			t.Errorf("%s: control row on line %d of %d, want the panel's last row:\n%s", label, ctrl, len(lines)-1, panel)
+		}
+		for _, needle := range []string{"Codex (", "Claude (", "% used"} {
+			if idx := lineIndex(lines, needle); idx < 0 || idx > ctrl {
+				t.Errorf("%s: %q (line %d) must sit above the control row (%d)", label, needle, idx, ctrl)
+			}
+		}
+	}
+
+	m = resize(t, m, wide.w, wide.h)
+	assertCtrlLast("wide band", stripAnsi(m.usagePanel()))
+	m = resize(t, m, medium.w, medium.h)
+	assertCtrlLast("medium column", stripAnsi(m.usageColumn()))
+
+	// The full medium view keeps the ordering: control row under every bar.
+	lines := strings.Split(stripAnsi(m.View()), "\n")
+	ctrl := lineIndex(lines, "r now", "a switch profile")
+	lastUsed := -1
+	for i, l := range lines {
+		if strings.Contains(l, "% used") {
+			lastUsed = i
+		}
+	}
+	if ctrl < 0 || lastUsed < 0 || ctrl < lastUsed {
+		t.Errorf("medium view: control row (%d) must render below the last usage bar (%d)", ctrl, lastUsed)
+	}
+
+	// Loading: the status row replaces the countdown but stays pinned last.
+	loading := multiProfileModel()
+	loading.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
+	loading.fetching = true
+	llines := strings.Split(stripAnsi(loading.usagePanel()), "\n")
+	if status := lineIndex(llines, "fetching usage…"); status != len(llines)-1 {
+		t.Errorf("loading: status row on line %d of %d, want last:\n%s", status, len(llines)-1, strings.Join(llines, "\n"))
+	}
+
+	// Switch failure: the error attaches directly under the control row.
+	failed := multiProfileModel()
+	failed.authErr = "state write denied"
+	flines := strings.Split(stripAnsi(failed.usagePanel()), "\n")
+	errLine := lineIndex(flines, "profile switch failed: state write denied")
+	fctrl := lineIndex(flines, "r now", "a switch profile")
+	if errLine != len(flines)-1 || fctrl != errLine-1 {
+		t.Errorf("switch failure must sit directly under the bottom control row (ctrl %d, err %d of %d):\n%s",
+			fctrl, errLine, len(flines)-1, strings.Join(flines, "\n"))
+	}
+}
+
+// TestMediumSecondarySeparator locks the medium secondary row's pane contract:
+// Routing is always the LEFT pane and Usage the RIGHT, and a visible one-cell
+// │ border column separates them on every secondary row at exactly the routing
+// column's width. Hiding usage removes both the right pane and the separator.
+func TestMediumSecondarySeparator(t *testing.T) {
+	m := layoutModel()
+	_, medium, _, _ := layoutSizes(t, m)
+	m = resize(t, m, medium.w, medium.h)
+	if m.mode() != modeMedium {
+		t.Fatalf("fixture: %dx%d must be medium, mode = %d", medium.w, medium.h, m.mode())
+	}
+	lines := strings.Split(stripAnsi(m.View()), "\n")
+	head := lineIndex(lines, "routing", "usage")
+	if head < 0 {
+		t.Fatalf("routing and usage titles must share the secondary row:\n%s", strings.Join(lines, "\n"))
+	}
+	row := lines[head]
+	if strings.Index(row, "routing") > strings.Index(row, "usage") {
+		t.Errorf("routing must be the left pane and usage the right: %q", row)
+	}
+	rw := m.routingColW()
+	genH, secH := m.mediumSplit(m.contentH())
+	first := topGap + genH + 1 // the row right under the full-width divider
+	for i := first; i < first+secH; i++ {
+		r := []rune(lines[i])
+		if len(r) <= rw || r[rw] != '│' {
+			t.Errorf("secondary row %d: want the │ separator at column %d, got %q", i, rw, lines[i])
+		}
+	}
+	if p := strings.IndexRune(row, '│'); p < 0 {
+		t.Errorf("the title row must carry the separator between the panes: %q", row)
+	} else if u := strings.Index(row, "usage"); u >= 0 && u < p {
+		t.Errorf("usage must sit right of the separator: %q", row)
+	}
+
+	m, _ = press(t, m, "s") // hiding usage removes the right pane AND the border
+	if view := stripAnsi(m.View()); strings.ContainsRune(view, '│') {
+		t.Errorf("no separator may remain once usage hides:\n%s", view)
+	}
+	assertLayoutInvariants(t, m, "medium separator hidden usage")
+}
+
+// TestGeneratorDefaultsCue locks the d · defaults placement: the cue lives in
+// the Generator title row in every composition that shows the Generator, the
+// compact help therefore drops the duplicate, the narrow routing-only swap
+// (Generator hidden) restores the action to the compact line, and the full
+// help always lists the binding.
+func TestGeneratorDefaultsCue(t *testing.T) {
+	m := multiProfileModel()
+	wide, medium, narrow, _ := layoutSizes(t, m)
+	for _, tc := range []struct {
+		label string
+		s     termSize
+	}{{"wide", wide}, {"medium", medium}, {"narrow", narrow}} {
+		m = resize(t, m, tc.s.w, tc.s.h)
+		lines := strings.Split(stripAnsi(m.View()), "\n")
+		if lineIndex(lines, "generator", "d · defaults") < 0 {
+			t.Errorf("%s: the generator title must carry the d · defaults cue:\n%s", tc.label, strings.Join(lines, "\n"))
+		}
+		if hasDesc(shortDescs(m), gReset+" defaults") {
+			t.Errorf("%s: the compact help must not repeat defaults while the title advertises it", tc.label)
+		}
+	}
+
+	m = resize(t, m, narrow.w, narrow.h)
+	swapped, _ := press(t, m, "p") // routing full-screen: generator (and its title cue) hidden
+	lines := strings.Split(stripAnsi(swapped.View()), "\n")
+	if lineIndex(lines, "d · defaults") >= 0 {
+		t.Errorf("routing-only: no generator title on screen, so no title cue:\n%s", strings.Join(lines, "\n"))
+	}
+	if !hasDesc(shortDescs(swapped), gReset+" defaults") {
+		t.Errorf("routing-only: the compact help must recover the defaults action: %v", shortDescs(swapped))
+	}
+
+	found := false
+	for _, group := range keys.FullHelp() {
+		for _, b := range group {
+			if len(b.Keys()) == 1 && b.Keys()[0] == "d" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("the full help must always list the d binding")
+	}
+}
+
+// TestLaunchFooterShape locks the generator footer: cost and speed meters, a
+// blank separator row, then the shortened ⏎ launch action with its managed /
+// sandbox alternatives — exactly launchFooterRows rows, action pinned last.
+func TestLaunchFooterShape(t *testing.T) {
+	m := layoutModel()
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	rows := m.launchFooter()
+	if len(rows) != launchFooterRows {
+		t.Fatalf("launch footer is %d rows, launchFooterRows says %d", len(rows), launchFooterRows)
+	}
+	plain := make([]string, len(rows))
+	for i, r := range rows {
+		plain[i] = stripAnsi(r)
+	}
+	if !strings.Contains(plain[1], "cost") || !strings.Contains(plain[2], "speed") {
+		t.Errorf("the meters must lead the footer: %q", plain)
+	}
+	if strings.TrimSpace(plain[3]) != "" {
+		t.Errorf("a blank row must separate the meters from the action, got %q", plain[3])
+	}
+	last := plain[len(plain)-1]
+	if !strings.Contains(last, "⏎ launch") || strings.Contains(last, "launch generated profile") {
+		t.Errorf("the action label must be the shortened ⏎ launch, got %q", last)
+	}
+	if !strings.Contains(last, "m managed omp · u sandbox") {
+		t.Errorf("the managed/sandbox alternatives must stay on the action row, got %q", last)
+	}
+}
+
+// ── reset-credit urgency tint ────────────────────────────────────────────────
+
+// TestCreditExpiryUrgency locks the credit-line tint boundaries: expiries are
+// bucketed on the same rounded-up whole days fmtDays renders — muted red
+// through creditUrgentDays, muted amber through creditSoonDays, muted green
+// beyond — and the text alone stays sufficient (count, ascending days) with
+// the prose dim regardless of tint.
+func TestCreditExpiryUrgency(t *testing.T) {
+	cases := []struct {
+		secs int64
+		want lipgloss.Style
+		name string
+	}{
+		{0, stCreditUrgent, "expired"},
+		{1, stCreditUrgent, "later today (1d)"},
+		{creditUrgentDays * day, stCreditUrgent, "exactly 3d"},
+		{creditUrgentDays*day + 1, stCreditSoon, "just past 3d (4d)"},
+		{creditSoonDays * day, stCreditSoon, "exactly 10d"},
+		{creditSoonDays*day + 1, stCreditSafe, "just past 10d (11d)"},
+	}
+	for _, c := range cases {
+		if got := creditDayStyle(c.secs); got.GetForeground() != c.want.GetForeground() {
+			t.Errorf("%s (%ds): tint = %v, want %v", c.name, c.secs, got.GetForeground(), c.want.GetForeground())
+		}
+	}
+	// The three buckets are visually distinct, precomputed colors.
+	if stCreditUrgent.GetForeground() == stCreditSoon.GetForeground() ||
+		stCreditSoon.GetForeground() == stCreditSafe.GetForeground() {
+		t.Error("urgency tints must be distinct palette entries")
+	}
+
+	// Text sufficiency: the stripped line carries count and ascending days.
+	m := layoutModel()
+	m.avail.credits = resetCredits{avail: 2, exp: []int64{30 * day, 2 * day, 8 * day}}
+	line := stripAnsi(m.creditLine())
+	if !strings.Contains(line, "2 resets") || !strings.Contains(line, "expiring in 2d, 8d, 30d") {
+		t.Errorf("credit line text must stay sufficient without color: %q", line)
+	}
+}
+
+// ── loading skeleton · first-load bar fill ───────────────────────────────────
+
+// TestUsageSkeleton locks the pre-first-fetch Usage shape: provider/account
+// headings over generic placeholder window rows (real labels, empty bars, no
+// fabricated numbers), the loading status pinned to the panel's last row, the
+// stacked skeleton exactly as tall as the loaded column (no layout pop), the
+// frame invariants at wide and medium, and standalone runs (no usage command)
+// staying neutral.
+func TestUsageSkeleton(t *testing.T) {
+	loading := layoutModel()
+	loading.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
+	loading.fetching = true
+
+	panel := stripAnsi(loading.usagePanel())
+	lines := strings.Split(panel, "\n")
+	for _, h := range []string{"Codex (Alex)", "Claude (Alex)"} {
+		if lineIndex(lines, h) < 0 {
+			t.Errorf("skeleton must keep the provider identity %q:\n%s", h, panel)
+		}
+	}
+	if got := strings.Count(panel, "··% used"); got != 4 {
+		t.Errorf("want two placeholder rows per provider (4 total), got %d:\n%s", got, panel)
+	}
+	if regexp.MustCompile(`\d+% used`).MatchString(panel) {
+		t.Errorf("the skeleton must not fabricate numeric values:\n%s", panel)
+	}
+	if strings.Contains(panel, "█") {
+		t.Errorf("skeleton bars must be empty:\n%s", panel)
+	}
+	if status := lineIndex(lines, "fetching usage…"); status != len(lines)-1 {
+		t.Errorf("the loading status must stay pinned to the panel's last row (%d of %d):\n%s", status, len(lines)-1, panel)
+	}
+	if sh, lh := lipgloss.Height(loading.usageColumn()), lipgloss.Height(layoutModel().usageColumn()); sh != lh {
+		t.Errorf("skeleton column is %d rows, loaded column %d — the first fetch would pop the layout", sh, lh)
+	}
+
+	wide, medium, _, _ := layoutSizes(t, loading)
+	loading = resize(t, loading, wide.w, wide.h)
+	assertLayoutInvariants(t, loading, "skeleton wide")
+	loading = resize(t, loading, medium.w, medium.h)
+	assertLayoutInvariants(t, loading, "skeleton medium")
+
+	bare := layoutModel()
+	bare.usageCmd = ""
+	bare.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
+	if p := stripAnsi(bare.usagePanel()); strings.Contains(p, "··% used") {
+		t.Errorf("standalone runs (no usage command) must stay neutral, not show the skeleton:\n%s", p)
+	}
+}
+
+// TestFirstLoadBarFill locks the one-time fill: the first successful usageMsg
+// starts a bounded 150–250ms tick sequence that grows only the bar fill
+// (labels and numbers real from frame one, monotonic, never overshooting),
+// the sequence self-terminates at full value, a mid-fill frame keeps every
+// layout invariant, refreshes never re-animate, and a stale-profile result
+// neither lands nor starts the fill.
+func TestFirstLoadBarFill(t *testing.T) {
+	if d := time.Duration(barAnimSteps) * barAnimInterval; d < 150*time.Millisecond || d > 250*time.Millisecond {
+		t.Fatalf("first-load fill runs %v, want 150–250ms", d)
+	}
+
+	loaded := layoutModel().avail
+	m := layoutModel()
+	m.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
+	m.fetching = true
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+
+	nm, cmd := m.Update(usageMsg{profile: "other", avail: loaded})
+	m = nm.(model)
+	if cmd != nil || m.barAnim != 0 || m.avail.ok || m.hadUsage {
+		t.Fatal("a stale-profile result must be dropped entirely — no data, no fill")
+	}
+
+	nm, cmd = m.Update(usageMsg{profile: "default", avail: loaded})
+	m = nm.(model)
+	if m.barAnim != 1 || cmd == nil {
+		t.Fatalf("the first successful result must start the fill: step %d, cmd nil = %v", m.barAnim, cmd == nil)
+	}
+
+	win := loaded.wins[2] // anthropic 5h at 55% — a mid-scale target
+	full := m
+	full.barAnim = 0
+	fullRow := stripAnsi(full.usageRow(win))
+	if !strings.Contains(fullRow, " 55% used") {
+		t.Fatalf("fixture: %q", fullRow)
+	}
+	fullFill := strings.Count(fullRow, "█")
+	prev := -1
+	for step := 1; step < barAnimSteps; step++ {
+		m.barAnim = step
+		row := stripAnsi(m.usageRow(win))
+		if !strings.Contains(row, " 55% used") {
+			t.Errorf("step %d: the percentage text must be real during the fill: %q", step, row)
+		}
+		if lipgloss.Width(row) != lipgloss.Width(fullRow) {
+			t.Errorf("step %d: row width %d changed from %d — the fill must not reflow", step, lipgloss.Width(row), lipgloss.Width(fullRow))
+		}
+		fill := strings.Count(row, "█")
+		if fill < prev || fill > fullFill {
+			t.Errorf("step %d: fill %d must grow monotonically toward %d (prev %d)", step, fill, fullFill, prev)
+		}
+		prev = fill
+	}
+
+	// Drive the dedicated tick sequence to completion — bounded, no network.
+	m.barAnim = 1
+	steps := 0
+	for m.barAnim != 0 {
+		nm, cmd = m.Update(barAnimMsg{step: m.barAnim + 1})
+		m = nm.(model)
+		if steps++; steps > barAnimSteps {
+			t.Fatal("the fill must self-terminate within barAnimSteps ticks")
+		}
+	}
+	if cmd != nil {
+		t.Error("the final frame must not arm another tick")
+	}
+	if row := stripAnsi(m.usageRow(win)); row != fullRow {
+		t.Errorf("after completion bars must render at full value:\n got %q\nwant %q", row, fullRow)
+	}
+
+	mid := m
+	mid.barAnim = barAnimSteps / 2
+	assertLayoutInvariants(t, mid, "mid-fill wide")
+
+	nm, cmd = m.Update(usageMsg{profile: "default", avail: loaded})
+	m = nm.(model)
+	if cmd != nil || m.barAnim != 0 {
+		t.Error("refreshes must never re-run the fill")
+	}
+}
+
+// TestRoutingWheelScroll locks the pointer-aware wheel dispatch: inside the
+// visible Routing pane vertical wheel scrolls the viewport continuously —
+// ungated, clamped at both ends, inverted to match the operator-confirmed
+// trackpad direction, horizontal inert — in the wide right pane, medium's
+// lower-left pane, and the narrow routing-only swap, while the generator
+// keeps the detented wheel everywhere else and no scroll ever touches the
+// facet selection.
+func TestRoutingWheelScroll(t *testing.T) {
+	long := layoutModel()
+	id := comboID(defaultSel())
+	rows := []string{"  thinking medium · fallback on · advisor on"}
+	for i := range 60 {
+		rows = append(rows, fmt.Sprintf("    role%02d     gpt-5.6-terra:medium", i))
+	}
+	long.generated[id] = rows
+	wide, medium, narrow, _ := layoutSizes(t, long)
+
+	wheel := func(m model, b tea.MouseButton, x, y int) model {
+		t.Helper()
+		nm, cmd := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: b, X: x, Y: y})
+		if cmd != nil {
+			t.Fatal("wheel input must never produce a command")
+		}
+		return nm.(model)
+	}
+
+	// Wide: the right pane scrolls continuously; the generator side steps.
+	m := resize(t, long, wide.w, wide.h)
+	rx, ry := m.listW()+4, topGap+4
+	for i := 1; i <= 3; i++ { // consecutive events — no gate, no pause needed
+		m = wheel(m, tea.MouseButtonWheelUp, rx, ry)
+		if m.vp.YOffset != i {
+			t.Fatalf("wide event %d: YOffset = %d, want continuous scroll to %d", i, m.vp.YOffset, i)
+		}
+	}
+	if m.fcur != 0 {
+		t.Fatalf("routing scroll must not move the generator selection, fcur = %d", m.fcur)
+	}
+	lane := m.sel["lane"]
+	m = wheel(m, tea.MouseButtonWheelLeft, rx, ry) // horizontal over routing: inert
+	if m.sel["lane"] != lane || m.vp.YOffset != 3 {
+		t.Fatal("horizontal wheel over routing must be ignored entirely")
+	}
+	m = wheel(m, tea.MouseButtonWheelDown, rx, ry)
+	if m.vp.YOffset != 2 {
+		t.Fatalf("wheel down over routing must scroll back (inverted), YOffset = %d", m.vp.YOffset)
+	}
+	for range 10 { // clamped at the top …
+		m = wheel(m, tea.MouseButtonWheelDown, rx, ry)
+	}
+	if m.vp.YOffset != 0 {
+		t.Fatalf("scroll must clamp at the top, YOffset = %d", m.vp.YOffset)
+	}
+	for range 200 { // … and at the bottom.
+		m = wheel(m, tea.MouseButtonWheelUp, rx, ry)
+	}
+	if maxOff := m.vp.TotalLineCount() - m.vp.Height; m.vp.YOffset > maxOff {
+		t.Fatalf("scroll must clamp at the bottom: YOffset %d > max %d", m.vp.YOffset, maxOff)
+	}
+	m = wheel(m, tea.MouseButtonWheelUp, 2, topGap+2) // generator side: detented step
+	if m.fcur != 1 {
+		t.Fatalf("generator wheel outside routing must step the selection, fcur = %d", m.fcur)
+	}
+
+	// Medium: only the lower-left secondary pane scrolls routing.
+	m = resize(t, long, medium.w, medium.h)
+	genH, _ := m.mediumSplit(m.contentH())
+	m = wheel(m, tea.MouseButtonWheelUp, 2, topGap+genH+2)
+	if m.vp.YOffset != 1 || m.fcur != 0 {
+		t.Fatalf("medium: wheel in the lower-left pane must scroll routing only (YOffset %d, fcur %d)", m.vp.YOffset, m.fcur)
+	}
+	m = wheel(m, tea.MouseButtonWheelUp, 2, topGap+1) // the generator's own rows
+	if m.fcur != 1 {
+		t.Fatalf("medium: wheel over the generator must step the selection, fcur = %d", m.fcur)
+	}
+
+	// Narrow routing-only: the whole body scrolls; facets stay untouched.
+	m = resize(t, long, narrow.w, narrow.h)
+	m, _ = press(t, m, "p")
+	sel := fmt.Sprint(m.sel)
+	m = wheel(m, tea.MouseButtonWheelUp, 3, topGap+3)
+	m = wheel(m, tea.MouseButtonWheelUp, 3, topGap+3)
+	if m.vp.YOffset != 2 {
+		t.Fatalf("narrow routing-only: want continuous scroll, YOffset = %d", m.vp.YOffset)
+	}
+	if fmt.Sprint(m.sel) != sel || m.fcur != 0 {
+		t.Fatal("routing-only scroll must never touch the generator state")
+	}
 }

--- a/pkgs/code-tui/selection_state.go
+++ b/pkgs/code-tui/selection_state.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// loadSelectionState overlays a persisted choice set onto the current defaults.
+// The state is deliberately only facet values: all transient TUI state remains
+// owned by the running model.
+func loadSelectionState(path string, facets []facet) map[string]string {
+	sel := defaultSel()
+	if path == "" {
+		return sel
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return sel
+	}
+	var stored map[string]json.RawMessage
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return sel
+	}
+
+	valid := facetValues(facets)
+	for key, raw := range stored {
+		values, ok := valid[key]
+		if !ok {
+			continue
+		}
+		var value string
+		if err := json.Unmarshal(raw, &value); err == nil && values[value] {
+			sel[key] = value
+		}
+	}
+	repairPersistedSelection(sel)
+	return sel
+}
+
+func facetValues(facets []facet) map[string]map[string]bool {
+	valid := make(map[string]map[string]bool, len(facets))
+	for _, f := range facets {
+		values := make(map[string]bool, len(f.values))
+		for _, value := range f.values {
+			values[value] = true
+		}
+		valid[f.key] = values
+	}
+	return valid
+}
+
+// repairPersistedSelection prevents a hidden fable/main choice from being
+// resurrected after loading. Other hidden facets retain their ordinary model
+// semantics; only main is a subordinate choice that must be explicitly remade.
+func repairPersistedSelection(sel map[string]string) {
+	if sel["lane"] == "gpt-only" {
+		sel["fable"] = "off"
+	}
+	if sel["fable"] != "on" {
+		sel["main"] = "off"
+	}
+}
+
+func selectionChoices(sel map[string]string, facets []facet) map[string]string {
+	choices := make(map[string]string, len(facets))
+	for _, f := range facets {
+		if value, ok := sel[f.key]; ok {
+			choices[f.key] = value
+		}
+	}
+	return choices
+}
+
+// saveSelectionState atomically replaces the choice file. An empty path is the
+// standalone-package opt-out: it performs no filesystem work and succeeds.
+func saveSelectionState(path string, sel map[string]string, facets []facet) error {
+	return saveSelectionStateWithRename(path, sel, facets, os.Rename)
+}
+
+func saveSelectionStateWithRename(path string, sel map[string]string, facets []facet, rename func(string, string) error) error {
+	if path == "" {
+		return nil
+	}
+	dir := filepath.Dir(path)
+	dirMissing := false
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		dirMissing = true
+	} else if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	// Tighten only a directory this save created. CODE_SELECTION_STATE is an
+	// override and may legitimately name a file beneath an existing shared
+	// parent (for example /tmp); mutating that parent's mode is unsafe.
+	if dirMissing {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return err
+		}
+	}
+
+	tmp, err := os.CreateTemp(dir, ".code-generator-selection-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	enc := json.NewEncoder(tmp)
+	if err := enc.Encode(selectionChoices(sel, facets)); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := rename(tmpPath, path); err != nil {
+		return err
+	}
+
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil && !errors.Is(err, os.ErrInvalid) {
+		return err
+	}
+	return nil
+}
+
+func (m *model) persistSelection() {
+	_ = saveSelectionState(m.selectionState, m.sel, m.facets)
+}

--- a/pkgs/code-tui/selection_state_test.go
+++ b/pkgs/code-tui/selection_state_test.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func testFacets() []facet { return facetDefs(map[string]string{}) }
+
+func writeSelectionFixture(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSelectionStateFirstRun(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "selection.json")
+	if got := loadSelectionState(path, testFacets()); !reflect.DeepEqual(got, defaultSel()) {
+		t.Fatalf("first run selection = %v, want defaults %v", got, defaultSel())
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("load created state file or returned unexpected error: %v", err)
+	}
+}
+
+func TestSelectionStateRoundTripStoresOnlyFacets(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "selection.json")
+	sel := defaultSel()
+	sel["lane"] = "claude-led"
+	sel["thinking"] = "xhigh"
+	sel["transient-cursor"] = "7"
+	if err := saveSelectionState(path, sel, testFacets()); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadSelectionState(path, testFacets()); !reflect.DeepEqual(got, map[string]string{
+		"lane": "claude-led", "model": "smart", "thinking": "xhigh", "advisor": "glance",
+		"spark": "on", "fable": "off", "main": "off", "fast": "off",
+	}) {
+		t.Fatalf("round-trip selection = %v", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stored map[string]string
+	if err := json.Unmarshal(data, &stored); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := stored["transient-cursor"]; ok {
+		t.Fatalf("non-facet state was persisted: %v", stored)
+	}
+	if len(stored) != len(testFacets()) {
+		t.Fatalf("stored %d keys, want one choice for each of %d facets", len(stored), len(testFacets()))
+	}
+}
+
+func TestSelectionStateInvalidEntriesKeepCurrentDefaults(t *testing.T) {
+	facets := testFacets()
+	cases := []struct {
+		name string
+		body string
+		want map[string]string
+	}{
+		{
+			name: "partial and unknown",
+			body: `{"thinking":"high","future-facet":"enabled"}`,
+			want: func() map[string]string { s := defaultSel(); s["thinking"] = "high"; return s }(),
+		},
+		{
+			name: "invalid value",
+			body: `{"lane":"sideways","model":"normal"}`,
+			want: func() map[string]string { s := defaultSel(); s["model"] = "normal"; return s }(),
+		},
+		{
+			name: "invalid type does not discard valid siblings",
+			body: `{"lane":7,"thinking":"xhigh"}`,
+			want: func() map[string]string { s := defaultSel(); s["thinking"] = "xhigh"; return s }(),
+		},
+		{name: "corrupt JSON", body: `{"lane":`, want: defaultSel()},
+		{name: "wrong JSON shape", body: `["lane","mixed"]`, want: defaultSel()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "selection.json")
+			writeSelectionFixture(t, path, tc.body)
+			if got := loadSelectionState(path, facets); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("selection = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectionStatePrivateModes(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "atyrode")
+	path := filepath.Join(dir, "selection.json")
+	if err := saveSelectionState(path, defaultSel(), testFacets()); err != nil {
+		t.Fatal(err)
+	}
+	for name, want := range map[string]os.FileMode{dir: 0o700, path: 0o600} {
+		info, err := os.Stat(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != want {
+			t.Errorf("%s mode = %04o, want %04o", name, got, want)
+		}
+	}
+}
+
+func TestSelectionStatePreservesExistingParentMode(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "shared")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "selection.json")
+	if err := saveSelectionState(path, defaultSel(), testFacets()); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("existing parent mode = %04o, want unchanged 0755", got)
+	}
+	if info, err = os.Stat(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("state file mode = %04o, want 0600", got)
+	}
+}
+
+func TestSelectionStateAtomicReplacementFailureKeepsLastGoodFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "atyrode", "selection.json")
+	old := defaultSel()
+	old["thinking"] = "low"
+	if err := saveSelectionState(path, old, testFacets()); err != nil {
+		t.Fatal(err)
+	}
+	replacement := defaultSel()
+	replacement["thinking"] = "high"
+	renamed := false
+	err := saveSelectionStateWithRename(path, replacement, testFacets(), func(from, to string) error {
+		renamed = true
+		if filepath.Dir(from) != filepath.Dir(to) {
+			t.Fatalf("temporary file %q is not beside destination %q", from, to)
+		}
+		return os.Rename(from, to)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !renamed {
+		t.Fatal("atomic save did not rename a completed temporary file")
+	}
+	if got := loadSelectionState(path, testFacets()); got["thinking"] != "high" {
+		t.Fatalf("replacement stored thinking %q, want high", got["thinking"])
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	next := defaultSel()
+	next["thinking"] = "max"
+	wantErr := errors.New("injected rename failure")
+	err = saveSelectionStateWithRename(path, next, testFacets(), func(_, _ string) error { return wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("save error = %v, want injected rename error", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("failed replacement changed last good file\nbefore: %s\nafter: %s", before, after)
+	}
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".code-generator-selection-") {
+			t.Fatalf("failed replacement leaked temporary file %q", entry.Name())
+		}
+	}
+}
+
+func TestSelectionStateFableMainInvariant(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"main cannot outlive fable", `{"lane":"mixed","fable":"off","main":"on"}`},
+		{"GPT-only hides fable and main", `{"lane":"gpt-only","fable":"on","main":"on"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "selection.json")
+			writeSelectionFixture(t, path, tc.body)
+			got := loadSelectionState(path, testFacets())
+			if got["fable"] != "off" || got["main"] != "off" {
+				t.Fatalf("loaded impossible fable/main state: %v", got)
+			}
+		})
+	}
+}
+
+func TestFacetChangeAndResetPersistSelection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "atyrode", "selection.json")
+	m := model{facets: testFacets(), sel: defaultSel(), selectionState: path}
+
+	changedModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	changed := changedModel.(model)
+	if got := loadSelectionState(path, testFacets()); !reflect.DeepEqual(got, changed.sel) {
+		t.Fatalf("facet change persisted %v, want %v", got, changed.sel)
+	}
+
+	resetModel, _ := changed.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	reset := resetModel.(model)
+	if !reflect.DeepEqual(reset.sel, defaultSel()) {
+		t.Fatalf("reset selection = %v, want defaults", reset.sel)
+	}
+	if got := loadSelectionState(path, testFacets()); !reflect.DeepEqual(got, defaultSel()) {
+		t.Fatalf("reset persisted %v, want defaults", got)
+	}
+}
+
+func TestSelectionPersistenceFailureDoesNotBlockFacetChange(t *testing.T) {
+	blockedParent := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blockedParent, []byte("block"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := model{
+		facets:         testFacets(),
+		sel:            defaultSel(),
+		selectionState: filepath.Join(blockedParent, "selection.json"),
+	}
+	before := m.sel["lane"]
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	updated := updatedModel.(model)
+	if updated.sel["lane"] == before {
+		t.Fatalf("facet did not change after persistence failure: %v", updated.sel)
+	}
+	if cmd != nil {
+		t.Fatalf("facet change unexpectedly returned a command after persistence failure")
+	}
+}
+
+func TestSelectionStateDisabledPath(t *testing.T) {
+	sel := defaultSel()
+	sel["thinking"] = "max"
+	if err := saveSelectionState("", sel, testFacets()); err != nil {
+		t.Fatalf("disabled save returned error: %v", err)
+	}
+	if got := loadSelectionState("", testFacets()); !reflect.DeepEqual(got, defaultSel()) {
+		t.Fatalf("disabled load = %v, want defaults", got)
+	}
+}

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1266,6 +1266,7 @@ let
         export CODE_AUTH_PROFILES
       fi
       export CODE_AUTH_STATE="''${CODE_AUTH_STATE:-''${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/code-auth-profile}"
+      export CODE_SELECTION_STATE="''${CODE_SELECTION_STATE:-''${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/code-generator-selection.json}"
       # The generator's prompt→profile classifier runs on the resident,
       # nix-managed ollama daemon (loopback HTTP, no auth) — see services.ollama
       # in the host config. CODE_OLLAMA_ENDPOINT / CODE_EVAL_MODEL override the


### PR DESCRIPTION
## Summary
- bottom-pin Routing's fallback cue and Usage's refresh/profile controls
- keep Routing left and Usage right in medium mode with a full-height separator
- put a subdued `d · defaults` cue beside Generator and simplify its launch area
- render provider identities as `Codex (Alex)` / `Claude (Mum)` with muted owners
- tint reset-credit expiries on a desaturated urgency scale
- preload stable Usage skeleton rows and animate only first-load bar fill over 200ms
- remember validated generator facet choices across runs using atomic private state
- invert trackpad axes to match observed gestures and hard-detent Generator changes to one step per release
- route vertical wheel events over Routing directly to its viewport without Generator detents

## Regression coverage
- pinned section chrome, medium pane ordering/separator, and width/height/footer invariants
- contextual/full help defaults visibility and collapsed section combinations
- loading skeleton geometry, bounded first-load animation, stale results, and no refresh animation
- reset-expiry urgency thresholds and provider identity formatting
- every wheel direction, hard gesture detent, axis jitter, and continuous Routing scrolling in all layouts
- selection first run, round trip, invalid/corrupt state, invariants, reset, permissions, atomic failure safety, and disabled persistence

## Verification
- `CGO_ENABLED=0 go test ./...` and `go vet ./...` in `pkgs/code-tui`
- `nix build path:.#code-tui path:.#omp-configured`
- `nix build path:.#checks.x86_64-linux.go-fmt path:.#checks.x86_64-linux.omp-stack`
- tmux smoke at 100x44 for loaded and delayed skeleton states
- truecolor tmux/freeze inspection of wide, medium, narrow, hidden-section, loading, animation, and urgency-color frames
- live 30-event trackpad burst produced exactly one choice change; Routing accepted five continuous wheel steps
- persisted a changed lane, relaunched and restored it, then `d` atomically restored persisted defaults