### PR TITLE
atyrode-tui: inspect resolved capabilities

### DIFF
--- a/docs/atyrode.md
+++ b/docs/atyrode.md
@@ -14,14 +14,32 @@ and the other command surfaces) continues through the Bash CLI even on a TTY.
 Existing scripts therefore do not enter the cockpit.
 
 The apply panel first resolves the requested branch to an exact commit, then
-loads `atyrode apply --ref <commit> --preview-json`. Its default activation
-preview summarizes package, store-path, and closure-size changes without
-showing raw generation paths; `d` toggles normalized technical details, where
-the previous and new generation paths remain available with labels. Startup
-and refresh perform no activation. The operator must open the confirmation
-step and accept it; the real apply uses that same exact commit, so the activated
-configuration cannot drift from the preview if the branch advances while the
-cockpit is open.
+loads both `atyrode apply --ref <commit> --preview-json` and `atyrode inventory
+--ref <commit> --json` asynchronously. Its default activation preview
+summarizes package, store-path, and closure-size changes without showing raw
+generation paths; `d` toggles normalized technical details, where the previous
+and new generation paths remain available with labels.
+
+Press `c` to open or focus the active capability inventory. `[`/`]` (or
+left/right arrows) cycle in the apply plan's declared order, and `j`/`k` or
+arrows scroll the focused pane. Wide terminals keep a 42-cell capability panel
+beside the preview and use `Tab` to change focus; medium terminals use a
+full-width capability view; narrow terminals stack the selection summary above
+the scrollable details. `c` or `esc` returns to the preview without losing
+selection or either scroll position.
+
+Capability details are read only from the exact-revision CLI manifest. The
+cockpit validates schema version, full revision, system/platform identity, and
+the planned host's canonical id or alias before showing purpose, active state,
+resolved deliverables, and ownership/security/mutable-state boundaries.
+Loading and inventory failures remain textual and never block confirmation or
+fall back to stale data.
+
+Startup and refresh perform no activation. The operator must open the
+confirmation step and accept it; the real apply uses that same exact commit, so
+the activated configuration cannot drift from the preview if the branch
+advances while the cockpit is open. The `ctrl+o` Ask overlay remains read-only
+and preserves the full cockpit state.
 
 ## Applying a configuration
 

--- a/pkgs/atyrode-tui/README.md
+++ b/pkgs/atyrode-tui/README.md
@@ -16,22 +16,51 @@ and checkout-specific behavior remain aligned.
 
 ## Apply panel
 
-Startup performs two read-only operations in order:
+Startup resolves the apply plan first, then starts two read-only operations
+asynchronously:
 
 1. `atyrode apply --plan --json` supplies the host, system, target revision,
-   backend, and capabilities rendered in the plan panel. Remote plans include
-   the full commit as `resolvedRevision`.
+   backend, and active capabilities rendered in the plan panel. Remote plans
+   include the full commit as `resolvedRevision`.
 2. `atyrode apply --ref <resolvedRevision> --preview-json` runs the same
    read-only `nh … --dry` preview and returns the stable schema described below.
    The TUI renders that structure rather than parsing terminal text.
+3. `atyrode inventory --ref <resolvedRevision> --json` supplies the complete
+   capability manifest for that exact commit. The inventory load runs alongside
+   the preview and cannot block or disable apply confirmation.
 
 No activation occurs during startup. Pressing `a` or `enter` opens a confirmation
 step; only `y` then runs `atyrode apply --ref <resolvedRevision>` in the terminal.
 The preview and activation therefore address the same immutable commit even if
 the published branch advances while the cockpit is open. `n` or `esc` cancels
-confirmation, `r` resolves and previews the branch again, arrow keys or `j`/`k`
-scroll the preview, `d` toggles between the operator summary and normalized
-technical details, and `q` exits.
+confirmation, `r` resolves and previews
+the branch again, arrow keys or `j`/`k` scroll the focused pane, and `d` toggles
+between the operator summary and normalized technical details. Press `c` to
+open or focus capabilities and `c`/`esc` to return to the preview without
+resetting either pane.
+
+## Capability panel
+
+Capabilities appear in the apply plan's declared active order. The selected
+view shows `Title  n/N`, textual active/applicable state, resolved item count,
+purpose, deliverables grouped by kind, and delivery, system, security, and
+mutable-state boundaries. Deliberate marker capabilities such as `server`
+explicitly say that they have no direct deliverables. Descriptions lead each
+item; name, version, source, and delivery are secondary.
+
+Use `[`/`]` or left/right arrows to cycle backward and forward with wrapping.
+On wide terminals the activation preview remains beside a 42-cell capability
+panel; `Tab` moves scrolling focus between them. Medium terminals open a
+full-width capability view, while narrow terminals stack the selection summary
+over a safely wrapped, scrollable detail list. Selection and both independent
+scroll positions survive `c`, `esc`, focus changes, and the Ask overlay.
+
+The parser accepts inventory schema version 1 only, requires the manifest's
+full revision and system to equal the apply plan, derives the platform from that
+system, and resolves the planned host through its canonical id or aliases.
+Loading, command failures, and identity/schema mismatches remain visible as
+text inside the capability view. They never substitute stale inventory and
+never change preview or confirmation state.
 
 ## Ask panel
 
@@ -68,18 +97,21 @@ host, system, or full revision differs from the plan.
 
 ## Scope
 
-This package owns the apply cockpit from issue #110 and its read-only Ask panel
-from issue #117. Follow-up operational panels remain separate:
+This package owns the apply cockpit from issue #110, its read-only Ask panel
+from issue #117, and the capability inventory panel from issue #196. Follow-up
+operational panels remain separate:
 
 - issue #111: generations, rollback, and clean;
-- issue #112: doctor, capabilities, and package inventory.
+- issue #112: doctor and remaining operational read panels.
 
 ## Verification
 
-`nix build .#atyrode-tui` runs the focused Go tests. They cover plan/preview
-command sequencing, explicit confirmation, failure safety, terminal-output
-normalization, responsive layout, CLI-derived Ask grounding, streamed
-completion, cancellation, toggle behavior, and preserved cockpit state. Visual
-changes also follow `docs/tui-verification.md`: capture the app in tmux under
-the truecolor environment and inspect both the character grid and a `freeze`
-render.
+`nix build .#atyrode-tui` runs the focused Go tests. They cover plan, preview,
+and exact-revision inventory command sequencing; schema and identity
+validation; active order; cycling and focus; independent scroll preservation;
+grouping, empty markers, long text, platform state, loading and failure safety;
+explicit apply confirmation; responsive 140-, 100-, 72-, and 44-column
+layouts; CLI-derived Ask grounding; streaming; and cancellation. Visual changes
+also follow `docs/tui-verification.md`: capture the app in tmux under the
+truecolor environment, verify PUA codepoints and row bounds from the character
+grid, and inspect `freeze` renders.

--- a/pkgs/atyrode-tui/inventory/parser.go
+++ b/pkgs/atyrode-tui/inventory/parser.go
@@ -1,0 +1,116 @@
+package inventory
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+func Parse(data []byte, expected Expected) (Document, error) {
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return Document{}, fmt.Errorf("decode inventory: %w", err)
+	}
+	if manifest.SchemaVersion != SchemaVersion {
+		return Document{}, fmt.Errorf("inventory schema mismatch: got %d, need %d", manifest.SchemaVersion, SchemaVersion)
+	}
+	if !isFullRevision(manifest.Identity.Revision) {
+		return Document{}, fmt.Errorf("inventory identity has no full revision")
+	}
+	if manifest.Identity.Revision != expected.Revision {
+		return Document{}, fmt.Errorf("inventory revision mismatch: got %.12s, need %.12s", shortSafe(manifest.Identity.Revision), shortSafe(expected.Revision))
+	}
+	if manifest.Identity.System != expected.System {
+		return Document{}, fmt.Errorf("inventory system mismatch: got %q, need %q", manifest.Identity.System, expected.System)
+	}
+	if want := platformForSystem(expected.System); want == "" || manifest.Identity.Platform != want {
+		return Document{}, fmt.Errorf("inventory platform mismatch: got %q for %q", manifest.Identity.Platform, expected.System)
+	}
+
+	host, ok := resolveHost(manifest.Hosts, expected.Host)
+	if !ok {
+		return Document{}, fmt.Errorf("inventory host mismatch: %q is not a canonical id or alias", expected.Host)
+	}
+	if host.System != expected.System || host.Platform != manifest.Identity.Platform {
+		return Document{}, fmt.Errorf("inventory host identity mismatch for %q", host.ID)
+	}
+
+	active := make(map[string]bool, len(host.Capabilities))
+	for _, name := range host.Capabilities {
+		active[name] = true
+	}
+	capabilities := make([]Capability, 0, len(expected.ActiveCapabilities))
+	for _, name := range expected.ActiveCapabilities {
+		if !active[name] {
+			return Document{}, fmt.Errorf("inventory capability mismatch: %q is not active on %q", name, host.ID)
+		}
+		capability, ok := manifest.Capabilities[name]
+		if !ok {
+			return Document{}, fmt.Errorf("inventory capability missing: %q", name)
+		}
+		if capability.Name != name {
+			return Document{}, fmt.Errorf("inventory capability identity mismatch: key %q names %q", name, capability.Name)
+		}
+		for _, item := range capability.Deliverables {
+			if item.System != expected.System || item.Platform != manifest.Identity.Platform {
+				return Document{}, fmt.Errorf("inventory deliverable identity mismatch: %s/%s", name, item.Name)
+			}
+		}
+		capabilities = append(capabilities, capability)
+	}
+	return Document{Identity: manifest.Identity, Host: host, Capabilities: capabilities}, nil
+}
+
+func resolveHost(hosts map[string]Host, requested string) (Host, bool) {
+	for key, host := range hosts {
+		if host.ID == "" {
+			host.ID = key
+		}
+		if key == requested || host.ID == requested || contains(host.Aliases, requested) {
+			if host.ID != key {
+				return Host{}, false
+			}
+			return host, true
+		}
+	}
+	return Host{}, false
+}
+
+func contains(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func platformForSystem(system string) string {
+	switch {
+	case strings.HasSuffix(system, "-linux"):
+		return "linux"
+	case strings.HasSuffix(system, "-darwin"):
+		return "darwin"
+	default:
+		return ""
+	}
+}
+
+func isFullRevision(revision string) bool {
+	if len(revision) != 40 {
+		return false
+	}
+	for _, c := range revision {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+func shortSafe(value string) string {
+	if len(value) < 12 {
+		return value
+	}
+	return value[:12]
+}

--- a/pkgs/atyrode-tui/inventory/parser.go
+++ b/pkgs/atyrode-tui/inventory/parser.go
@@ -35,13 +35,26 @@ func Parse(data []byte, expected Expected) (Document, error) {
 		return Document{}, fmt.Errorf("inventory host identity mismatch for %q", host.ID)
 	}
 
-	active := make(map[string]bool, len(host.Capabilities))
+	planned := make(map[string]struct{}, len(expected.ActiveCapabilities))
+	for _, name := range expected.ActiveCapabilities {
+		if _, exists := planned[name]; exists {
+			return Document{}, fmt.Errorf("inventory capability mismatch: duplicate %q in apply plan", name)
+		}
+		planned[name] = struct{}{}
+	}
+	active := make(map[string]struct{}, len(host.Capabilities))
 	for _, name := range host.Capabilities {
-		active[name] = true
+		if _, exists := active[name]; exists {
+			return Document{}, fmt.Errorf("inventory capability mismatch: duplicate %q on %q", name, host.ID)
+		}
+		if _, expected := planned[name]; !expected {
+			return Document{}, fmt.Errorf("inventory capability mismatch: unexpected %q is active on %q", name, host.ID)
+		}
+		active[name] = struct{}{}
 	}
 	capabilities := make([]Capability, 0, len(expected.ActiveCapabilities))
 	for _, name := range expected.ActiveCapabilities {
-		if !active[name] {
+		if _, ok := active[name]; !ok {
 			return Document{}, fmt.Errorf("inventory capability mismatch: %q is not active on %q", name, host.ID)
 		}
 		capability, ok := manifest.Capabilities[name]

--- a/pkgs/atyrode-tui/inventory/parser_test.go
+++ b/pkgs/atyrode-tui/inventory/parser_test.go
@@ -68,6 +68,8 @@ func TestParseRejectsHostCapabilityAndDeliverableIdentityMismatch(t *testing.T) 
 	}{
 		{"host", `"desk"`, `"other"`, "host mismatch"},
 		{"capability", `"capabilities":["base","server"]`, `"capabilities":["base"]`, "capability mismatch"},
+		{"extra capability", `"capabilities":["base","server"]`, `"capabilities":["base","server","desktop"]`, "unexpected \"desktop\""},
+		{"duplicate capability", `"capabilities":["base","server"]`, `"capabilities":["base","server","base"]`, "duplicate \"base\""},
 		{"deliverable", `"system":"x86_64-linux","platform":"linux"}]`, `"system":"aarch64-linux","platform":"linux"}]`, "deliverable identity mismatch"},
 	}
 	for _, tt := range tests {
@@ -78,5 +80,14 @@ func TestParseRejectsHostCapabilityAndDeliverableIdentityMismatch(t *testing.T) 
 				t.Fatalf("error = %v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseRejectsDuplicatePlanCapability(t *testing.T) {
+	want := expected()
+	want.ActiveCapabilities = append(want.ActiveCapabilities, "base")
+	_, err := Parse([]byte(manifestJSON(1, revision, "x86_64-linux", "linux")), want)
+	if err == nil || !strings.Contains(err.Error(), `duplicate "base" in apply plan`) {
+		t.Fatalf("error = %v, want duplicate plan capability", err)
 	}
 }

--- a/pkgs/atyrode-tui/inventory/parser_test.go
+++ b/pkgs/atyrode-tui/inventory/parser_test.go
@@ -1,0 +1,82 @@
+package inventory
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const revision = "feedfacefeedfacefeedfacefeedfacefeedface"
+
+func manifestJSON(schema int, identityRevision, system, platform string) string {
+	return fmt.Sprintf(`{
+		"schemaVersion":%d,
+		"identity":{"revision":%q,"system":%q,"platform":%q},
+		"capabilities":{
+			"base":{"name":"base","title":"Base","purpose":"Shell baseline","consumer":"operator","group":"core","platforms":["linux","darwin"],"applicable":true,"marker":false,"deliveryBoundary":"Home Manager","mutableState":"Caches only","securityBoundary":"No credentials","selectedOnHosts":["workstation"],"deliverables":[{"kind":"package","name":"git","version":"2.50","description":"Distributed version control","homepage":"https://git-scm.com","delivery":"home-manager","source":"pinned-nixpkgs","system":%q,"platform":%q}]},
+			"server":{"name":"server","title":"Server","purpose":"Headless composition marker","consumer":"servers","group":"operations","platforms":["linux"],"applicable":true,"marker":true,"deliveryBoundary":"Marker capability","mutableState":"System-owned","securityBoundary":"No production facts","selectedOnHosts":["workstation"],"deliverables":[]}
+		},
+		"hosts":{"workstation":{"id":"workstation","aliases":["desk"],"description":"fixture","hostname":"desk","platform":%q,"system":%q,"capabilities":["base","server"]}}
+	}`, schema, identityRevision, system, platform, system, platform, platform, system)
+}
+
+func expected() Expected {
+	return Expected{Revision: revision, System: "x86_64-linux", Host: "desk", ActiveCapabilities: []string{"server", "base"}}
+}
+
+func TestParseUsesPlanOrderAndCanonicalAlias(t *testing.T) {
+	doc, err := Parse([]byte(manifestJSON(1, revision, "x86_64-linux", "linux")), expected())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.Host.ID != "workstation" {
+		t.Fatalf("host = %q", doc.Host.ID)
+	}
+	if got := []string{doc.Capabilities[0].Name, doc.Capabilities[1].Name}; strings.Join(got, ",") != "server,base" {
+		t.Fatalf("capability order = %v", got)
+	}
+	if !doc.Capabilities[0].Marker || len(doc.Capabilities[0].Deliverables) != 0 {
+		t.Fatal("empty marker was not preserved")
+	}
+}
+
+func TestParseRejectsSchemaRevisionSystemAndPlatformMismatch(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want string
+	}{
+		{"schema", manifestJSON(2, revision, "x86_64-linux", "linux"), "schema mismatch"},
+		{"short revision", manifestJSON(1, "feedface", "x86_64-linux", "linux"), "no full revision"},
+		{"revision", manifestJSON(1, strings.Repeat("a", 40), "x86_64-linux", "linux"), "revision mismatch"},
+		{"system", manifestJSON(1, revision, "aarch64-linux", "linux"), "system mismatch"},
+		{"platform", manifestJSON(1, revision, "x86_64-linux", "darwin"), "platform mismatch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.json), expected())
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRejectsHostCapabilityAndDeliverableIdentityMismatch(t *testing.T) {
+	tests := []struct {
+		name, replace, with, want string
+	}{
+		{"host", `"desk"`, `"other"`, "host mismatch"},
+		{"capability", `"capabilities":["base","server"]`, `"capabilities":["base"]`, "capability mismatch"},
+		{"deliverable", `"system":"x86_64-linux","platform":"linux"}]`, `"system":"aarch64-linux","platform":"linux"}]`, "deliverable identity mismatch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := strings.Replace(manifestJSON(1, revision, "x86_64-linux", "linux"), tt.replace, tt.with, 1)
+			_, err := Parse([]byte(data), expected())
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/pkgs/atyrode-tui/inventory/schema.go
+++ b/pkgs/atyrode-tui/inventory/schema.go
@@ -50,8 +50,8 @@ type Host struct {
 type Manifest struct {
 	SchemaVersion int                   `json:"schemaVersion"`
 	Identity      Identity              `json:"identity"`
-	Capabilities map[string]Capability `json:"capabilities"`
-	Hosts        map[string]Host       `json:"hosts"`
+	Capabilities  map[string]Capability `json:"capabilities"`
+	Hosts         map[string]Host       `json:"hosts"`
 }
 
 type Expected struct {

--- a/pkgs/atyrode-tui/inventory/schema.go
+++ b/pkgs/atyrode-tui/inventory/schema.go
@@ -1,0 +1,68 @@
+// Package inventory decodes the stable atyrode inventory JSON contract.
+package inventory
+
+const SchemaVersion = 1
+
+type Identity struct {
+	Revision string `json:"revision"`
+	System   string `json:"system"`
+	Platform string `json:"platform"`
+}
+
+type Deliverable struct {
+	Kind        string  `json:"kind"`
+	Name        string  `json:"name"`
+	Version     string  `json:"version"`
+	Description string  `json:"description"`
+	Homepage    *string `json:"homepage"`
+	Delivery    string  `json:"delivery"`
+	Source      string  `json:"source"`
+	System      string  `json:"system"`
+	Platform    string  `json:"platform"`
+}
+
+type Capability struct {
+	Name             string        `json:"name"`
+	Title            string        `json:"title"`
+	Purpose          string        `json:"purpose"`
+	Consumer         string        `json:"consumer"`
+	Group            string        `json:"group"`
+	Platforms        []string      `json:"platforms"`
+	Applicable       bool          `json:"applicable"`
+	Marker           bool          `json:"marker"`
+	DeliveryBoundary string        `json:"deliveryBoundary"`
+	MutableState     string        `json:"mutableState"`
+	SecurityBoundary string        `json:"securityBoundary"`
+	SelectedOnHosts  []string      `json:"selectedOnHosts"`
+	Deliverables     []Deliverable `json:"deliverables"`
+}
+
+type Host struct {
+	ID           string   `json:"id"`
+	Aliases      []string `json:"aliases"`
+	Description  string   `json:"description"`
+	Hostname     string   `json:"hostname"`
+	Platform     string   `json:"platform"`
+	System       string   `json:"system"`
+	Capabilities []string `json:"capabilities"`
+}
+
+type Manifest struct {
+	SchemaVersion int                   `json:"schemaVersion"`
+	Identity      Identity              `json:"identity"`
+	Capabilities map[string]Capability `json:"capabilities"`
+	Hosts        map[string]Host       `json:"hosts"`
+}
+
+type Expected struct {
+	Revision           string
+	System             string
+	Host               string
+	ActiveCapabilities []string
+}
+
+type Document struct {
+	Identity     Identity
+	Host         Host
+	Capabilities []Capability
+}

--- a/pkgs/atyrode-tui/main.go
+++ b/pkgs/atyrode-tui/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	inventorydata "atyrode-tui/inventory"
 	previewdata "atyrode-tui/preview"
 	clikit "cli-kit"
 	tea "github.com/charmbracelet/bubbletea"
@@ -54,6 +55,18 @@ type previewMsg struct {
 	preview previewdata.Document
 	err     error
 }
+type inventoryMsg struct {
+	inventory inventorydata.Document
+	err       error
+}
+
+type pane int
+
+const (
+	previewPane pane = iota
+	capabilityPane
+)
+
 
 type applyDoneMsg struct{ err error }
 
@@ -114,15 +127,22 @@ type model struct {
 	output  outputFunc
 	apply   applyFunc
 	asker   clikit.Asker
-	phase   phase
-	plan    applyPlan
-	preview previewdata.Document
-	details bool
-	cursor  int
-	width   int
-	height  int
-	err     error
-	status  string
+	phase              phase
+	plan               applyPlan
+	preview            previewdata.Document
+	inventory          inventorydata.Document
+	inventoryLoading   bool
+	inventoryErr       error
+	details            bool
+	capabilitiesOpen   bool
+	focus              pane
+	previewCursor      int
+	capabilityCursor   int
+	selectedCapability int
+	width              int
+	height             int
+	err                error
+	status             string
 }
 
 func commandOutput(name string, args ...string) ([]byte, error) {
@@ -202,6 +222,25 @@ func (m model) loadPreview() tea.Cmd {
 		return previewMsg{preview: result}
 	}
 }
+func (m model) loadInventory() tea.Cmd {
+	return func() tea.Msg {
+		out, err := m.output(m.cli, "inventory", "--ref", m.plan.ResolvedRevision, "--json")
+		if err != nil {
+			return inventoryMsg{err: commandError("inventory unavailable", out, err)}
+		}
+		result, err := inventorydata.Parse(out, inventorydata.Expected{
+			Revision:           m.plan.ResolvedRevision,
+			System:             m.plan.System,
+			Host:               m.plan.Host,
+			ActiveCapabilities: m.plan.Capabilities,
+		})
+		if err != nil {
+			return inventoryMsg{err: err}
+		}
+		return inventoryMsg{inventory: result}
+	}
+}
+
 
 func (m model) applyArgs(preview bool) []string {
 	args := []string{"apply"}
@@ -262,14 +301,27 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.plan, m.phase, m.err = msg.plan, loadingPreview, nil
-		return m, m.loadPreview()
+		m.inventory, m.inventoryErr, m.inventoryLoading = inventorydata.Document{}, nil, true
+		return m, tea.Batch(m.loadPreview(), m.loadInventory())
 	case previewMsg:
 		if msg.err != nil {
 			m.phase, m.err = failed, msg.err
 			return m, nil
 		}
 		m.preview = msg.preview
-		m.phase, m.err, m.cursor, m.details = ready, nil, 0, false
+		m.phase, m.err, m.previewCursor, m.details = ready, nil, 0, false
+		return m, nil
+	case inventoryMsg:
+		m.inventoryLoading = false
+		if msg.err != nil {
+			m.inventory, m.inventoryErr = inventorydata.Document{}, msg.err
+		} else {
+			m.inventory, m.inventoryErr = msg.inventory, nil
+			if m.selectedCapability >= len(m.inventory.Capabilities) {
+				m.selectedCapability = 0
+				m.capabilityCursor = 0
+			}
+		}
 		return m, nil
 	case applyDoneMsg:
 		if msg.err != nil {
@@ -284,33 +336,50 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "r":
 			if m.phase != applying {
-				m.phase, m.err, m.status, m.preview, m.cursor, m.details = loadingPlan, nil, "", previewdata.Document{}, 0, false
+				m.phase, m.err, m.status, m.preview, m.inventory = loadingPlan, nil, "", previewdata.Document{}, inventorydata.Document{}
+				m.inventoryErr, m.inventoryLoading, m.details = nil, false, false
+				m.capabilitiesOpen, m.focus = false, previewPane
+				m.previewCursor, m.capabilityCursor, m.selectedCapability = 0, 0, 0
 				return m, m.loadPlan()
 			}
-		case "up", "k":
-			if m.cursor > 0 {
-				m.cursor--
-			}
-		case "down", "j":
-			if m.cursor+1 < len(m.previewRows()) {
-				m.cursor++
-			}
-		case "pgup":
-			m.cursor -= m.previewHeight()
-			if m.cursor < 0 {
-				m.cursor = 0
-			}
-		case "pgdown":
-			m.cursor += m.previewHeight()
-			if m.cursor >= len(m.previewRows()) {
-				m.cursor = len(m.previewRows()) - 1
-			}
-			if m.cursor < 0 {
-				m.cursor = 0
-			}
-		case "d":
+		case "c":
 			if m.phase == ready || m.phase == confirming || m.phase == applied {
-				m.details, m.cursor = !m.details, 0
+				if m.focus == capabilityPane {
+					m.focus = previewPane
+					if !m.isWide() {
+						m.capabilitiesOpen = false
+					}
+				} else {
+					m.focus, m.capabilitiesOpen = capabilityPane, true
+				}
+			}
+		case "tab":
+			if m.isWide() && (m.phase == ready || m.phase == confirming || m.phase == applied) {
+				if m.focus == capabilityPane {
+					m.focus = previewPane
+				} else {
+					m.focus, m.capabilitiesOpen = capabilityPane, true
+				}
+			}
+		case "[", "left":
+			if m.focus == capabilityPane {
+				m = m.cycleCapability(-1)
+			}
+		case "]", "right":
+			if m.focus == capabilityPane {
+				m = m.cycleCapability(1)
+			}
+		case "up", "k":
+			m = m.scrollFocused(-1)
+		case "down", "j":
+			m = m.scrollFocused(1)
+		case "pgup":
+			m = m.scrollFocused(-m.paneBodyHeight())
+		case "pgdown":
+			m = m.scrollFocused(m.paneBodyHeight())
+		case "d":
+			if m.focus == previewPane && (m.phase == ready || m.phase == confirming || m.phase == applied) {
+				m.details, m.previewCursor = !m.details, 0
 			}
 		case "a", "enter":
 			if m.phase == ready {
@@ -321,13 +390,51 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.phase, m.err = applying, nil
 				return m, m.apply(m.cli, m.applyArgs(false)...)
 			}
-		case "n", "esc":
+		case "n":
 			if m.phase == confirming {
+				m.phase = ready
+			}
+		case "esc":
+			if m.focus == capabilityPane {
+				m.focus = previewPane
+				if !m.isWide() {
+					m.capabilitiesOpen = false
+				}
+			} else if m.phase == confirming {
 				m.phase = ready
 			}
 		}
 	}
 	return m, nil
+}
+
+func (m model) cycleCapability(delta int) model {
+	count := len(m.inventory.Capabilities)
+	if count == 0 {
+		return m
+	}
+	m.selectedCapability = (m.selectedCapability + delta + count) % count
+	m.capabilityCursor = 0
+	return m
+}
+
+func (m model) scrollFocused(delta int) model {
+	if m.focus == capabilityPane {
+		m.capabilityCursor = clampCursor(m.capabilityCursor+delta, len(m.capabilityRows()))
+	} else {
+		m.previewCursor = clampCursor(m.previewCursor+delta, len(m.previewRows()))
+	}
+	return m
+}
+
+func clampCursor(cursor, rows int) int {
+	if cursor < 0 || rows == 0 {
+		return 0
+	}
+	if cursor >= rows {
+		return rows - 1
+	}
+	return cursor
 }
 
 var (
@@ -341,14 +448,54 @@ var (
 
 func (m model) View() string {
 	margin, panelWidth := m.horizontalLayout()
+	content := m.previewBox(panelWidth)
+	if m.isWide() {
+		previewWidth, capabilityWidth := m.splitWidths(panelWidth)
+		content = lipgloss.JoinHorizontal(lipgloss.Top, m.previewBox(previewWidth), " ", m.capabilityBox(capabilityWidth))
+	} else if m.capabilitiesOpen {
+		content = m.capabilityBox(panelWidth)
+	}
 
 	sections := []string{
 		titleStyle.Render("ATYRODE") + "  " + pillStyle.Render("apply"),
 		m.header(panelWidth),
-		m.previewBox(panelWidth),
+		content,
 		m.footer(),
 	}
 	return clikit.PadLeft(strings.Join(sections, "\n\n"), margin)
+}
+
+func (m model) isWide() bool { return m.width >= 112 }
+
+func (m model) splitWidths(total int) (previewWidth, capabilityWidth int) {
+	capabilityWidth = 42
+	if total < 84 {
+		capabilityWidth = max(38, total/2)
+	}
+	previewWidth = max(1, total-capabilityWidth-1)
+	return previewWidth, capabilityWidth
+}
+
+func (m model) contentPanelWidth() int {
+	_, total := m.horizontalLayout()
+	if m.isWide() {
+		previewWidth, capabilityWidth := m.splitWidths(total)
+		if m.focus == capabilityPane {
+			return capabilityWidth
+		}
+		return previewWidth
+	}
+	return total
+}
+
+func (m model) contentOuterHeight() int {
+	_, width := m.horizontalLayout()
+	fixed := 1 + lipgloss.Height(m.header(width)) + lipgloss.Height(m.footer()) + 7
+	return max(4, m.height-fixed)
+}
+
+func (m model) paneBodyHeight() int {
+	return max(1, m.contentOuterHeight()-3)
 }
 
 func (m model) horizontalLayout() (margin, panelWidth int) {
@@ -380,8 +527,8 @@ func (m model) header(width int) string {
 	if targetWidth < 1 {
 		targetWidth = 1
 	}
-	target := ansi.Truncate(m.plan.Installable, targetWidth, "")
-	compactTarget := ansi.Truncate(m.plan.Installable, available-2, "")
+	target := ansi.Truncate(m.plan.Installable, targetWidth, "…")
+	compactTarget := ansi.Truncate(m.plan.Installable, available-2, "…")
 	var lines []string
 	system := m.plan.System
 	if width >= 50 {
@@ -471,16 +618,7 @@ func capabilityChips(capabilities []string, width int) string {
 }
 
 func (m model) previewHeight() int {
-	_, width := m.horizontalLayout()
-	// Three blank separators plus the title, preview border/title, footer, and
-	// two terminal auto-wrap safety rows consume ten rows. Measuring the rendered
-	// header keeps narrow layouts from pushing the title into scrollback.
-	fixedRows := lipgloss.Height(m.header(width)) + lipgloss.Height(m.footer()) + 10
-	h := m.height - fixedRows
-	if h < 1 {
-		h = 1
-	}
-	return h
+	return m.paneBodyHeight()
 }
 
 func (m model) previewBox(width int) string {
@@ -496,23 +634,169 @@ func (m model) previewBox(width int) string {
 		if m.preview.SchemaVersion == 0 {
 			body = clikit.StDim.Render("Preview unavailable.")
 		} else {
-			previewWidth := panelContentWidth(width) - 4
-			if previewWidth < 1 {
-				previewWidth = 1
-			}
-			body = clikit.WindowList(m.previewRowsForWidth(max(1, previewWidth-1)), m.cursor, m.previewHeight(), previewWidth)
+			previewWidth := max(1, panelContentWidth(width)-4)
+			body = clikit.WindowList(m.previewRowsForWidth(max(1, previewWidth-1)), m.previewCursor, m.previewHeight(), previewWidth)
 		}
 	}
-	label := iconStyle.Render("\uf0ad") + "  " + titleStyle.Render("ACTIVATION PREVIEW") + "\n"
-	return panel(width, label+body)
+	label := iconStyle.Render("\uf0ad") + "  " + titleStyle.Render("ACTIVATION PREVIEW")
+	if m.focus == previewPane {
+		label += clikit.StHead.Render("  ·  FOCUSED")
+	}
+	return panel(width, label+"\n"+body)
 }
+func (m model) capabilityPanelWidth() int {
+	_, total := m.horizontalLayout()
+	if m.isWide() {
+		_, width := m.splitWidths(total)
+		return width
+	}
+	return total
+}
+
+func (m model) capabilityBox(width int) string {
+	bodyWidth := max(1, panelContentWidth(width)-4)
+	rows := m.capabilityRowsForWidth(max(1, bodyWidth-1))
+	body := clikit.WindowList(rows, m.capabilityCursor, m.paneBodyHeight(), bodyWidth)
+	label := iconStyle.Render("\uf085") + "  " + titleStyle.Render("CAPABILITIES")
+	if m.focus == capabilityPane {
+		label += clikit.StHead.Render("  ·  FOCUSED")
+	}
+	return panel(width, label+"\n"+body)
+}
+
+func (m model) capabilityRows() []string {
+	width := max(1, panelContentWidth(m.capabilityPanelWidth())-5)
+	return m.capabilityRowsForWidth(width)
+}
+
+func (m model) capabilityRowsForWidth(width int) []string {
+	rows := make([]string, 0, 32)
+	switch {
+	case m.inventoryLoading:
+		appendWrappedRow(&rows, clikit.StDim.Render("Loading exact-revision inventory…"), width)
+		return rows
+	case m.inventoryErr != nil:
+		appendWrappedRow(&rows, clikit.StBrk.Bold(true).Render("Inventory unavailable"), width)
+		rows = append(rows, "")
+		appendWrappedRow(&rows, clikit.StDim.Render(stripTerminalControls(m.inventoryErr.Error())), width)
+		rows = append(rows, "")
+		appendWrappedRow(&rows, "The activation preview and apply confirmation remain available.", width)
+		return rows
+	case len(m.inventory.Capabilities) == 0:
+		appendWrappedRow(&rows, clikit.StDim.Render("No active capabilities were declared by this apply plan."), width)
+		return rows
+	}
+
+	index := m.selectedCapability
+	if index < 0 || index >= len(m.inventory.Capabilities) {
+		index = 0
+	}
+	capability := m.inventory.Capabilities[index]
+	appendWrappedRow(&rows, titleStyle.Render(capability.Title)+clikit.StDim.Render(fmt.Sprintf("  %d/%d", index+1, len(m.inventory.Capabilities))), width)
+	state := "ACTIVE"
+	if !capability.Applicable {
+		state = "ACTIVE · NOT APPLICABLE ON " + strings.ToUpper(m.inventory.Identity.Platform)
+	}
+	appendWrappedRow(&rows, clikit.StHead.Render(state)+clikit.StDim.Render(fmt.Sprintf("  ·  %d items", len(capability.Deliverables))), width)
+	rows = append(rows, "")
+	appendWrappedRow(&rows, capability.Purpose, width)
+
+	if len(capability.Deliverables) == 0 {
+		rows = append(rows, "")
+		marker := "No direct deliverables."
+		if capability.Marker {
+			marker = "Intentional marker · no direct deliverables."
+		}
+		appendWrappedRow(&rows, clikit.StWarn.Render(marker), width)
+	} else {
+		for _, group := range deliverableGroups(capability.Deliverables) {
+			rows = append(rows, "")
+			appendWrappedRow(&rows, titleStyle.Render(fmt.Sprintf("%s (%d)", kindTitle(group.kind), len(group.items))), width)
+			for _, item := range group.items {
+				appendIndentedWrappedRow(&rows, item.Description, width, 2)
+				secondary := strings.TrimSpace(strings.Join(nonEmpty(item.Name, item.Version, item.Source), "  ·  "))
+				if secondary != "" {
+					appendIndentedWrappedRow(&rows, clikit.StDim.Render(secondary), width, 4)
+				}
+				if item.Delivery != "" {
+					appendIndentedWrappedRow(&rows, clikit.StDim.Render("via "+item.Delivery), width, 4)
+				}
+				if item.System != "" {
+					appendIndentedWrappedRow(&rows, clikit.StDim.Render("for "+item.System), width, 4)
+				}
+			}
+		}
+	}
+
+	boundaries := []struct {
+		label string
+		value string
+	}{
+		{label: "Delivery boundary", value: capability.DeliveryBoundary},
+		{label: "Security boundary", value: capability.SecurityBoundary},
+		{label: "Mutable state", value: capability.MutableState},
+	}
+	for _, boundary := range boundaries {
+		if boundary.value == "" {
+			continue
+		}
+		rows = append(rows, "")
+		appendWrappedRow(&rows, clikit.StHead.Render(boundary.label), width)
+		appendIndentedWrappedRow(&rows, clikit.StDim.Render(boundary.value), width, 2)
+	}
+	return rows
+}
+
+type deliverableGroup struct {
+	kind  string
+	items []inventorydata.Deliverable
+}
+
+func deliverableGroups(items []inventorydata.Deliverable) []deliverableGroup {
+	groups := make([]deliverableGroup, 0, 2)
+	indices := make(map[string]int, 2)
+	for _, item := range items {
+		index, ok := indices[item.Kind]
+		if !ok {
+			index = len(groups)
+			indices[item.Kind] = index
+			groups = append(groups, deliverableGroup{kind: item.Kind})
+		}
+		groups[index].items = append(groups[index].items, item)
+	}
+	return groups
+}
+
+func kindTitle(kind string) string {
+	switch kind {
+	case "package":
+		return "Packages"
+	case "application":
+		return "Applications"
+	case "":
+		return "Deliverables"
+	default:
+		return strings.ToUpper(kind[:1]) + kind[1:]
+	}
+}
+
+func nonEmpty(values ...string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != "" {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
 
 func (m model) previewRows() []string {
 	_, width := m.horizontalLayout()
-	previewWidth := panelContentWidth(width) - 4
-	if previewWidth < 1 {
-		previewWidth = 1
+	if m.isWide() {
+		width, _ = m.splitWidths(width)
 	}
+	previewWidth := max(1, panelContentWidth(width)-4)
 	return m.previewRowsForWidth(max(1, previewWidth-1))
 }
 
@@ -698,24 +982,47 @@ func (m model) footer() string {
 	if m.details {
 		mode = "summary"
 	}
+	if m.focus == capabilityPane {
+		controls := "↑/↓ scroll  ·  [/] cycle  ·  c back"
+		if m.isWide() {
+			controls = "↑/↓ capability  ·  [/] cycle  ·  Tab/c preview"
+		}
+		if m.width < 60 {
+			if m.phase == confirming {
+				return clikit.StWarn.Render("[/] cycle  ·  c back  ·  y/n apply")
+			}
+			return clikit.StDim.Render(controls)
+		}
+		if m.phase == confirming && m.width < 68 {
+			return clikit.StWarn.Render("[/] cycle  ·  c back  ·  y/n apply")
+		}
+		if m.phase == confirming {
+			controls += "  ·  y confirm  ·  n cancel"
+			return clikit.StWarn.Render(controls)
+		}
+		return clikit.StDim.Render(controls + "  ·  ^O ask  ·  q")
+	}
 	switch m.phase {
 	case confirming:
 		if m.width < 80 {
-			return clikit.StWarn.Render("^O ask  ·  y confirm  ·  n cancel")
+			return clikit.StWarn.Render("y confirm  ·  n cancel  ·  c capabilities")
 		}
-		return clikit.StWarn.Render("Apply this configuration?  y confirm  ·  n cancel  ·  d " + mode + "  ·  ^O ask")
+		return clikit.StWarn.Render("Apply this configuration?  y confirm  ·  n cancel  ·  d " + mode + "  ·  c capabilities  ·  ^O ask")
 	case applying:
 		return clikit.StDim.Render("Applying…  ·  ^O ask")
 	case applied:
 		if m.width < 60 {
-			return clikit.StOk.Render(m.status) + "\n" + clikit.StDim.Render("^O ask  ·  d "+mode+"  ·  r refresh  ·  q")
+			return clikit.StOk.Render(m.status) + "\n" + clikit.StDim.Render("c capabilities  ·  r refresh  ·  q")
 		}
-		return clikit.StOk.Render(m.status) + "\n" + clikit.StDim.Render("^O ask  ·  d "+mode+"  ·  r refresh  ·  q quit")
+		return clikit.StOk.Render(m.status) + "\n" + clikit.StDim.Render("c capabilities  ·  d "+mode+"  ·  r refresh  ·  ^O ask  ·  q quit")
 	case ready:
-		if m.width < 80 {
-			return clikit.StDim.Render("^O ask · d " + mode + " · enter apply · q")
+		if m.width < 60 {
+			return clikit.StDim.Render("c capabilities  ·  enter apply  ·  q")
 		}
-		return clikit.StDim.Render("↑/↓ preview  ·  d " + mode + "  ·  enter apply  ·  r refresh  ·  ^O ask  ·  q")
+		if m.width < 112 {
+			return clikit.StDim.Render("↑/↓ preview  ·  c capabilities  ·  d " + mode + "  ·  enter apply  ·  q")
+		}
+		return clikit.StDim.Render("↑/↓ preview  ·  Tab/c capabilities  ·  d " + mode + "  ·  enter apply  ·  r refresh  ·  ^O ask  ·  q")
 	default:
 		return clikit.StDim.Render("^O ask  ·  q quit")
 	}

--- a/pkgs/atyrode-tui/main.go
+++ b/pkgs/atyrode-tui/main.go
@@ -70,7 +70,6 @@ const (
 	capabilityPane
 )
 
-
 type applyDoneMsg struct{ err error }
 
 type outputFunc func(string, ...string) ([]byte, error)
@@ -254,7 +253,6 @@ func (m model) loadInventory() tea.Cmd {
 		return inventoryMsg{revision: revision, generation: generation, inventory: result}
 	}
 }
-
 
 func (m model) applyArgs(preview bool) []string {
 	args := []string{"apply"}
@@ -850,7 +848,6 @@ func nonEmpty(values ...string) []string {
 	}
 	return result
 }
-
 
 func (m model) previewRows() []string {
 	_, width := m.horizontalLayout()

--- a/pkgs/atyrode-tui/main.go
+++ b/pkgs/atyrode-tui/main.go
@@ -56,8 +56,11 @@ type previewMsg struct {
 	err     error
 }
 type inventoryMsg struct {
-	inventory inventorydata.Document
-	err       error
+	revision   string
+	generation uint64
+	inventory  inventorydata.Document
+	err        error
+	diagnostic string
 }
 
 type pane int
@@ -123,16 +126,21 @@ func buildAskGrounding(help []byte) (clikit.DocCorpus, error) {
 }
 
 type model struct {
-	cli     string
-	output  outputFunc
-	apply   applyFunc
-	asker   clikit.Asker
-	phase              phase
-	plan               applyPlan
-	preview            previewdata.Document
-	inventory          inventorydata.Document
-	inventoryLoading   bool
-	inventoryErr       error
+	cli    string
+	output outputFunc
+	apply  applyFunc
+	asker  clikit.Asker
+	phase  phase
+	plan   applyPlan
+
+	preview              previewdata.Document
+	inventory            inventorydata.Document
+	inventoryLoading     bool
+	inventoryErr         error
+	inventoryGeneration  uint64
+	inventoryDiagnostic  string
+	inventoryDetailsOpen bool
+
 	details            bool
 	capabilitiesOpen   bool
 	focus              pane
@@ -223,21 +231,27 @@ func (m model) loadPreview() tea.Cmd {
 	}
 }
 func (m model) loadInventory() tea.Cmd {
+	revision, generation := m.plan.ResolvedRevision, m.inventoryGeneration
 	return func() tea.Msg {
-		out, err := m.output(m.cli, "inventory", "--ref", m.plan.ResolvedRevision, "--json")
+		out, err := m.output(m.cli, "inventory", "--ref", revision, "--json")
 		if err != nil {
-			return inventoryMsg{err: commandError("inventory unavailable", out, err)}
+			return inventoryMsg{
+				revision:   revision,
+				generation: generation,
+				err:        fmt.Errorf("inventory unavailable: %w", err),
+				diagnostic: boundedInventoryDiagnostic(out),
+			}
 		}
 		result, err := inventorydata.Parse(out, inventorydata.Expected{
-			Revision:           m.plan.ResolvedRevision,
+			Revision:           revision,
 			System:             m.plan.System,
 			Host:               m.plan.Host,
 			ActiveCapabilities: m.plan.Capabilities,
 		})
 		if err != nil {
-			return inventoryMsg{err: err}
+			return inventoryMsg{revision: revision, generation: generation, err: err}
 		}
-		return inventoryMsg{inventory: result}
+		return inventoryMsg{revision: revision, generation: generation, inventory: result}
 	}
 }
 
@@ -273,6 +287,29 @@ func commandError(action string, output []byte, err error) error {
 	return fmt.Errorf("%s: %w\n%s", action, err, text)
 }
 
+const (
+	maxInventoryDiagnosticLines = 4
+	maxInventoryDiagnosticRunes = 512
+)
+
+func boundedInventoryDiagnostic(output []byte) string {
+	text := strings.TrimSpace(stripTerminalControls(strings.ReplaceAll(string(output), "\r", "\n")))
+	if text == "" {
+		return ""
+	}
+	lines := strings.Split(text, "\n")
+	if len(lines) > maxInventoryDiagnosticLines {
+		lines = lines[:maxInventoryDiagnosticLines]
+		lines[len(lines)-1] = strings.TrimRight(lines[len(lines)-1], " ") + "…"
+	}
+	text = strings.Join(lines, "\n")
+	runes := []rune(text)
+	if len(runes) > maxInventoryDiagnosticRunes {
+		text = string(runes[:maxInventoryDiagnosticRunes-1]) + "…"
+	}
+	return text
+}
+
 // stripTerminalControls delegates ECMA-48 parsing (CSI, OSC, DCS, SOS, PM, APC,
 // and their BEL/ST terminators) to Charm's ANSI parser. C0/C1 execution controls
 // that are intentionally preserved by ansi.Strip are removed separately, except
@@ -301,7 +338,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.plan, m.phase, m.err = msg.plan, loadingPreview, nil
+		m.inventoryGeneration++
 		m.inventory, m.inventoryErr, m.inventoryLoading = inventorydata.Document{}, nil, true
+		m.inventoryDiagnostic, m.inventoryDetailsOpen = "", false
 		return m, tea.Batch(m.loadPreview(), m.loadInventory())
 	case previewMsg:
 		if msg.err != nil {
@@ -312,7 +351,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.phase, m.err, m.previewCursor, m.details = ready, nil, 0, false
 		return m, nil
 	case inventoryMsg:
+		if msg.generation != m.inventoryGeneration || msg.revision != m.plan.ResolvedRevision {
+			return m, nil
+		}
 		m.inventoryLoading = false
+		m.inventoryDiagnostic, m.inventoryDetailsOpen = msg.diagnostic, false
 		if msg.err != nil {
 			m.inventory, m.inventoryErr = inventorydata.Document{}, msg.err
 		} else {
@@ -337,7 +380,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "r":
 			if m.phase != applying {
 				m.phase, m.err, m.status, m.preview, m.inventory = loadingPlan, nil, "", previewdata.Document{}, inventorydata.Document{}
+				m.inventoryGeneration++
 				m.inventoryErr, m.inventoryLoading, m.details = nil, false, false
+				m.inventoryDiagnostic, m.inventoryDetailsOpen = "", false
 				m.capabilitiesOpen, m.focus = false, previewPane
 				m.previewCursor, m.capabilityCursor, m.selectedCapability = 0, 0, 0
 				return m, m.loadPlan()
@@ -378,7 +423,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "pgdown":
 			m = m.scrollFocused(m.paneBodyHeight())
 		case "d":
-			if m.focus == previewPane && (m.phase == ready || m.phase == confirming || m.phase == applied) {
+			if m.focus == capabilityPane && m.inventoryErr != nil && m.inventoryDiagnostic != "" &&
+				(m.phase == ready || m.phase == confirming || m.phase == applied) {
+				m.inventoryDetailsOpen = !m.inventoryDetailsOpen
+				m.capabilityCursor = 0
+			} else if m.focus == previewPane && (m.phase == ready || m.phase == confirming || m.phase == applied) {
 				m.details, m.previewCursor = !m.details, 0
 			}
 		case "a", "enter":
@@ -395,13 +444,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.phase = ready
 			}
 		case "esc":
-			if m.focus == capabilityPane {
+			if m.phase == confirming {
+				m.phase = ready
+			} else if m.focus == capabilityPane {
 				m.focus = previewPane
 				if !m.isWide() {
 					m.capabilitiesOpen = false
 				}
-			} else if m.phase == confirming {
-				m.phase = ready
 			}
 		}
 	}
@@ -678,7 +727,19 @@ func (m model) capabilityRowsForWidth(width int) []string {
 	case m.inventoryErr != nil:
 		appendWrappedRow(&rows, clikit.StBrk.Bold(true).Render("Inventory unavailable"), width)
 		rows = append(rows, "")
-		appendWrappedRow(&rows, clikit.StDim.Render(stripTerminalControls(m.inventoryErr.Error())), width)
+		reason := strings.TrimPrefix(m.inventoryErr.Error(), "inventory unavailable: ")
+		appendWrappedRow(&rows, clikit.StDim.Render(stripTerminalControls(reason)), width)
+		if m.inventoryDiagnostic != "" {
+			rows = append(rows, "")
+			if m.inventoryDetailsOpen {
+				appendWrappedRow(&rows, titleStyle.Render("Diagnostic detail"), width)
+				for _, line := range strings.Split(m.inventoryDiagnostic, "\n") {
+					appendIndentedWrappedRow(&rows, clikit.StDim.Render(line), width, 2)
+				}
+			} else {
+				appendWrappedRow(&rows, clikit.StDim.Render("Press d to show bounded diagnostic detail."), width)
+			}
+		}
 		rows = append(rows, "")
 		appendWrappedRow(&rows, "The activation preview and apply confirmation remain available.", width)
 		return rows
@@ -986,6 +1047,13 @@ func (m model) footer() string {
 		controls := "↑/↓ scroll  ·  [/] cycle  ·  c back"
 		if m.isWide() {
 			controls = "↑/↓ capability  ·  [/] cycle  ·  Tab/c preview"
+		}
+		if m.inventoryErr != nil && m.inventoryDiagnostic != "" && m.width >= 80 {
+			diagnosticMode := "diagnostics"
+			if m.inventoryDetailsOpen {
+				diagnosticMode = "hide diagnostics"
+			}
+			controls += "  ·  d " + diagnosticMode
 		}
 		if m.width < 60 {
 			if m.phase == confirming {

--- a/pkgs/atyrode-tui/main_test.go
+++ b/pkgs/atyrode-tui/main_test.go
@@ -76,7 +76,6 @@ func testInventoryDocument() inventorydata.Manifest {
 	}
 }
 
-
 type recordingAsker struct {
 	docs   clikit.DocCorpus
 	chunks []string

--- a/pkgs/atyrode-tui/main_test.go
+++ b/pkgs/atyrode-tui/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	inventorydata "atyrode-tui/inventory"
 	previewdata "atyrode-tui/preview"
 	clikit "cli-kit"
 	tea "github.com/charmbracelet/bubbletea"
@@ -38,6 +39,42 @@ func testPreviewDocument() previewdata.Document {
 		Technical:   []string{"<<< /nix/store/old-home-manager-generation", ">>> /nix/store/new-home-manager-generation", "PATHS: 7529 -> 7536 (+5054, -5047)", "SIZE: 1.50 GiB -> 1.49 GiB", "DIFF: -5.59 MiB"},
 	}
 }
+func testInventoryDocument() inventorydata.Manifest {
+	return inventorydata.Manifest{
+		SchemaVersion: inventorydata.SchemaVersion,
+		Identity: inventorydata.Identity{
+			Revision: testRevision,
+			System:   "x86_64-linux",
+			Platform: "linux",
+		},
+		Capabilities: map[string]inventorydata.Capability{
+			"base": {
+				Name: "base", Title: "Base", Purpose: "Shell and operator baseline", Applicable: true,
+				DeliveryBoundary: "Home Manager", MutableState: "Caches only", SecurityBoundary: "No credentials",
+				Deliverables: []inventorydata.Deliverable{
+					{Kind: "package", Name: "git", Version: "2.50", Description: "Distributed version control", Delivery: "home-manager", Source: "pinned-nixpkgs", System: "x86_64-linux", Platform: "linux"},
+					{Kind: "package", Name: "gh", Version: "2.75", Description: "GitHub command-line client", Delivery: "home-manager", Source: "pinned-nixpkgs", System: "x86_64-linux", Platform: "linux"},
+				},
+			},
+			"agents": {
+				Name: "agents", Title: "Agent tools", Purpose: "Managed agent tools and configuration", Applicable: true,
+				DeliveryBoundary: "Home Manager and overlays", MutableState: "Sessions stay mutable", SecurityBoundary: "Credentials are excluded",
+				Deliverables: []inventorydata.Deliverable{
+					{Kind: "application", Name: "omp", Version: "1.2", Description: "Agent orchestration cockpit with a deliberately long description for responsive wrapping", Delivery: "home-manager", Source: "repository-overlay", System: "x86_64-linux", Platform: "linux"},
+				},
+			},
+			"server": {
+				Name: "server", Title: "Server", Purpose: "Linux-only headless composition marker", Applicable: true, Marker: true,
+				DeliveryBoundary: "Marker capability", MutableState: "System-owned", SecurityBoundary: "No production facts",
+				Deliverables: []inventorydata.Deliverable{},
+			},
+		},
+		Hosts: map[string]inventorydata.Host{
+			"workstation": {ID: "workstation", Aliases: []string{"desk"}, Platform: "linux", System: "x86_64-linux", Capabilities: []string{"base", "agents", "server"}},
+		},
+	}
+}
+
 
 type recordingAsker struct {
 	docs   clikit.DocCorpus
@@ -164,6 +201,12 @@ func TestInitLoadsPlanThenDryRunPreview(t *testing.T) {
 				t.Fatal(err)
 			}
 			return result, nil
+		case 3:
+			result, err := json.Marshal(testInventoryDocument())
+			if err != nil {
+				t.Fatal(err)
+			}
+			return result, nil
 		default:
 			t.Fatal("unexpected command")
 			return nil, nil
@@ -173,13 +216,16 @@ func TestInitLoadsPlanThenDryRunPreview(t *testing.T) {
 	plan := m.Init()().(planMsg)
 	next, cmd := m.Update(plan)
 	m = next.(model)
-	preview := cmd().(previewMsg)
-	next, _ = m.Update(preview)
-	m = next.(model)
+	batch := cmd().(tea.BatchMsg)
+	for _, load := range batch {
+		next, _ = m.Update(load())
+		m = next.(model)
+	}
 
 	wantCalls := [][]string{
 		{"/bin/atyrode", "apply", "--plan", "--json"},
 		{"/bin/atyrode", "apply", "--ref", testRevision, "--preview-json"},
+		{"/bin/atyrode", "inventory", "--ref", testRevision, "--json"},
 	}
 	if !reflect.DeepEqual(calls, wantCalls) {
 		t.Fatalf("commands = %#v, want %#v", calls, wantCalls)
@@ -302,8 +348,8 @@ func TestDetailsToggleLabelsGenerationPaths(t *testing.T) {
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	m = next.(model)
-	if !m.details || m.cursor != 0 {
-		t.Fatalf("details toggle = %t, cursor = %d", m.details, m.cursor)
+	if !m.details || m.previewCursor != 0 {
+		t.Fatalf("details toggle = %t, cursor = %d", m.details, m.previewCursor)
 	}
 	view := stripTerminalControls(m.View())
 	if !strings.Contains(view, "Technical details") || !strings.Contains(view, "d summary") {
@@ -484,5 +530,192 @@ func TestCapabilityChipsAdaptToAvailableWidth(t *testing.T) {
 	compact := stripTerminalControls(capabilityChips(capabilities, 18))
 	if compact != " 4 active " {
 		t.Fatalf("compact capabilities = %q", compact)
+	}
+}
+
+func readyInventoryModel(width int) model {
+	m := newModel("atyrode")
+	m.width, m.height, m.phase = width, 34, ready
+	m.plan = applyPlan{
+		Host: "workstation", System: "x86_64-linux", User: "alex", Source: "remote",
+		ResolvedRevision: testRevision, Revision: "feedfacefeed", Capabilities: []string{"base", "agents", "server"},
+	}
+	m.preview = testPreviewDocument()
+	data, _ := json.Marshal(testInventoryDocument())
+	m.inventory, _ = inventorydata.Parse(data, inventorydata.Expected{
+		Revision: testRevision, System: "x86_64-linux", Host: "workstation",
+		ActiveCapabilities: m.plan.Capabilities,
+	})
+	return m
+}
+
+func press(m model, key string) model {
+	var msg tea.KeyMsg
+	switch key {
+	case "tab":
+		msg = tea.KeyMsg{Type: tea.KeyTab}
+	case "esc":
+		msg = tea.KeyMsg{Type: tea.KeyEsc}
+	case "up":
+		msg = tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		msg = tea.KeyMsg{Type: tea.KeyDown}
+	case "left":
+		msg = tea.KeyMsg{Type: tea.KeyLeft}
+	case "right":
+		msg = tea.KeyMsg{Type: tea.KeyRight}
+	case "enter":
+		msg = tea.KeyMsg{Type: tea.KeyEnter}
+	default:
+		msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
+	}
+	next, _ := m.Update(msg)
+	return next.(model)
+}
+
+func TestCapabilityCyclingWrapsBothDirectionsInPlanOrder(t *testing.T) {
+	m := readyInventoryModel(100)
+	m = press(m, "c")
+	if m.focus != capabilityPane || !m.capabilitiesOpen {
+		t.Fatal("c did not open and focus capabilities")
+	}
+	m = press(m, "[")
+	if m.selectedCapability != 2 || m.inventory.Capabilities[2].Name != "server" {
+		t.Fatalf("backward wrap selected %d", m.selectedCapability)
+	}
+	m = press(m, "]")
+	if m.selectedCapability != 0 || m.inventory.Capabilities[0].Name != "base" {
+		t.Fatalf("forward wrap selected %d", m.selectedCapability)
+	}
+	m = press(m, "right")
+	if m.inventory.Capabilities[m.selectedCapability].Name != "agents" {
+		t.Fatal("right-arrow alternative did not cycle forward")
+	}
+}
+
+func TestCapabilityFocusAndIndependentScrollSurviveReturn(t *testing.T) {
+	m := readyInventoryModel(140)
+	m.previewCursor = 3
+	m = press(m, "tab")
+	if m.focus != capabilityPane {
+		t.Fatal("Tab did not move focus to capability pane")
+	}
+	for range 5 {
+		m = press(m, "j")
+	}
+	capabilityCursor := m.capabilityCursor
+	if capabilityCursor == 0 {
+		t.Fatal("focused capability pane did not scroll")
+	}
+	m = press(m, "c")
+	if m.focus != previewPane || m.previewCursor != 3 || m.capabilityCursor != capabilityCursor {
+		t.Fatalf("return lost pane state: focus=%v preview=%d capability=%d", m.focus, m.previewCursor, m.capabilityCursor)
+	}
+	m = press(m, "c")
+	if m.focus != capabilityPane || m.capabilityCursor != capabilityCursor {
+		t.Fatal("reopening capabilities reset its scroll")
+	}
+	m = press(m, "esc")
+	if m.focus != previewPane || m.capabilityCursor != capabilityCursor {
+		t.Fatal("Esc did not preserve capability scroll")
+	}
+}
+
+func flattened(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func TestCapabilityRowsGroupItemsAndExplainEmptyAndPlatformStates(t *testing.T) {
+	m := readyInventoryModel(100)
+	base := flattened(stripTerminalControls(strings.Join(m.capabilityRowsForWidth(36), "\n")))
+	for _, want := range []string{"Base 1/3", "ACTIVE · 2 items", "Packages (2)", "Distributed version control", "git · 2.50 · pinned-nixpkgs", "via home-manager", "for x86_64-linux", "Delivery boundary", "Security boundary", "Mutable state"} {
+		if !strings.Contains(base, want) {
+			t.Errorf("base capability missing %q:\n%s", want, base)
+		}
+	}
+	if strings.Contains(base, "Applications (") {
+		t.Fatal("empty deliverable group was rendered")
+	}
+
+	m.selectedCapability = 2
+	server := flattened(stripTerminalControls(strings.Join(m.capabilityRowsForWidth(30), "\n")))
+	for _, want := range []string{"Server 3/3", "0 items", "Intentional marker", "no direct deliverables"} {
+		if !strings.Contains(server, want) {
+			t.Errorf("server marker missing %q:\n%s", want, server)
+		}
+	}
+
+	m.selectedCapability = 1
+	m.inventory.Capabilities[1].Applicable = false
+	conditional := flattened(stripTerminalControls(strings.Join(m.capabilityRowsForWidth(24), "\n")))
+	if !strings.Contains(conditional, "NOT APPLICABLE ON LINUX") {
+		t.Fatalf("platform condition was not textual:\n%s", conditional)
+	}
+	for _, line := range m.capabilityRowsForWidth(24) {
+		if lipgloss.Width(line) > 24 {
+			t.Errorf("long capability text exceeded width: %q", stripTerminalControls(line))
+		}
+	}
+}
+
+func TestInventoryLoadingAndFailureNeverAlterApplyConfirmation(t *testing.T) {
+	m := readyInventoryModel(72)
+	m.inventory, m.inventoryLoading = inventorydata.Document{}, true
+	loading := flattened(stripTerminalControls(strings.Join(m.capabilityRowsForWidth(30), "\n")))
+	if !strings.Contains(loading, "Loading exact-revision inventory") {
+		t.Fatalf("loading state = %q", loading)
+	}
+	m.inventoryLoading = false
+	m.inventoryErr = errors.New("inventory revision mismatch: got deadbeef, need feedface")
+	failure := flattened(stripTerminalControls(strings.Join(m.capabilityRowsForWidth(30), "\n")))
+	for _, want := range []string{"Inventory unavailable", "revision mismatch", "apply confirmation remain available"} {
+		if !strings.Contains(failure, want) {
+			t.Errorf("failure state missing %q: %q", want, failure)
+		}
+	}
+	m = press(m, "enter")
+	if m.phase != confirming {
+		t.Fatal("inventory failure disabled confirmation")
+	}
+	m = press(m, "n")
+	if m.phase != ready {
+		t.Fatal("inventory failure disabled confirmation cancel")
+	}
+	applies := 0
+	m.apply = func(string, ...string) tea.Cmd {
+		applies++
+		return func() tea.Msg { return applyDoneMsg{} }
+	}
+	m = press(m, "enter")
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	m = next.(model)
+	if m.phase != applying || applies != 1 || cmd == nil {
+		t.Fatalf("inventory failure blocked confirmed apply: phase=%v applies=%d", m.phase, applies)
+	}
+}
+
+func TestCapabilityResponsiveLayoutsStayWithinTerminal(t *testing.T) {
+	for _, width := range []int{140, 100, 72, 44} {
+		m := readyInventoryModel(width)
+		if !m.isWide() {
+			m = press(m, "c")
+		}
+		rendered := m.View()
+		lines := strings.Split(rendered, "\n")
+		if len(lines) > m.height {
+			t.Errorf("width %d rendered %d rows into height %d", width, len(lines), m.height)
+		}
+		for _, line := range lines {
+			if got := lipgloss.Width(line); got > width-1 {
+				t.Errorf("width %d row overflowed at %d: %q", width, got, stripTerminalControls(line))
+			}
+		}
+		plain := stripTerminalControls(rendered)
+		if !strings.Contains(plain, "CAPABILITIES") {
+			t.Errorf("width %d did not render capability view", width)
+		}
+		if width == 140 && !strings.Contains(plain, "ACTIVATION PREVIEW") {
+			t.Fatal("wide layout did not preserve split preview")
+		}
 	}
 }

--- a/pkgs/atyrode-tui/main_test.go
+++ b/pkgs/atyrode-tui/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -717,5 +718,209 @@ func TestCapabilityResponsiveLayoutsStayWithinTerminal(t *testing.T) {
 		if width == 140 && !strings.Contains(plain, "ACTIVATION PREVIEW") {
 			t.Fatal("wide layout did not preserve split preview")
 		}
+	}
+}
+
+func TestInventoryRepliesAreScopedToRevisionAndGeneration(t *testing.T) {
+	currentRevision := strings.Repeat("a", 40)
+	currentDocument := inventorydata.Document{
+		Identity:     inventorydata.Identity{Revision: currentRevision},
+		Capabilities: []inventorydata.Capability{{Name: "current"}},
+	}
+	staleDocument := inventorydata.Document{
+		Identity:     inventorydata.Identity{Revision: testRevision},
+		Capabilities: []inventorydata.Capability{{Name: "stale"}},
+	}
+	tests := []struct {
+		name    string
+		current inventoryMsg
+		stale   inventoryMsg
+	}{
+		{
+			name:    "A failure after B success",
+			current: inventoryMsg{revision: currentRevision, generation: 8, inventory: currentDocument},
+			stale: inventoryMsg{
+				revision: testRevision, generation: 7, err: errors.New("stale failure"),
+				diagnostic: "stale diagnostic",
+			},
+		},
+		{
+			name: "A success after B failure",
+			current: inventoryMsg{
+				revision: currentRevision, generation: 8, err: errors.New("current failure"),
+				diagnostic: "current diagnostic",
+			},
+			stale: inventoryMsg{revision: testRevision, generation: 7, inventory: staleDocument},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newModel("atyrode")
+			m.plan.ResolvedRevision = currentRevision
+			m.inventoryGeneration, m.inventoryLoading = 8, true
+
+			next, _ := m.Update(tt.current)
+			m = next.(model)
+			wantInventory, wantErr := m.inventory, m.inventoryErr
+			wantDiagnostic, wantLoading := m.inventoryDiagnostic, m.inventoryLoading
+
+			next, _ = m.Update(tt.stale)
+			m = next.(model)
+			if !reflect.DeepEqual(m.inventory, wantInventory) {
+				t.Fatalf("stale reply changed inventory: got %#v, want %#v", m.inventory, wantInventory)
+			}
+			if fmt.Sprint(m.inventoryErr) != fmt.Sprint(wantErr) {
+				t.Fatalf("stale reply changed error: got %v, want %v", m.inventoryErr, wantErr)
+			}
+			if m.inventoryDiagnostic != wantDiagnostic || m.inventoryLoading != wantLoading {
+				t.Fatalf("stale reply changed diagnostic/loading: diagnostic=%q loading=%t", m.inventoryDiagnostic, m.inventoryLoading)
+			}
+		})
+	}
+}
+
+func TestRefreshInvalidatesPriorInventoryWhileReplacementLoads(t *testing.T) {
+	m := readyInventoryModel(100)
+	m.inventoryGeneration = 11
+	m = press(m, "r")
+	if m.phase != loadingPlan || m.inventoryGeneration != 12 {
+		t.Fatalf("refresh phase/generation = %v/%d", m.phase, m.inventoryGeneration)
+	}
+
+	replacement := m.plan
+	next, _ := m.Update(planMsg{plan: replacement})
+	m = next.(model)
+	if !m.inventoryLoading || m.inventoryGeneration != 13 {
+		t.Fatalf("replacement request loading/generation = %t/%d", m.inventoryLoading, m.inventoryGeneration)
+	}
+
+	stale := []inventoryMsg{
+		{
+			revision: testRevision, generation: 11,
+			inventory: inventorydata.Document{Capabilities: []inventorydata.Capability{{Name: "stale"}}},
+		},
+		{revision: testRevision, generation: 11, err: errors.New("stale failure"), diagnostic: "stale detail"},
+		{revision: strings.Repeat("b", 40), generation: 13, err: errors.New("wrong revision")},
+	}
+	for _, msg := range stale {
+		next, _ = m.Update(msg)
+		m = next.(model)
+		if !m.inventoryLoading || len(m.inventory.Capabilities) != 0 || m.inventoryErr != nil || m.inventoryDiagnostic != "" {
+			t.Fatalf("stale reply mutated replacement state: loading=%t inventory=%#v err=%v diagnostic=%q",
+				m.inventoryLoading, m.inventory, m.inventoryErr, m.inventoryDiagnostic)
+		}
+	}
+}
+
+func TestEscapeCancelsConfirmationBeforeCapabilityNavigation(t *testing.T) {
+	tests := []struct {
+		name             string
+		width            int
+		focus            pane
+		capabilitiesOpen bool
+	}{
+		{name: "narrow capability view", width: 72, focus: capabilityPane, capabilitiesOpen: true},
+		{name: "wide capability focus", width: 140, focus: capabilityPane, capabilitiesOpen: true},
+		{name: "wide preview focus", width: 140, focus: previewPane, capabilitiesOpen: true},
+		{name: "narrow preview view", width: 72, focus: previewPane, capabilitiesOpen: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := readyInventoryModel(tt.width)
+			m.phase, m.focus, m.capabilitiesOpen = confirming, tt.focus, tt.capabilitiesOpen
+			m = press(m, "esc")
+			if m.phase != ready {
+				t.Fatalf("Escape left phase %v, want ready", m.phase)
+			}
+			if m.focus != tt.focus || m.capabilitiesOpen != tt.capabilitiesOpen {
+				t.Fatalf("Escape navigated while cancelling: focus/open = %v/%t, want %v/%t",
+					m.focus, m.capabilitiesOpen, tt.focus, tt.capabilitiesOpen)
+			}
+		})
+	}
+}
+
+func TestInventoryFailureDiagnosticsAreExplicitSanitizedAndBounded(t *testing.T) {
+	raw := strings.Join([]string{
+		"\x1b]0;unsafe\x07FIRST DETAIL",
+		"SECOND " + strings.Repeat("a", 100),
+		"THIRD " + strings.Repeat("b", 100),
+		"FOURTH " + strings.Repeat("c", 100),
+		"FIFTH SECRET",
+		"SIXTH SECRET",
+	}, "\n")
+	m := readyInventoryModel(100)
+	m.inventoryGeneration, m.inventoryLoading = 5, true
+	m.output = func(string, ...string) ([]byte, error) {
+		return []byte(raw), errors.New("exit status 27")
+	}
+	msg := m.loadInventory()().(inventoryMsg)
+	if msg.err == nil || msg.err.Error() != "inventory unavailable: exit status 27" {
+		t.Fatalf("primary inventory error = %v", msg.err)
+	}
+	if strings.Contains(msg.err.Error(), "FIRST DETAIL") {
+		t.Fatalf("primary error exposed command output: %q", msg.err)
+	}
+	if strings.ContainsAny(msg.diagnostic, "\x1b\a\r") {
+		t.Fatalf("diagnostic retained terminal controls: %q", msg.diagnostic)
+	}
+	if lines := strings.Count(msg.diagnostic, "\n") + 1; lines > maxInventoryDiagnosticLines {
+		t.Fatalf("diagnostic lines = %d, cap = %d", lines, maxInventoryDiagnosticLines)
+	}
+	if runes := len([]rune(msg.diagnostic)); runes > maxInventoryDiagnosticRunes {
+		t.Fatalf("diagnostic runes = %d, cap = %d", runes, maxInventoryDiagnosticRunes)
+	}
+	if strings.Contains(msg.diagnostic, "FIFTH SECRET") {
+		t.Fatalf("diagnostic exceeded line cap: %q", msg.diagnostic)
+	}
+
+	next, _ := m.Update(msg)
+	m = next.(model)
+	m.focus, m.capabilitiesOpen = capabilityPane, true
+	primary := stripTerminalControls(strings.Join(m.capabilityRowsForWidth(60), "\n"))
+	for _, want := range []string{"Inventory unavailable", "exit status 27", "Press d to show bounded diagnostic detail"} {
+		if !strings.Contains(primary, want) {
+			t.Errorf("primary failure missing %q: %q", want, primary)
+		}
+	}
+	for _, rawLine := range []string{"FIRST DETAIL", "SECOND", "THIRD", "FOURTH", "FIFTH SECRET", "SIXTH SECRET"} {
+		if strings.Contains(primary, rawLine) {
+			t.Fatalf("primary failure exposed raw diagnostic %q: %q", rawLine, primary)
+		}
+	}
+
+	m = press(m, "d")
+	if !m.inventoryDetailsOpen || m.details {
+		t.Fatalf("capability diagnostic toggle conflicted with preview details: diagnostic=%t preview=%t", m.inventoryDetailsOpen, m.details)
+	}
+	detail := stripTerminalControls(strings.Join(m.capabilityRowsForWidth(60), "\n"))
+	if !strings.Contains(detail, "Diagnostic detail") || !strings.Contains(detail, "FIRST DETAIL") || strings.Contains(detail, "FIFTH SECRET") {
+		t.Fatalf("requested diagnostic detail = %q", detail)
+	}
+
+	previewFocused := m
+	previewFocused.focus, previewFocused.inventoryDetailsOpen = previewPane, false
+	previewFocused = press(previewFocused, "d")
+	if !previewFocused.details || previewFocused.inventoryDetailsOpen {
+		t.Fatal("preview details key opened inventory diagnostics")
+	}
+
+	applies := 0
+	m.apply = func(string, ...string) tea.Cmd {
+		applies++
+		return func() tea.Msg { return applyDoneMsg{} }
+	}
+	m = press(m, "enter")
+	if m.phase != confirming {
+		t.Fatal("inventory diagnostic view blocked apply confirmation")
+	}
+	m = press(m, "d")
+	if m.phase != confirming {
+		t.Fatal("diagnostic toggle cancelled apply confirmation")
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	m = next.(model)
+	if m.phase != applying || applies != 1 || cmd == nil {
+		t.Fatalf("diagnostic view blocked confirmed apply: phase=%v applies=%d", m.phase, applies)
 	}
 }


### PR DESCRIPTION
Closes #196

## Summary
- load the versioned inventory asynchronously from the apply plan's exact resolved revision
- browse active capabilities in plan order with cycling, focus, independent scrolling, grouped deliverables, boundaries, and deliberate empty states
- provide wide split, medium full-view, and narrow stacked layouts while preserving apply/Ask state
- reject schema/revision/system/host/composition mismatches and ignore stale refresh replies
- keep failures concise, with bounded diagnostics behind an explicit detail toggle; apply confirmation remains available

## Verification
- `nix build .#atyrode-tui --no-link`
- focused parser/model/update/view tests cover identity mismatches, active-set exactness, cycling, focus/scroll preservation, loading/failure, stale refresh races, confirmation safety, diagnostic bounds, grouping/empty markers, and 140/100/72/44-column containment
- truecolor tmux/freeze renders inspected for active, cycled, empty-server, medium, narrow, and failure states
- all captured rows remained within terminal width/height; footer, truecolor SGR, and glyph codepoints verified

No activation was performed. Inactive/all capability browsing remains optional and is not included.