### PR TITLE
atyrode-tui: add grounded Ask panel

### DIFF
--- a/pkgs/atyrode-tui/README.md
+++ b/pkgs/atyrode-tui/README.md
@@ -11,8 +11,8 @@ operation to the existing CLI rather than reimplementing activation logic.
 - Bare non-TTY invocation continues to print CLI help.
 
 The wrapper exports `ATYRODE_CLI` before launching the cockpit. The TUI uses
-that exact executable for plan, preview, and apply commands, so packaged and
-checkout-specific behavior remain aligned.
+that exact executable for plan, preview, apply, and Ask grounding, so packaged
+and checkout-specific behavior remain aligned.
 
 ## Apply panel
 
@@ -32,6 +32,19 @@ the published branch advances while the cockpit is open. `n` or `esc` cancels
 confirmation, `r` resolves and previews the branch again, arrow keys or `j`/`k`
 scroll the preview, `d` toggles between the operator summary and normalized
 technical details, and `q` exits.
+
+## Ask panel
+
+Press `ctrl+o` to open the read-only Ask panel and ask a question about
+`atyrode`. The panel uses `cli-kit`'s `PromptBox` with the OMP Asker backend and
+streams the answer in place. On the first question it derives its grounding
+directly from `atyrode --help`, caches that command reference, and instructs the
+backend not to invent undocumented commands or flags. It does not expose Act
+mode, typed actions, or any command-execution path.
+
+Press `esc` or `ctrl+o` to close the panel. Either key cancels an in-flight
+request, and opening or closing the panel does not reset the apply plan,
+preview, selection, details mode, or confirmation state.
 
 ## Preview JSON contract
 
@@ -55,17 +68,18 @@ host, system, or full revision differs from the plan.
 
 ## Scope
 
-This package currently owns only the apply cockpit from issue #110. Follow-up
-panels remain separate:
+This package owns the apply cockpit from issue #110 and its read-only Ask panel
+from issue #117. Follow-up operational panels remain separate:
 
 - issue #111: generations, rollback, and clean;
-- issue #112: doctor, capabilities, and package inventory;
-- issue #117: the read-only Ask panel.
+- issue #112: doctor, capabilities, and package inventory.
 
 ## Verification
 
-`nix build .#atyrode-tui` runs the Go tests. The tests cover plan/preview command
-sequencing, explicit confirmation, failure safety, terminal-output normalization,
-responsive panel borders, capability layout, and narrow-window overflow. Visual
-changes should also follow `docs/tui-verification.md`: capture the app in tmux at
-representative sizes and inspect a truecolor ANSI render with `freeze`.
+`nix build .#atyrode-tui` runs the focused Go tests. They cover plan/preview
+command sequencing, explicit confirmation, failure safety, terminal-output
+normalization, responsive layout, CLI-derived Ask grounding, streamed
+completion, cancellation, toggle behavior, and preserved cockpit state. Visual
+changes also follow `docs/tui-verification.md`: capture the app in tmux under
+the truecolor environment and inspect both the character grid and a `freeze`
+render.

--- a/pkgs/atyrode-tui/main.go
+++ b/pkgs/atyrode-tui/main.go
@@ -2,12 +2,14 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 
 	previewdata "atyrode-tui/preview"
 	clikit "cli-kit"
@@ -58,10 +60,60 @@ type applyDoneMsg struct{ err error }
 type outputFunc func(string, ...string) ([]byte, error)
 type applyFunc func(string, ...string) tea.Cmd
 
+type askGroundingFunc func(context.Context, string) ([]byte, error)
+
+type groundedAsker struct {
+	cli       string
+	grounding askGroundingFunc
+	backend   func(clikit.DocCorpus) clikit.Asker
+
+	mu   sync.Mutex
+	docs clikit.DocCorpus
+}
+
+func (a *groundedAsker) Ask(ctx context.Context, prompt string) (<-chan string, error) {
+	docs, err := a.loadDocs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return a.backend(docs).Ask(ctx, prompt)
+}
+
+func (a *groundedAsker) loadDocs(ctx context.Context) (clikit.DocCorpus, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.docs != "" {
+		return a.docs, nil
+	}
+	help, err := a.grounding(ctx, a.cli)
+	if err != nil {
+		return "", commandError("load atyrode command reference", help, err)
+	}
+	docs, err := buildAskGrounding(help)
+	if err != nil {
+		return "", err
+	}
+	a.docs = docs
+	return docs, nil
+}
+
+func commandGrounding(ctx context.Context, cli string) ([]byte, error) {
+	return exec.CommandContext(ctx, cli, "--help").CombinedOutput()
+}
+
+func buildAskGrounding(help []byte) (clikit.DocCorpus, error) {
+	reference := strings.TrimSpace(stripTerminalControls(string(help)))
+	if reference == "" || !strings.Contains(reference, "Usage:") || !strings.Contains(reference, "atyrode ") {
+		return "", fmt.Errorf("load atyrode command reference: --help returned no recognizable usage")
+	}
+	return clikit.DocCorpus("You are atyrode's read-only Ask assistant. Answer questions about atyrode only from the command reference below. Never claim to execute commands or change the system. Do not invent commands, flags, behavior, or help forms. Suggest only exact invocations supported by the reference. If the reference does not answer a question, say that it is not documented and stop; do not suggest other commands or sources.\n\nCommand reference (from `atyrode --help`):\n" + reference), nil
+}
+
 type model struct {
 	cli     string
 	output  outputFunc
 	apply   applyFunc
+	asker   clikit.Asker
 	phase   phase
 	plan    applyPlan
 	preview previewdata.Document
@@ -85,16 +137,32 @@ func execApply(cli string, args ...string) tea.Cmd {
 	return tea.ExecProcess(cmd, func(err error) tea.Msg { return applyDoneMsg{err: err} })
 }
 
+func newAskBackend(docs clikit.DocCorpus) clikit.Asker {
+	asker := clikit.NewOmpAsker(docs)
+	asker.ReplaceSystem = true
+	return asker
+}
+
 func newModel(cli string) model {
+	asker := &groundedAsker{
+		cli:       cli,
+		grounding: commandGrounding,
+		backend:   newAskBackend,
+	}
 	return model{
 		cli:    cli,
 		output: commandOutput,
 		apply:  execApply,
+		asker:  asker,
 		phase:  loadingPlan,
 		width:  100,
 		height: 30,
 	}
 }
+
+func (m model) Asker() clikit.Asker { return m.asker }
+
+func (model) BoxTitle() string { return "ASK ATYRODE · read-only" }
 
 func (m model) Init() tea.Cmd { return m.loadPlan() }
 
@@ -618,7 +686,7 @@ func (m model) errorFooter() string {
 		}
 		lines[maxErrorLines-1] = ansi.Truncate(lines[maxErrorLines-1], tailWidth, "") + "…"
 	}
-	lines = append(lines, clikit.StDim.Render("r retry  ·  q quit"))
+	lines = append(lines, clikit.StDim.Render("^O ask  ·  r retry  ·  q quit"))
 	return strings.Join(lines, "\n")
 }
 
@@ -632,21 +700,24 @@ func (m model) footer() string {
 	}
 	switch m.phase {
 	case confirming:
-		if m.width < 60 {
-			return clikit.StWarn.Render("Apply?  y confirm  ·  n cancel  ·  d " + mode)
+		if m.width < 80 {
+			return clikit.StWarn.Render("^O ask  ·  y confirm  ·  n cancel")
 		}
-		return clikit.StWarn.Render("Apply this configuration?  y confirm  ·  n cancel  ·  d " + mode)
+		return clikit.StWarn.Render("Apply this configuration?  y confirm  ·  n cancel  ·  d " + mode + "  ·  ^O ask")
 	case applying:
-		return clikit.StDim.Render("Applying…")
+		return clikit.StDim.Render("Applying…  ·  ^O ask")
 	case applied:
-		return clikit.StOk.Render(m.status) + "\n" + clikit.StDim.Render("d "+mode+"  ·  r refresh  ·  q quit")
-	case ready:
 		if m.width < 60 {
-			return clikit.StDim.Render("d " + mode + "  ·  enter apply  ·  q quit")
+			return clikit.StOk.Render(m.status) + "\n" + clikit.StDim.Render("^O ask  ·  d "+mode+"  ·  r refresh  ·  q")
 		}
-		return clikit.StDim.Render("↑/↓ preview  ·  d " + mode + "  ·  a/enter apply  ·  r refresh  ·  q quit")
+		return clikit.StOk.Render(m.status) + "\n" + clikit.StDim.Render("^O ask  ·  d "+mode+"  ·  r refresh  ·  q quit")
+	case ready:
+		if m.width < 80 {
+			return clikit.StDim.Render("^O ask · d " + mode + " · enter apply · q")
+		}
+		return clikit.StDim.Render("↑/↓ preview  ·  d " + mode + "  ·  enter apply  ·  r refresh  ·  ^O ask  ·  q")
 	default:
-		return clikit.StDim.Render("q quit")
+		return clikit.StDim.Render("^O ask  ·  q quit")
 	}
 }
 

--- a/pkgs/atyrode-tui/main_test.go
+++ b/pkgs/atyrode-tui/main_test.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	previewdata "atyrode-tui/preview"
+	clikit "cli-kit"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -33,6 +36,117 @@ func testPreviewDocument() previewdata.Document {
 		Closure:     &previewdata.ClosureSummary{Previous: "1.50 GiB", Resulting: "1.49 GiB", Delta: "-5.59 MiB"},
 		Generations: &previewdata.GenerationPaths{Previous: "/nix/store/old-home-manager-generation", New: "/nix/store/new-home-manager-generation"},
 		Technical:   []string{"<<< /nix/store/old-home-manager-generation", ">>> /nix/store/new-home-manager-generation", "PATHS: 7529 -> 7536 (+5054, -5047)", "SIZE: 1.50 GiB -> 1.49 GiB", "DIFF: -5.59 MiB"},
+	}
+}
+
+type recordingAsker struct {
+	docs   clikit.DocCorpus
+	chunks []string
+}
+
+func (a *recordingAsker) Ask(context.Context, string) (<-chan string, error) {
+	ch := make(chan string, len(a.chunks))
+	for _, chunk := range a.chunks {
+		ch <- chunk
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestAskGroundingComesFromCLIHelp(t *testing.T) {
+	help := []byte(`Usage:
+  atyrode apply [HOST] [--ref REF] [--repo PATH] [--plan|--dry-run|--preview-json] [--json] [--restart-shell]
+apply preview modes are non-activating: --plan resolves and validates the target
+then prints preflight metadata without invoking nh; --dry-run invokes the normal
+nh switch backend with --dry; --preview-json runs that dry backend and emits its
+normalized package/action preview as JSON.
+`)
+	docs, err := buildAskGrounding(help)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(docs)
+	for _, want := range []string{"atyrode apply [HOST]", "--plan resolves and validates the target", "--dry-run invokes the normal", "--preview-json runs that dry backend", "read-only", "Do not invent"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("grounding missing %q: %q", want, got)
+		}
+	}
+	if _, err := buildAskGrounding([]byte("not command help")); err == nil {
+		t.Fatal("unrecognizable help unexpectedly produced grounding")
+	}
+	if backend, ok := newAskBackend(docs).(clikit.OmpAsker); !ok || !backend.ReplaceSystem {
+		t.Fatal("atyrode Ask backend did not isolate its grounded system prompt")
+	}
+}
+
+func TestGroundedAskerStreamsCompletionAndCachesHelp(t *testing.T) {
+	loadCalls := 0
+	var backend *recordingAsker
+	asker := &groundedAsker{
+		cli: "atyrode",
+		grounding: func(context.Context, string) ([]byte, error) {
+			loadCalls++
+			return []byte("Usage:\n  atyrode generations [--json] [--sizes]\n"), nil
+		},
+		backend: func(docs clikit.DocCorpus) clikit.Asker {
+			backend = &recordingAsker{docs: docs, chunks: []string{"first", " second"}}
+			return backend
+		},
+	}
+
+	for range 2 {
+		stream, err := asker.Ask(context.Background(), "how do generations work?")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var answer strings.Builder
+		for chunk := range stream {
+			answer.WriteString(chunk)
+		}
+		if got := answer.String(); got != "first second" {
+			t.Fatalf("streamed answer = %q", got)
+		}
+	}
+	if loadCalls != 1 {
+		t.Fatalf("--help loads = %d, want one cached load", loadCalls)
+	}
+	if backend == nil || !strings.Contains(string(backend.docs), "atyrode generations") {
+		t.Fatal("backend did not receive CLI-derived grounding")
+	}
+}
+
+type cancellingAsker struct{}
+
+func (cancellingAsker) Ask(ctx context.Context, _ string) (<-chan string, error) {
+	ch := make(chan string)
+	go func() {
+		defer close(ch)
+		<-ctx.Done()
+	}()
+	return ch, nil
+}
+
+func TestGroundedAskerCancellationClosesStream(t *testing.T) {
+	asker := &groundedAsker{
+		cli: "atyrode",
+		grounding: func(context.Context, string) ([]byte, error) {
+			return []byte("Usage:\n  atyrode host [HOST] [--json]\n"), nil
+		},
+		backend: func(clikit.DocCorpus) clikit.Asker { return cancellingAsker{} },
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := asker.Ask(ctx, "which host?")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	select {
+	case _, ok := <-stream:
+		if ok {
+			t.Fatal("cancelled stream produced a token")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled stream did not close")
 	}
 }
 

--- a/pkgs/cli-kit/README.md
+++ b/pkgs/cli-kit/README.md
@@ -28,7 +28,8 @@ small interfaces — structural, compile-time, à la carte:
 | `Documented` → `Docs() DocCorpus` | grounding injected into the backend's system prompt |
 
 `clikit.Run(app)` detects what's implemented and mounts the box behind a toggle
-key (default `ctrl+o`). Act mode takes precedence over Ask when both are present.
+key (default `ctrl+o`). The same key or `esc` closes it and cancels any in-flight
+request. Act mode takes precedence over Ask when both are present.
 
 ### Ask mode
 
@@ -43,8 +44,10 @@ func main() { _, _ = clikit.Run(helpApp{...}, clikit.WithAltScreen()) }
 
 `NewOmpAsker` shells out to a headless omp run
 (`omp -p --mode text --no-session --no-tools --model claude-haiku-4-5
---append-system-prompt <docs> <prompt>`) and streams the answer; cancelling (esc)
-kills the omp subprocess. Override the evaluator via `OmpAsker.Model`.
+--append-system-prompt <docs> <prompt>`) and streams the answer; dismissing the
+box kills the omp subprocess. Set `OmpAsker.ReplaceSystem` for a narrow grounded
+assistant that must replace the coding-agent prompt and managed scaffolding.
+Override the evaluator via `OmpAsker.Model`.
 
 ### Act mode
 

--- a/pkgs/cli-kit/ompasker.go
+++ b/pkgs/cli-kit/ompasker.go
@@ -17,9 +17,10 @@ const DefaultEvaluatorModel = "claude-haiku-4-5"
 // invoked at runtime, never linked. Cancelling the Ask context kills the omp
 // subprocess (exec.CommandContext), satisfying esc-to-cancel.
 type OmpAsker struct {
-	Bin   string    // omp binary; defaults to "omp" on PATH
-	Model string    // evaluator model; defaults to DefaultEvaluatorModel
-	Docs  DocCorpus // grounding, appended to omp's system prompt
+	Bin           string    // omp binary; defaults to "omp" on PATH
+	Model         string    // evaluator model; defaults to DefaultEvaluatorModel
+	Docs          DocCorpus // grounding injected into omp's system prompt
+	ReplaceSystem bool      // use docs as the complete system prompt and strip agent scaffolding
 }
 
 // NewOmpAsker builds an OmpAsker grounded in docs, with the default binary and
@@ -30,12 +31,11 @@ func NewOmpAsker(docs DocCorpus) OmpAsker {
 
 // ompArgs assembles the headless invocation: process one prompt and exit (-p),
 // plain streamed text, no session, no tools. thinking (if set) pins the reasoning
-// level. When replaceSystem is true this is BARE-CLASSIFIER mode: the docs REPLACE
-// omp's default system prompt (--system-prompt) AND omp's agent scaffolding
-// (rules, skills, extensions loaded from the managed ~/.omp) is stripped —
-// otherwise omp behaves like a coding agent and answers the prompt instead of
-// classifying it. When false the docs are appended and the agent stays intact.
-// Kept pure so the command line is unit-testable.
+// level. When replaceSystem is true the docs replace omp's default system prompt
+// and its managed agent scaffolding (rules, skills, extensions) is stripped. This
+// supports narrow grounded assistants and bare classifiers that must not inherit
+// general coding-agent behavior. When false the docs are appended and the agent
+// stays intact. Kept pure so the command line is unit-testable.
 func ompArgs(model, thinking string, replaceSystem bool, docs DocCorpus, prompt string) []string {
 	args := []string{"-p", "--mode", "text", "--no-session", "--no-tools"}
 	if replaceSystem {
@@ -68,7 +68,7 @@ func (o OmpAsker) Ask(ctx context.Context, prompt string) (<-chan string, error)
 	if model == "" {
 		model = DefaultEvaluatorModel
 	}
-	cmd := exec.CommandContext(ctx, bin, ompArgs(model, "", false, o.Docs, prompt)...)
+	cmd := exec.CommandContext(ctx, bin, ompArgs(model, "", o.ReplaceSystem, o.Docs, prompt)...)
 	return streamCmd(ctx, cmd)
 }
 

--- a/pkgs/cli-kit/promptbox_test.go
+++ b/pkgs/cli-kit/promptbox_test.go
@@ -216,6 +216,66 @@ func assertResizeHistory(t *testing.T, got, want []tea.WindowSizeMsg) {
 	}
 }
 
+type statefulAskableApp struct {
+	cursor int
+}
+
+func (statefulAskableApp) Init() tea.Cmd { return nil }
+func (a statefulAskableApp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if key, ok := msg.(tea.KeyMsg); ok && key.String() == "down" {
+		a.cursor++
+	}
+	return a, nil
+}
+func (statefulAskableApp) View() string { return "cockpit" }
+func (statefulAskableApp) Asker() Asker { return stubAsker{} }
+
+func TestHostTogglePreservesAppState(t *testing.T) {
+	h := newHost(statefulAskableApp{cursor: 7})
+	next, _ := h.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	h = next.(host)
+	if !h.active {
+		t.Fatal("toggle did not open prompt box")
+	}
+
+	next, _ = h.Update(tea.KeyMsg{Type: tea.KeyDown})
+	h = next.(host)
+	if got := h.app.(statefulAskableApp).cursor; got != 7 {
+		t.Fatalf("open prompt changed app cursor to %d", got)
+	}
+
+	next, _ = h.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	h = next.(host)
+	if h.active {
+		t.Fatal("second toggle did not close prompt box")
+	}
+	if got := h.app.(statefulAskableApp).cursor; got != 7 {
+		t.Fatalf("toggle round trip changed app cursor to %d", got)
+	}
+}
+
+func TestHostDismissCancelsBusyPrompt(t *testing.T) {
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyEsc},
+		{Type: tea.KeyCtrlO},
+	} {
+		h := newHost(statefulAskableApp{})
+		h.active = true
+		h.box.state = boxBusy
+		cancelled := false
+		h.box.cancel = func() { cancelled = true }
+
+		next, _ := h.Update(key)
+		h = next.(host)
+		if h.active {
+			t.Errorf("%s left prompt open", key.String())
+		}
+		if !cancelled || h.box.state != boxEditing {
+			t.Errorf("%s did not cancel busy prompt", key.String())
+		}
+	}
+}
+
 // stubCommander streams optional output and parses to a fixed action set.
 type stubCommander struct {
 	actions []Action

--- a/pkgs/cli-kit/run.go
+++ b/pkgs/cli-kit/run.go
@@ -134,6 +134,12 @@ func (h host) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case h.hasBox && !h.active && msg.String() == h.toggleKey:
 			h.active = true
 			cmd = h.box.Focus()
+		case h.active && (msg.String() == h.toggleKey || msg.String() == "esc"):
+			// Dismissing the overlay is one action even while a request is
+			// streaming. Feeding esc through PromptBox first cancels its context
+			// and invalidates trailing stream messages; then hide it immediately.
+			h.box, cmd = h.box.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			h.active = false
 		case h.active:
 			h.box, cmd = h.box.Update(msg)
 		default:


### PR DESCRIPTION
Closes #117

## Summary
- add a discoverable Ctrl+O Ask overlay using the shared `clikit.PromptBox`
- ground answers from the runtime-matched `atyrode --help` source of truth
- stream through the existing OMP Asker with tools disabled and isolated system grounding
- preserve apply cockpit state and cancel in-flight work on Esc or toggle
- keep the feature strictly read-only

## Verification
- `nix build .#atyrode-tui .#cli-kit .#atyrode --no-link`
- `nix run .#atyrode -- --help` confirmed the integrated inventory/preview help contract
- focused tests cover toggling, state preservation, grounding, streaming, and cancellation
- truecolor 120x40 tmux smoke exercised a real streamed OMP answer and live cancellation without apply
- character capture and freeze render inspected; footer, PUA glyphs, truecolor, and bottom overflow verified

Runtime Ask requires the configured OMP executable/model. No activation was performed.