### PR TITLE
code-tui: replay usage fill after profile switch

### DIFF
--- a/pkgs/code-tui/auth.go
+++ b/pkgs/code-tui/auth.go
@@ -152,6 +152,8 @@ func (m *model) switchAuthProfile() error {
 		return err
 	}
 	m.authIdx = next
+	m.hadUsage = false
+	m.barAnim = 0
 	m.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
 	m.nextRefresh = time.Time{}
 	return nil

--- a/pkgs/code-tui/auth_test.go
+++ b/pkgs/code-tui/auth_test.go
@@ -53,6 +53,76 @@ func TestAuthProfileSelectionPersists(t *testing.T) {
 	}
 }
 
+func TestAuthProfileSwitchReplaysUsageFill(t *testing.T) {
+	m := layoutModel()
+	m = resize(t, m, 120, 40)
+	loaded := m.avail
+	m.authProfiles = []authProfile{{ID: "default"}, {ID: "mum"}}
+	m.authState = filepath.Join(t.TempDir(), "selected")
+	m.hadUsage = true
+	m.barAnim = barAnimSteps / 2
+
+	if err := m.switchAuthProfile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := m.activeAuthProfile().ID; got != "mum" {
+		t.Fatalf("active profile = %q, want mum", got)
+	}
+	if m.hadUsage || m.barAnim != 0 || m.avail.ok {
+		t.Fatalf("switch must clear usage and re-arm its fill: hadUsage=%v barAnim=%d avail.ok=%v", m.hadUsage, m.barAnim, m.avail.ok)
+	}
+
+	nm, cmd := m.Update(usageMsg{profile: "default", avail: loaded})
+	m = nm.(model)
+	if cmd != nil || m.hadUsage || m.barAnim != 0 || m.avail.ok {
+		t.Fatal("a stale prior-profile result must remain ignored after the switch")
+	}
+
+	failed := availability{bucket: map[string]string{}, reset: map[string]int64{}}
+	nm, cmd = m.Update(usageMsg{profile: "mum", avail: failed})
+	m = nm.(model)
+	if cmd != nil || m.hadUsage || m.barAnim != 0 || m.avail.ok {
+		t.Fatal("a failed matching-profile fetch must not start or consume the fill")
+	}
+
+	nm, cmd = m.Update(usageMsg{profile: "mum", avail: loaded})
+	m = nm.(model)
+	if cmd == nil || !m.hadUsage || m.barAnim != 1 || !m.avail.ok {
+		t.Fatalf("the first successful switched-profile result must start the fill: cmd nil=%v hadUsage=%v barAnim=%d avail.ok=%v", cmd == nil, m.hadUsage, m.barAnim, m.avail.ok)
+	}
+	for m.barAnim != 0 {
+		nm, _ = m.Update(barAnimMsg{step: m.barAnim + 1})
+		m = nm.(model)
+	}
+
+	refreshed := loaded
+	refreshed.wins = append([]usageWin(nil), loaded.wins...)
+	refreshed.wins[0].pct = 78
+	nm, cmd = m.Update(usageMsg{profile: "mum", avail: refreshed})
+	m = nm.(model)
+	if cmd != nil || m.barAnim != 0 {
+		t.Fatal("a same-profile refresh must update directly without replaying the fill")
+	}
+	if got := m.avail.wins[0].pct; got != 78 {
+		t.Fatalf("same-profile refresh did not land: pct = %d, want 78", got)
+	}
+
+	if err := m.switchAuthProfile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := m.activeAuthProfile().ID; got != "default" {
+		t.Fatalf("active profile = %q after switching back, want default", got)
+	}
+	if m.hadUsage || m.barAnim != 0 || m.avail.ok {
+		t.Fatalf("switching back must re-arm the fill: hadUsage=%v barAnim=%d avail.ok=%v", m.hadUsage, m.barAnim, m.avail.ok)
+	}
+	nm, cmd = m.Update(usageMsg{profile: "default", avail: loaded})
+	m = nm.(model)
+	if cmd == nil || !m.hadUsage || m.barAnim != 1 {
+		t.Fatalf("switching back must replay the fill on success: cmd nil=%v hadUsage=%v barAnim=%d", cmd == nil, m.hadUsage, m.barAnim)
+	}
+}
+
 func TestLoadAvailabilityUsesSelectedProfile(t *testing.T) {
 	dir := t.TempDir()
 	argsPath := filepath.Join(dir, "args")

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -1242,7 +1242,7 @@ type model struct {
 
 	fetching    bool      // a usage fetch is in flight (manual or auto)
 	nextRefresh time.Time // when the next auto-refresh fires
-	hadUsage    bool      // a successful fetch has landed — gates the one-time first-load bar fill
+	hadUsage    bool      // a successful fetch has landed for this profile — gates its first-load bar fill
 	usageStale  bool      // the last refresh failed outright; avail is retained from an earlier success
 	barAnim     int       // first-load fill frame (1..barAnimSteps-1 = partial); 0 = inactive, bars at full value
 
@@ -1278,13 +1278,13 @@ func fetchUsageCmd(cmd, profile string) tea.Cmd {
 	return func() tea.Msg { return usageMsg{profile: profile, avail: loadAvailability(cmd, profile)} }
 }
 
-// First-load bar fill: the one-time animation that grows each usage bar from
-// empty to its real value when the FIRST successful fetch replaces the loading
-// skeleton. A dedicated bounded tick sequence — barAnimSteps frames at
+// First-load bar fill: the per-profile-context animation that grows each usage
+// bar from empty to its real value when the first successful fetch replaces the
+// loading skeleton. A dedicated bounded tick sequence — barAnimSteps frames at
 // barAnimInterval (8 × 25ms = 200ms total) — renders every bar's fill at
 // step/steps of its target; labels and numbers are real from the first frame,
-// only the fill animates. Refreshes (manual, auto, or post-switch) never
-// re-run it, and each tick schedules nothing beyond the next frame.
+// only the fill animates. Manual and automatic refreshes for the same profile
+// never re-run it, and each tick schedules nothing beyond the next frame.
 const (
 	barAnimSteps    = 8
 	barAnimInterval = 25 * time.Millisecond


### PR DESCRIPTION
## Summary
- re-arm the existing bounded usage-bar fill after a successful authentication profile switch
- cancel any in-progress prior-profile fill
- keep manual and automatic refreshes within the same profile non-animated

## Verification
- focused state-transition tests cover switch success/failure, stale prior-profile replies, same-profile refresh, and switching back
- full `pkgs/code-tui` Go tests passed
- `nix build .#code-tui` passed
- truecolor 150x44 tmux smoke observed partial-to-full fill after `a`, then a direct non-animated update after `r`; footer and width remained contained

The smoke used deterministic fake usage JSON; no live provider credentials were accessed.