### PR TITLE
code-tui: refine usage layout and refresh resilience

### DIFF
--- a/pkgs/cli-kit/ollamacommander.go
+++ b/pkgs/cli-kit/ollamacommander.go
@@ -72,6 +72,9 @@ type ollamaChatReq struct {
 	Model    string          `json:"model"`
 	Messages []ollamaMessage `json:"messages"`
 	Stream   bool            `json:"stream"`
+	// Format asks Ollama to constrain generation to valid JSON. Commanders
+	// always return machine-parsed actions, so free-form output is never useful.
+	Format string `json:"format"`
 	// KeepAlive is any so it serialises correctly for both forms ollama accepts:
 	// a duration string ("30m") OR a bare number (-1 = never unload). Sending -1
 	// as the string "-1" fails ollama's duration parser ("missing unit"), so the
@@ -124,6 +127,7 @@ func (o OllamaCommander) Propose(ctx context.Context, prompt string) (<-chan str
 		Model:     model,
 		Messages:  msgs,
 		Stream:    true,
+		Format:    "json",
 		KeepAlive: o.proposeKeepAlive(),
 	})
 	if err != nil {

--- a/pkgs/cli-kit/ollamacommander_test.go
+++ b/pkgs/cli-kit/ollamacommander_test.go
@@ -50,12 +50,15 @@ func TestOllamaCommanderProposeParse(t *testing.T) {
 		t.Errorf("stream missing rationale, got: %q", out.String())
 	}
 
-	// The wrapped prompt and system prompt must reach the request body.
+	// The wrapped prompt, system prompt, and JSON constraint must reach the request.
 	if !strings.Contains(gotBody, "classify: audit the repo") {
 		t.Errorf("request body missing wrapped prompt: %s", gotBody)
 	}
 	if !strings.Contains(gotBody, "be a selector") {
 		t.Errorf("request body missing system prompt: %s", gotBody)
+	}
+	if !strings.Contains(gotBody, `"format":"json"`) {
+		t.Errorf("request body does not enforce JSON output: %s", gotBody)
 	}
 
 	got, err := o.Parse(out.String())

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -231,12 +231,14 @@ func loadBlocks(path string) map[string][]string {
 
 // ── usage + availability ─────────────────────────────────────────────────────
 type usageWin struct {
-	label string
-	pct   int
-	tier  string
-	secs  int64 // seconds until reset (relative)
-	dur   int64 // window length in seconds
-	prov  string
+	label   string
+	pct     int
+	tier    string
+	secs    int64 // seconds until reset (relative)
+	dur     int64 // window length in seconds
+	prov    string
+	stale   bool // retained from the last successful fetch after a refresh omitted this window
+	missing bool // never observed: rendered as a deterministic placeholder row
 }
 
 // resetCredits tracks OpenAI reset credits: how many are currently available
@@ -300,7 +302,8 @@ func loadAvailability(cmd, profile string) availability {
 		provSeen[r.Provider] = true
 		for _, l := range r.Limits {
 			pct := int(l.Amount.UsedFraction*100 + 0.5)
-			a.wins = append(a.wins, usageWin{l.Label, pct, l.Scope.Tier, l.Window.ResetsAt/1000 - now, l.Window.DurationMs / 1000, r.Provider})
+			a.wins = append(a.wins, usageWin{label: l.Label, pct: pct, tier: l.Scope.Tier,
+				secs: l.Window.ResetsAt/1000 - now, dur: l.Window.DurationMs / 1000, prov: r.Provider})
 			bkt := bucketForProviderTier(r.Provider, l.Scope.Tier)
 			if bkt == "" {
 				continue
@@ -361,6 +364,69 @@ func bucketForProviderTier(prov, tier string) string {
 func (a availability) down(bucket string) bool {
 	return a.bucket[bucket] == "maxed" || a.bucket[bucket] == "unauthed"
 }
+
+// reconcileUsage folds a freshly fetched availability over the one currently
+// shown, so a flaky upstream never wipes known-good data. It returns the
+// availability to display plus whether the whole panel is stale:
+//
+//   - a total fetch failure after any prior success keeps the previous
+//     availability wholesale and reports it stale — the control row shows a
+//     refresh-failed warning instead of dropping to the unauthenticated error;
+//   - a successful payload that omits the Anthropic fable window (the
+//     "Claude 7 Day (Fable)" datum is flaky upstream) retains the last
+//     observed fable row marked stale, along with its bucket/reset state, so
+//     down-routing stays conservative instead of silently flipping a maxed
+//     fable back to ok on missing evidence;
+//   - a successful payload with no fable window ever observed appends a
+//     deterministic unavailable placeholder, so the datum appearing on a
+//     later refresh never pops the panel geometry.
+//
+// Fresh values always win; nothing is fabricated — retained rows are visibly
+// marked stale and placeholders carry no numbers.
+func reconcileUsage(prev, next availability) (availability, bool) {
+	if !next.ok {
+		if prev.ok {
+			return prev, true
+		}
+		return next, false
+	}
+	hasClaude, hasFable := false, false
+	for _, w := range next.wins {
+		if w.prov != "anthropic" {
+			continue
+		}
+		hasClaude = true
+		if w.tier == "fable" {
+			hasFable = true
+		}
+	}
+	if !hasClaude || hasFable {
+		return next, false
+	}
+	for _, w := range prev.wins {
+		if w.prov == "anthropic" && w.tier == "fable" && !w.missing {
+			w.stale = true
+			next.wins = append(next.wins, w)
+			// Carry the bucket/reset state observed with the retained window:
+			// loadAvailability defaults an unseen bucket to "ok", which would
+			// route onto a fable the last real datum said was maxed.
+			if st, ok := prev.bucket["claude-fable"]; ok {
+				next.bucket["claude-fable"] = st
+			}
+			if r, ok := prev.reset["claude-fable"]; ok {
+				next.reset["claude-fable"] = r
+			}
+			return next, false
+		}
+	}
+	next.wins = append(next.wins, fablePlaceholder)
+	return next, false
+}
+
+// fablePlaceholder is the never-observed fable window's deterministic
+// stand-in: the real payload label (so shortWin renders the same "7d fable"
+// tag) and window length, with no usage numbers to fabricate.
+var fablePlaceholder = usageWin{label: "Claude 7 Day (Fable)", tier: "fable", dur: 7 * 24 * 3600, prov: "anthropic", missing: true}
 
 // ── routing render (depth: 0 lead · 1 full) ──────────────────────────────────
 // renderRoute lays out each role's chain, wrapping cleanly at `width`: when a
@@ -867,9 +933,10 @@ func (m model) genConfigYAML() string {
 //	split     — wide:   the focused list on the left, routing preview on the
 //	            right, and Usage spanning the full bottom width
 //	medium    — generator-dominant: the list full width on top (primary), then
-//	            Routing and Usage side by side in a secondary row, with Usage's
-//	            provider groups stacked vertically inside its narrower column
-//	            (Routing takes the whole row while ‹s› hides Usage)
+//	            Usage and Routing side by side in a secondary row — Usage's
+//	            provider groups stacked vertically inside its measured left
+//	            column, Routing on the right (and taking the whole row while
+//	            ‹s› hides Usage)
 //	collapsed — narrow/short or ‹p›: one full-width panel at a time (list, or
 //	            routing w/ showResult) — the Generator stays usable instead of
 //	            compressing every section into an unreadable split
@@ -904,7 +971,7 @@ const (
 	// its keep.
 	routingMinW = 33
 	// secSepW is the one-cell border column between medium's adjacent
-	// secondary panes (Routing left, Usage right) — visible separation, same
+	// secondary panes (Usage left, Routing right) — visible separation, same
 	// stroke as the wide layout's routing pane border.
 	secSepW = 1
 	// genMinRows is the fewest facet rows the generator list may be windowed to
@@ -988,7 +1055,7 @@ func (m model) mediumMinW() int {
 // footerH measures the pinned footer for a composition directly from its parts
 // — mode selection depends on it, so it must not consult the mode itself.
 func (m model) footerH(withUsage bool) int {
-	h := 1 + lipgloss.Height("  "+m.help.View(keys))
+	h := 1 + lipgloss.Height(padLeft(m.help.View(keys), gut))
 	if withUsage {
 		if p := m.usagePanel(); p != "" {
 			h += 1 + lipgloss.Height(p)
@@ -1071,12 +1138,29 @@ func (m model) previewDims() (int, int) {
 	}
 }
 
-// routingColW is the medium secondary row's routing share: whatever the
-// measured usage column (and the separator between the panes) leaves free.
+// usageColShare is the medium secondary row's Usage width: Usage is the
+// favored pane — it takes the larger 3/5 proportional share of the row so its
+// bars and notes keep breathing room, never dropping below its measured
+// stacked minimum. Routing is the pane that shrinks as Usage grows, floored
+// at routingMinW (the medium width threshold guarantees both floors seat).
+func (m model) usageColShare() int {
+	avail := m.w - secSepW
+	uw := avail * 3 / 5
+	if min := m.usageColW(); uw < min {
+		uw = min
+	}
+	if avail-uw < routingMinW {
+		uw = avail - routingMinW
+	}
+	return uw
+}
+
+// routingColW is the medium secondary row's routing share: whatever Usage's
+// favored share (and the separator between the panes) leaves free.
 func (m model) routingColW() int {
 	w := m.w
 	if !m.hideUsage {
-		w -= m.usageColW() + secSepW
+		w -= m.usageColShare() + secSepW
 	}
 	if w < routingMinW {
 		w = routingMinW
@@ -1159,6 +1243,7 @@ type model struct {
 	fetching    bool      // a usage fetch is in flight (manual or auto)
 	nextRefresh time.Time // when the next auto-refresh fires
 	hadUsage    bool      // a successful fetch has landed — gates the one-time first-load bar fill
+	usageStale  bool      // the last refresh failed outright; avail is retained from an earlier success
 	barAnim     int       // first-load fill frame (1..barAnimSteps-1 = partial); 0 = inactive, bars at full value
 
 	launchManaged   bool              // m: run CODE_OMP with no overlay (the managed defaults)
@@ -1299,6 +1384,13 @@ func (m *model) usageCtrlLine() string {
 			parts = append(parts, stDim.Render(m.spin.View()+" fetching usage…"))
 		case m.fetching:
 			parts = append(parts, stWarn.Render(gReset+" refreshing…"))
+		case m.usageStale:
+			// A failed refresh kept the previous data on screen: the warning
+			// takes the countdown's slot (same row, similar width) so the
+			// measured panel geometry — and with it the medium/collapsed
+			// breakpoint — barely moves on a flaky refresh.
+			parts = append(parts, stWarn.Render("refresh failed · stale")+
+				stDim.Render(" · ")+stKey.Render("r")+stDim.Render(" retry"))
 		default:
 			rem := time.Until(m.nextRefresh)
 			if rem < 0 {
@@ -1363,7 +1455,7 @@ func (m *model) usagePanelFor(w int) string {
 	out := padLeft(m.pill("usage")+"  "+stCueKey.Render("s")+stCue.Render(" · hide"), gut) + "\n" +
 		"\n" + m.usageBodyFor(w)
 	if ctrl := m.usageCtrlLine(); ctrl != "" {
-		out += "\n" + ctrl
+		out += "\n\n" + ctrl // blank row: air between provider content and the control row
 	}
 	return out
 }
@@ -1496,7 +1588,7 @@ func (m *model) skeletonBody(w int, p authProfile) string {
 	return layoutGroups(w, order, blocks)
 }
 
-// usageColumn is the medium layout's right-hand Usage section: the panel with
+// usageColumn is the medium layout's left-hand Usage section: the panel with
 // provider groups forced into a vertical stack — the column is deliberately
 // too narrow for side-by-side groups. The panel carries its own title chrome.
 func (m model) usageColumn() string {
@@ -1524,6 +1616,12 @@ func (m model) secondaryMinH() int {
 }
 
 func (m *model) usageRow(w usageWin) string {
+	if w.missing {
+		// Never-observed window (the upstream payload omits it): the real
+		// row's exact geometry with dotted values, so the datum appearing on
+		// a later refresh never pops the layout — no fabricated numbers.
+		return skeletonRow(shortWin(w.label)) + "  " + stDim.Render("unavailable")
+	}
 	note := ""
 	if w.pct >= 80 {
 		note = "  " + stWarn.Render("tight")
@@ -1533,6 +1631,11 @@ func (m *model) usageRow(w usageWin) string {
 	}
 	if w.tier == "spark" && w.pct == 0 {
 		note = "  " + lipgloss.NewStyle().Foreground(lipgloss.Color(cGreen)).Render("idle")
+	}
+	if w.stale {
+		// Retained from the last successful fetch after a refresh omitted
+		// this window — the value is old, and the row says so.
+		note += "  " + stWarn.Render("stale")
 	}
 	reset := stDim.Render(gReset + " " + fmtReset(w.secs))
 	if w.dur > 0 && w.secs*10 < w.dur {
@@ -1671,7 +1774,7 @@ func (m *model) footer() string {
 			parts = append(parts, rule, p)
 		}
 	}
-	parts = append(parts, rule, "  "+m.help.View(m.contextHelp()))
+	parts = append(parts, rule, padLeft(m.help.View(m.contextHelp()), gut))
 	return strings.Join(parts, "\n")
 }
 
@@ -1784,7 +1887,7 @@ func (m model) contextHelp() helpKeys {
 }
 
 func (m *model) relayout() {
-	m.help.Width = m.w
+	m.help.Width = m.w - gut // the footer help is gutter-inset on every line; wrap inside the padded width
 	pw, ph := m.previewDims()
 	if pw < 10 {
 		pw = 10
@@ -1811,7 +1914,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil // stale profile: never applied, never starts the fill
 		}
 		first := !m.hadUsage && msg.avail.ok
-		m.avail = msg.avail
+		m.avail, m.usageStale = reconcileUsage(m.avail, msg.avail)
 		m.hadUsage = m.hadUsage || msg.avail.ok
 		m.fetching = false
 		m.nextRefresh = time.Now().Add(refreshEvery)
@@ -1910,6 +2013,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					break
 				}
 				m.authErr = ""
+				m.usageStale = false // the wiped avail belongs to the new profile; no stale carry-over
 				m.fetching = m.usageCmd != ""
 				m.relayout()
 				if m.fetching {
@@ -1977,7 +2081,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // wheelInRouting reports whether a pointer position (terminal cells, 0-based)
 // falls inside the visible Routing pane, whose viewport then owns vertical
-// wheel scrolling: the wide split's right pane, medium's lower-left pane, or
+// wheel scrolling: the wide split's right pane, medium's lower-right pane, or
 // the narrow routing-only swap's full body. Hidden/collapsed routing claims
 // nothing, so the generator keeps the wheel everywhere else.
 func (m model) wheelInRouting(x, y int) bool {
@@ -1988,10 +2092,10 @@ func (m model) wheelInRouting(x, y int) bool {
 	switch m.mode() {
 	case modeCollapsed: // routing-only swap: the whole body is Routing
 		return y >= topGap && y < topGap+ch
-	case modeMedium: // the secondary row's left column, under the divider
+	case modeMedium: // the secondary row's right column, under the divider
 		genH, secH := m.mediumSplit(ch)
 		secTop := topGap + genH + 1
-		return y >= secTop && y < secTop+secH && x < m.routingColW()
+		return y >= secTop && y < secTop+secH && x >= m.w-m.routingColW()
 	default: // split: the right pane, from the list's right edge on
 		return y >= topGap && y < topGap+ch && x >= m.listW()
 	}
@@ -2141,10 +2245,10 @@ func (m model) leftColumn(w, totalH int) string {
 }
 
 // mediumContent is the generator-dominant layout: the full-width facet list on
-// top (primary), a divider, then Routing (left) and Usage (right) side by side
-// in a secondary row, separated by a one-cell border column. Routing keeps its
-// own scrolling viewport; Usage stacks its provider groups vertically inside
-// the measured-width right column.
+// top (primary), a divider, then Usage (left) and Routing (right) side by side
+// in a secondary row, separated by a one-cell border column. Usage stacks its
+// provider groups vertically inside the measured-width left column; Routing
+// keeps its own scrolling viewport in whatever the row leaves free.
 func (m model) mediumContent(bodyH int) string {
 	genH, secH := m.mediumSplit(bodyH)
 	top := m.leftColumn(m.w, genH)
@@ -2156,10 +2260,12 @@ func (m model) mediumContent(bodyH int) string {
 		lipgloss.NewStyle().MaxWidth(rw).Render(padLeft(m.previewColumn(), gut)))
 	sec := routing
 	if !m.hideUsage {
+		uw := m.w - rw - secSepW // the measured usage column's share, left of the border
 		sep := lipgloss.NewStyle().Foreground(lipgloss.Color(cBord)).Render(
 			strings.TrimSuffix(strings.Repeat("│\n", secH), "\n"))
-		usage := lipgloss.NewStyle().MaxWidth(m.w - rw - secSepW).MaxHeight(secH).Render(m.usageColumn())
-		sec = lipgloss.JoinHorizontal(lipgloss.Top, routing, sep, usage)
+		usage := lipgloss.NewStyle().Width(uw).MaxHeight(secH).Render(
+			lipgloss.NewStyle().MaxWidth(uw).Render(m.usageColumn()))
+		sec = lipgloss.JoinHorizontal(lipgloss.Top, usage, sep, routing)
 	}
 	return lipgloss.JoinVertical(lipgloss.Left, top, div, sec)
 }

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -1547,9 +1547,10 @@ func TestUsageCtrlRowPinned(t *testing.T) {
 }
 
 // TestMediumSecondarySeparator locks the medium secondary row's pane contract:
-// Routing is always the LEFT pane and Usage the RIGHT, and a visible one-cell
-// │ border column separates them on every secondary row at exactly the routing
-// column's width. Hiding usage removes both the right pane and the separator.
+// Usage is always the LEFT pane and Routing the RIGHT, and a visible one-cell
+// │ border column separates them on every secondary row at exactly the usage
+// column's favored share. Hiding usage removes both the left pane and the
+// separator.
 func TestMediumSecondarySeparator(t *testing.T) {
 	m := layoutModel()
 	_, medium, _, _ := layoutSizes(t, m)
@@ -1563,25 +1564,31 @@ func TestMediumSecondarySeparator(t *testing.T) {
 		t.Fatalf("routing and usage titles must share the secondary row:\n%s", strings.Join(lines, "\n"))
 	}
 	row := lines[head]
-	if strings.Index(row, "routing") > strings.Index(row, "usage") {
-		t.Errorf("routing must be the left pane and usage the right: %q", row)
+	if strings.Index(row, "usage") > strings.Index(row, "routing") {
+		t.Errorf("usage must be the left pane and routing the right: %q", row)
 	}
-	rw := m.routingColW()
+	uw := m.w - m.routingColW() - secSepW
 	genH, secH := m.mediumSplit(m.contentH())
 	first := topGap + genH + 1 // the row right under the full-width divider
 	for i := first; i < first+secH; i++ {
-		r := []rune(lines[i])
-		if len(r) <= rw || r[rw] != '│' {
-			t.Errorf("secondary row %d: want the │ separator at column %d, got %q", i, rw, lines[i])
+		// usage rows carry zero-width runes (the ↻︎ variation selector), so
+		// locate the separator and measure its display column, not rune index.
+		p := strings.IndexRune(lines[i], '│')
+		if p < 0 {
+			t.Errorf("secondary row %d: missing the │ separator: %q", i, lines[i])
+			continue
+		}
+		if col := lipgloss.Width(lines[i][:p]); col != uw {
+			t.Errorf("secondary row %d: separator at display column %d, want %d: %q", i, col, uw, lines[i])
 		}
 	}
 	if p := strings.IndexRune(row, '│'); p < 0 {
 		t.Errorf("the title row must carry the separator between the panes: %q", row)
-	} else if u := strings.Index(row, "usage"); u >= 0 && u < p {
-		t.Errorf("usage must sit right of the separator: %q", row)
+	} else if u := strings.Index(row, "routing"); u >= 0 && u < p {
+		t.Errorf("routing must sit right of the separator: %q", row)
 	}
 
-	m, _ = press(t, m, "s") // hiding usage removes the right pane AND the border
+	m, _ = press(t, m, "s") // hiding usage removes the left pane AND the border
 	if view := stripAnsi(m.View()); strings.ContainsRune(view, '│') {
 		t.Errorf("no separator may remain once usage hides:\n%s", view)
 	}
@@ -1840,7 +1847,7 @@ func TestFirstLoadBarFill(t *testing.T) {
 // visible Routing pane vertical wheel scrolls the viewport continuously —
 // ungated, clamped at both ends, inverted to match the operator-confirmed
 // trackpad direction, horizontal inert — in the wide right pane, medium's
-// lower-left pane, and the narrow routing-only swap, while the generator
+// lower-right pane, and the narrow routing-only swap, while the generator
 // keeps the detented wheel everywhere else and no scroll ever touches the
 // facet selection.
 func TestRoutingWheelScroll(t *testing.T) {
@@ -1900,16 +1907,17 @@ func TestRoutingWheelScroll(t *testing.T) {
 		t.Fatalf("generator wheel outside routing must step the selection, fcur = %d", m.fcur)
 	}
 
-	// Medium: only the lower-left secondary pane scrolls routing.
+	// Medium: only the lower-right secondary pane scrolls routing; the usage
+	// pane left of the separator belongs to the generator wheel.
 	m = resize(t, long, medium.w, medium.h)
 	genH, _ := m.mediumSplit(m.contentH())
-	m = wheel(m, tea.MouseButtonWheelUp, 2, topGap+genH+2)
-	if m.vp.YOffset != 1 || m.fcur != 0 {
-		t.Fatalf("medium: wheel in the lower-left pane must scroll routing only (YOffset %d, fcur %d)", m.vp.YOffset, m.fcur)
+	m = wheel(m, tea.MouseButtonWheelUp, 2, topGap+genH+2) // over the left usage pane
+	if m.vp.YOffset != 0 || m.fcur != 1 {
+		t.Fatalf("medium: wheel over the usage pane must step the generator, never scroll routing (YOffset %d, fcur %d)", m.vp.YOffset, m.fcur)
 	}
-	m = wheel(m, tea.MouseButtonWheelUp, 2, topGap+1) // the generator's own rows
-	if m.fcur != 1 {
-		t.Fatalf("medium: wheel over the generator must step the selection, fcur = %d", m.fcur)
+	m = wheel(m, tea.MouseButtonWheelUp, m.w-2, topGap+genH+2) // right of the separator
+	if m.vp.YOffset != 1 || m.fcur != 1 {
+		t.Fatalf("medium: wheel in the lower-right pane must scroll routing only (YOffset %d, fcur %d)", m.vp.YOffset, m.fcur)
 	}
 
 	// Narrow routing-only: the whole body scrolls; facets stay untouched.
@@ -1923,5 +1931,305 @@ func TestRoutingWheelScroll(t *testing.T) {
 	}
 	if fmt.Sprint(m.sel) != sel || m.fcur != 0 {
 		t.Fatal("routing-only scroll must never touch the generator state")
+	}
+}
+
+// TestMediumFavoredUsageShare locks medium's secondary width allocation:
+// Usage is the favored pane — it takes the larger share of the row and never
+// less than its measured stacked column — while Routing is the pane that
+// shrinks, floored at routingMinW, and every representative medium width
+// renders without a single auto-wrapped line.
+func TestMediumFavoredUsageShare(t *testing.T) {
+	m := layoutModel()
+	wideW := m.genRowWidth() + routingMinW
+	minW := m.mediumMinW()
+	for _, w := range []int{minW, minW + (wideW-minW)/2, wideW - 1} {
+		m = resize(t, m, w, 40)
+		if m.mode() != modeMedium {
+			t.Fatalf("width %d: mode = %d, want medium", w, m.mode())
+		}
+		rw := m.routingColW()
+		uw := m.w - rw - secSepW
+		if rw < routingMinW {
+			t.Errorf("width %d: routing share %d lost its useful minimum %d", w, rw, routingMinW)
+		}
+		if uw <= rw {
+			t.Errorf("width %d: usage share %d must exceed routing's %d — usage is the favored pane", w, uw, rw)
+		}
+		if min := m.usageColW(); uw < min {
+			t.Errorf("width %d: usage share %d clips its measured column %d", w, uw, min)
+		}
+		assertLayoutInvariants(t, m, fmt.Sprintf("medium favored usage width %d", w))
+	}
+}
+
+// TestUsageCtrlBlankRow: exactly one blank visual row separates the provider
+// content — including a present fable window — from the bottom refresh/hotkey
+// control line, in the wide band and medium's stacked column alike.
+func TestUsageCtrlBlankRow(t *testing.T) {
+	m := multiProfileModel()
+	m.avail.wins = append(m.avail.wins,
+		usageWin{label: "Claude 7 Day (Fable)", pct: 40, tier: "fable", secs: 4 * day, dur: 7 * day, prov: "anthropic"})
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	for _, tc := range []struct{ label, panel string }{
+		{"wide band", stripAnsi(m.usagePanel())},
+		{"medium column", stripAnsi(m.usageColumn())},
+	} {
+		lines := strings.Split(tc.panel, "\n")
+		if lineIndex(lines, "7d fable") < 0 {
+			t.Fatalf("%s: fixture fable row missing:\n%s", tc.label, tc.panel)
+		}
+		ctrl := lineIndex(lines, "r now")
+		if ctrl < 2 {
+			t.Fatalf("%s: control row missing:\n%s", tc.label, tc.panel)
+		}
+		if strings.TrimSpace(lines[ctrl-1]) != "" {
+			t.Errorf("%s: want a blank row above the control line, got %q", tc.label, lines[ctrl-1])
+		}
+		if strings.TrimSpace(lines[ctrl-2]) == "" {
+			t.Errorf("%s: want exactly one blank row — content directly above it, got %q", tc.label, lines[ctrl-2])
+		}
+	}
+}
+
+// TestReconcileUsageFableRetention: a successful refresh that omits the
+// Anthropic fable window keeps the previously observed window — marked stale,
+// with its bucket/reset state carried so down-routing never flips to ok on
+// missing evidence — while every freshly fetched window wins as usual.
+func TestReconcileUsageFableRetention(t *testing.T) {
+	prev := availability{
+		ok:     true,
+		bucket: map[string]string{"claude-fable": "maxed", "claude-main": "ok"},
+		reset:  map[string]int64{"claude-fable": 9000},
+		wins: []usageWin{
+			{label: "Claude 5 Hour", pct: 10, secs: 3600, dur: 5 * 3600, prov: "anthropic"},
+			{label: "Claude 7 Day (Fable)", pct: 100, tier: "fable", secs: 9000, dur: 7 * day, prov: "anthropic"},
+		},
+	}
+	next := availability{
+		ok:     true,
+		bucket: map[string]string{"claude-fable": "ok", "claude-main": "ok"},
+		reset:  map[string]int64{},
+		wins: []usageWin{
+			{label: "Claude 5 Hour", pct: 20, secs: 3000, dur: 5 * 3600, prov: "anthropic"},
+		},
+	}
+	got, stale := reconcileUsage(prev, next)
+	if stale {
+		t.Fatal("a successful refresh must not mark the whole panel stale")
+	}
+	fable := usageWin{}
+	found := false
+	for _, w := range got.wins {
+		if w.tier == "fable" {
+			fable, found = w, true
+		}
+	}
+	if !found {
+		t.Fatalf("the omitted fable window must be retained: %+v", got.wins)
+	}
+	if !fable.stale || fable.missing || fable.pct != 100 || fable.secs != 9000 {
+		t.Errorf("retained fable row must carry the last observed value marked stale: %+v", fable)
+	}
+	if got.bucket["claude-fable"] != "maxed" || got.reset["claude-fable"] != 9000 {
+		t.Errorf("bucket/reset must stay conservative, got %q/%d", got.bucket["claude-fable"], got.reset["claude-fable"])
+	}
+	if !got.down("claude-fable") {
+		t.Error("down-routing must not flip a maxed fable to ok on missing evidence")
+	}
+	for _, w := range got.wins {
+		if w.tier == "" && w.pct != 20 {
+			t.Errorf("freshly fetched windows must win: %+v", w)
+		}
+	}
+	m := layoutModel()
+	row := stripAnsi(m.usageRow(fable))
+	if !strings.Contains(row, "7d fable") || !strings.Contains(row, "stale") {
+		t.Errorf("the retained row must carry a visible stale warning: %q", row)
+	}
+	if !strings.Contains(row, "100% used") {
+		t.Errorf("the retained row must show the last observed value: %q", row)
+	}
+}
+
+// TestReconcileUsageFablePlaceholder: with no fable window ever observed a
+// successful anthropic payload gains a deterministic unavailable placeholder
+// (no fabricated numbers, real row geometry), a payload with no anthropic
+// windows at all gains nothing, and a payload carrying the fable window
+// passes through untouched.
+func TestReconcileUsageFablePlaceholder(t *testing.T) {
+	empty := availability{bucket: map[string]string{}, reset: map[string]int64{}}
+	next := availability{
+		ok:     true,
+		bucket: map[string]string{"claude-fable": "ok"},
+		reset:  map[string]int64{},
+		wins: []usageWin{
+			{label: "Claude 5 Hour", pct: 20, secs: 3000, dur: 5 * 3600, prov: "anthropic"},
+		},
+	}
+	got, stale := reconcileUsage(empty, next)
+	if stale {
+		t.Fatal("a successful first fetch must not read stale")
+	}
+	fable := usageWin{}
+	found := false
+	for _, w := range got.wins {
+		if w.tier == "fable" {
+			fable, found = w, true
+		}
+	}
+	if !found {
+		t.Fatalf("a missing fable window with no prior value must gain a placeholder: %+v", got.wins)
+	}
+	if !fable.missing || fable.stale || fable.pct != 0 {
+		t.Errorf("the placeholder must be marked missing and carry no value: %+v", fable)
+	}
+	m := layoutModel()
+	row := stripAnsi(m.usageRow(fable))
+	if !strings.Contains(row, "7d fable") || !strings.Contains(row, "··%") || !strings.Contains(row, "unavailable") {
+		t.Errorf("placeholder row must read as a deterministic unavailable stand-in: %q", row)
+	}
+	if regexp.MustCompile(`\d+% used`).MatchString(row) || strings.Contains(row, "█") {
+		t.Errorf("the placeholder must not fabricate values: %q", row)
+	}
+
+	// Geometry: swapping the placeholder for a later real value never pops
+	// the stacked column's row count.
+	mp := layoutModel()
+	mp.avail = got
+	real := got
+	real.wins = append([]usageWin(nil), got.wins...)
+	for i := range real.wins {
+		if real.wins[i].missing {
+			real.wins[i] = usageWin{label: "Claude 7 Day (Fable)", pct: 40, tier: "fable", secs: 4 * day, dur: 7 * day, prov: "anthropic"}
+		}
+	}
+	mr := layoutModel()
+	mr.avail = real
+	if hp, hr := lipgloss.Height(mp.usageColumn()), lipgloss.Height(mr.usageColumn()); hp != hr {
+		t.Errorf("placeholder column is %d rows, real column %d — the datum appearing would pop the layout", hp, hr)
+	}
+
+	// No anthropic report at all: nothing to place a row under.
+	gptOnly := availability{ok: true, bucket: map[string]string{}, reset: map[string]int64{},
+		wins: []usageWin{{label: "5 hours", pct: 5, secs: 3600, dur: 5 * 3600, prov: "openai-codex"}}}
+	if got, _ := reconcileUsage(empty, gptOnly); len(got.wins) != 1 {
+		t.Errorf("no anthropic windows → no fable placeholder: %+v", got.wins)
+	}
+
+	// A payload carrying the fable window passes through untouched.
+	withFable := availability{ok: true, bucket: map[string]string{}, reset: map[string]int64{},
+		wins: []usageWin{
+			{label: "Claude 5 Hour", pct: 20, secs: 3000, dur: 5 * 3600, prov: "anthropic"},
+			{label: "Claude 7 Day (Fable)", pct: 7, tier: "fable", secs: 2 * day, dur: 7 * day, prov: "anthropic"},
+		}}
+	got2, _ := reconcileUsage(got, withFable)
+	if len(got2.wins) != 2 || got2.wins[1].stale || got2.wins[1].missing || got2.wins[1].pct != 7 {
+		t.Errorf("a present fable window must pass through fresh: %+v", got2.wins)
+	}
+}
+
+// TestUsageRefreshFailureRetention: a total refresh failure after a prior
+// success keeps the full previous availability on screen with a visible
+// refresh-failed warning — never wiping to the unauthenticated error — and
+// the next successful refresh clears the warning. Without any prior success
+// a failure still reads unavailable (nothing is fabricated).
+func TestUsageRefreshFailureRetention(t *testing.T) {
+	m := multiProfileModel()
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	m.hadUsage = true
+	before := m.avail
+	failed := availability{bucket: map[string]string{}, reset: map[string]int64{}}
+
+	nm, cmd := m.Update(usageMsg{profile: "default", avail: failed})
+	m = nm.(model)
+	if cmd != nil || m.barAnim != 0 {
+		t.Fatal("a failed refresh must not start the first-load fill")
+	}
+	if !m.avail.ok || !reflect.DeepEqual(m.avail, before) {
+		t.Fatalf("a failed refresh must keep the previous availability wholesale:\n got %+v\nwant %+v", m.avail, before)
+	}
+	if !m.usageStale {
+		t.Fatal("a failed refresh after a success must mark the panel stale")
+	}
+	panel := stripAnsi(m.usagePanel())
+	if !strings.Contains(panel, "refresh failed · stale") {
+		t.Errorf("the control row must warn about the failed refresh:\n%s", panel)
+	}
+	if strings.Contains(panel, "usage unavailable") {
+		t.Errorf("retained data must not read as unavailable:\n%s", panel)
+	}
+	if lineIndex(strings.Split(panel, "\n"), "% used") < 0 {
+		t.Errorf("the previous usage rows must stay on screen:\n%s", panel)
+	}
+	// The warning replaces the countdown's slot, so the measured medium
+	// breakpoint barely moves: a flaky refresh must not collapse the layout.
+	_, staleMedium, _, _ := layoutSizes(t, m)
+	m = resize(t, m, staleMedium.w, staleMedium.h)
+	if m.mode() != modeMedium {
+		t.Fatalf("stale usage at %dx%d: mode = %d, want medium — the warning must not blow up the measured column", staleMedium.w, staleMedium.h, m.mode())
+	}
+	assertLayoutInvariants(t, m, "medium stale usage")
+
+	// The next successful refresh clears the warning.
+	nm, _ = m.Update(usageMsg{profile: "default", avail: before})
+	m = nm.(model)
+	if m.usageStale {
+		t.Fatal("a successful refresh must clear the stale flag")
+	}
+	if panel := stripAnsi(m.usagePanel()); strings.Contains(panel, "refresh failed") {
+		t.Errorf("the warning must clear on the next success:\n%s", panel)
+	}
+
+	// Without any prior success a failure keeps the honest unavailable state.
+	fresh := multiProfileModel()
+	fresh.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
+	nm, _ = fresh.Update(usageMsg{profile: "default", avail: failed})
+	f := nm.(model)
+	if f.avail.ok || f.usageStale {
+		t.Errorf("no prior success → no retention, no stale flag (ok %v, stale %v)", f.avail.ok, f.usageStale)
+	}
+}
+
+// TestFooterHelpGutter: every physical help line — the compact row and every
+// row of the multi-line ? full help — carries the shared gut indentation, not
+// just the first one, and no footer line overflows the terminal.
+func TestFooterHelpGutter(t *testing.T) {
+	m := multiProfileModel()
+	wide, medium, _, _ := layoutSizes(t, m)
+	for _, tc := range []struct {
+		label string
+		s     termSize
+	}{{"wide", wide}, {"medium", medium}} {
+		m = resize(t, m, tc.s.w, tc.s.h)
+		m.help.ShowAll = true
+		footer := stripAnsi(m.footer())
+		flines := strings.Split(footer, "\n")
+		rule := -1
+		for i, l := range flines {
+			if strings.HasPrefix(l, "─") {
+				rule = i
+			}
+		}
+		help := flines[rule+1:]
+		if len(help) < 2 {
+			t.Fatalf("%s: full help must span multiple physical lines, got %d:\n%s", tc.label, len(help), footer)
+		}
+		for i, l := range help {
+			if strings.TrimSpace(l) == "" {
+				continue
+			}
+			if !strings.HasPrefix(l, strings.Repeat(" ", gut)) {
+				t.Errorf("%s: help line %d lost the %d-cell gutter: %q", tc.label, i, gut, l)
+			}
+		}
+		for i, l := range flines {
+			if w := lipgloss.Width(l); w > m.w {
+				t.Errorf("%s: footer line %d is %d cells for a %d-cell terminal: %q", tc.label, i, w, m.w, l)
+			}
+		}
+		m.help.ShowAll = false
 	}
 }


### PR DESCRIPTION
## Summary
- place Usage on the left and Routing on the right in the shared medium row
- favor Usage width while preserving Routing's useful minimum
- retain stale Fable/usage data across refresh failures with visible warnings and stable placeholders
- separate usage controls, align wrapped hotkeys, and require JSON from the local Ollama proposer

## Verification
- `CGO_ENABLED=0 nix shell nixpkgs#go --command go test ./...` in `pkgs/cli-kit`
- focused `pkgs/code-tui` build, vet, and Go tests
- truecolor tmux captures at 96x40 for healthy, missing-Fable, total-failure, no-prior-Fable, and full-help states
- freeze renders inspected; no over-width rows/footer overflow; truecolor SGR and PUA glyph codepoints verified

The medium layout interprets the requested side swap as Usage left / Routing right.