### PR TITLE
code-tui: keep trackpad bursts responsive

### DIFF
--- a/pkgs/cli-kit/run.go
+++ b/pkgs/cli-kit/run.go
@@ -16,6 +16,12 @@ type App interface {
 // RunOption configures Run.
 type RunOption func(*host)
 
+// MessageFilter runs before Bubble Tea dispatches a message. Returning nil
+// drops the message before Update and View, which is useful for coalescing
+// high-rate input that would otherwise trigger redundant redraws. The model
+// passed to the filter is the consumer app, not cli-kit's host wrapper.
+type MessageFilter func(tea.Model, tea.Msg) tea.Msg
+
 // WithToggleKey overrides the key that opens the prompt box (default "ctrl+o").
 func WithToggleKey(k string) RunOption {
 	return func(h *host) { h.toggleKey = k }
@@ -29,6 +35,11 @@ func WithAltScreen() RunOption {
 // WithMouseCellMotion enables cell-motion mouse reporting (e.g. wheel scroll).
 func WithMouseCellMotion() RunOption {
 	return func(h *host) { h.mouse = true }
+}
+
+// WithMessageFilter installs a pre-dispatch Bubble Tea message filter.
+func WithMessageFilter(filter MessageFilter) RunOption {
+	return func(h *host) { h.messageFilter = filter }
 }
 
 // Run starts app under a cli-kit host that auto-mounts capabilities: Askable gets
@@ -47,6 +58,9 @@ func Run(app App, opts ...RunOption) (tea.Model, error) {
 	if h.mouse {
 		teaOpts = append(teaOpts, tea.WithMouseCellMotion())
 	}
+	if h.messageFilter != nil {
+		teaOpts = append(teaOpts, tea.WithFilter(h.filterMessage))
+	}
 	final, err := tea.NewProgram(h, teaOpts...).Run()
 	if fh, ok := final.(host); ok {
 		return fh.app, err
@@ -57,16 +71,29 @@ func Run(app App, opts ...RunOption) (tea.Model, error) {
 // host wraps a consumer App, overlaying the prompt box when active and routing
 // input between the two.
 type host struct {
-	app       tea.Model
-	box       PromptBox
-	hasBox    bool
-	active    bool
-	toggleKey string
-	altScreen bool
-	mouse     bool
-	w, h      int
-	appW      int // width last handed to a capability app (see reflow); -1 until set
-	appH      int // height last handed to a capability app (see reflow); -1 until set
+	app           tea.Model
+	box           PromptBox
+	hasBox        bool
+	active        bool
+	toggleKey     string
+	altScreen     bool
+	mouse         bool
+	messageFilter MessageFilter
+	w, h          int
+	appW          int // width last handed to a capability app (see reflow); -1 until set
+	appH          int // height last handed to a capability app (see reflow); -1 until set
+}
+
+// filterMessage unwraps the current host so consumer filters can reason about
+// their own model while still running at Bubble Tea's pre-Update boundary.
+func (h host) filterMessage(current tea.Model, msg tea.Msg) tea.Msg {
+	if h.messageFilter == nil {
+		return msg
+	}
+	if currentHost, ok := current.(host); ok {
+		current = currentHost.app
+	}
+	return h.messageFilter(current, msg)
 }
 
 func newHost(app App) host {

--- a/pkgs/cli-kit/run_test.go
+++ b/pkgs/cli-kit/run_test.go
@@ -1,0 +1,31 @@
+package clikit
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type filterTestApp struct{ id string }
+
+func (a filterTestApp) Init() tea.Cmd                       { return nil }
+func (a filterTestApp) Update(tea.Msg) (tea.Model, tea.Cmd) { return a, nil }
+func (a filterTestApp) View() string                        { return a.id }
+
+func TestWithMessageFilterReceivesCurrentConsumerApp(t *testing.T) {
+	initial := newHost(filterTestApp{id: "initial"})
+	current := newHost(filterTestApp{id: "current"})
+	var seen tea.Model
+	WithMessageFilter(func(m tea.Model, msg tea.Msg) tea.Msg {
+		seen = m
+		return nil
+	})(&initial)
+
+	if got := initial.filterMessage(current, tea.KeyMsg{}); got != nil {
+		t.Fatalf("filter return = %#v, want nil", got)
+	}
+	app, ok := seen.(filterTestApp)
+	if !ok || app.id != "current" {
+		t.Fatalf("filter saw %#v, want the current consumer app", seen)
+	}
+}

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -1209,6 +1209,67 @@ func (g *wheelGate) admit(a int, t time.Time) bool {
 	return false
 }
 
+// admittedWheelMsg marks a generator wheel event admitted before Bubble Tea's
+// Update/render cycle. Routing wheel events remain ordinary tea.MouseMsgs.
+type admittedWheelMsg tea.MouseMsg
+
+// wheelTarget is the layout state the pre-dispatch filter needs. Keeping this
+// interface narrow also lets the raw-input regression test wrap model while
+// preserving the exact production filter path.
+type wheelTarget interface {
+	wheelInRouting(int, int) bool
+	routingWheelCanMove(tea.MouseButton) bool
+}
+
+// wheelInputFilter removes mouse traffic before Bubble Tea's unconditional
+// redraw-after-Update. Generator momentum is hard-detented here; motion,
+// non-wheel presses, routing horizontal wheel, and clamped routing scroll are
+// dropped because none can change the view.
+type wheelInputFilter struct {
+	gate wheelGate
+	now  func() time.Time
+}
+
+func (f *wheelInputFilter) Filter(app tea.Model, msg tea.Msg) tea.Msg {
+	mouse, ok := msg.(tea.MouseMsg)
+	if !ok {
+		return msg
+	}
+	if mouse.Action != tea.MouseActionPress {
+		return nil
+	}
+	target, ok := app.(wheelTarget)
+	if !ok {
+		return msg
+	}
+	if target.wheelInRouting(mouse.X, mouse.Y) {
+		switch mouse.Button {
+		case tea.MouseButtonWheelUp, tea.MouseButtonWheelDown:
+			if target.routingWheelCanMove(mouse.Button) {
+				return mouse
+			}
+		}
+		return nil
+	}
+	axis := wheelAxisNone
+	switch mouse.Button {
+	case tea.MouseButtonWheelUp, tea.MouseButtonWheelDown:
+		axis = wheelAxisV
+	case tea.MouseButtonWheelLeft, tea.MouseButtonWheelRight:
+		axis = wheelAxisH
+	default:
+		return nil
+	}
+	now := time.Now()
+	if f.now != nil {
+		now = f.now()
+	}
+	if !f.gate.admit(axis, now) {
+		return nil
+	}
+	return admittedWheelMsg(mouse)
+}
+
 type model struct {
 	generated map[string][]string
 	advisors  map[string][]string  // "level/ctx" → advisor model chain
@@ -1226,7 +1287,7 @@ type model struct {
 	sel            map[string]string
 	selectionState string // CODE_SELECTION_STATE; empty keeps standalone runs stateless
 
-	wheel wheelGate // trackpad/mouse wheel arbiter: axis lock + step resistance
+	wheel wheelGate // direct-Update detent; live input is admitted by wheelInputFilter before redraw
 
 	vp       viewport.Model
 	spin     spinner.Model
@@ -1951,6 +2012,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.spin, cmd = m.spin.Update(msg)
 			return m, cmd
 		}
+	case admittedWheelMsg:
+		m.applyWheelStep(msg.Button)
+		return m, nil
 	case tea.MouseMsg:
 		// Wheel dispatch by pointer position: inside the visible Routing pane
 		// the viewport owns vertical scrolling — continuous, ungated, clamped
@@ -2101,6 +2165,19 @@ func (m model) wheelInRouting(x, y int) bool {
 	}
 }
 
+// routingWheelCanMove reports whether a vertical routing scroll would change
+// the viewport. No-op events at either clamp are filtered before redraw.
+func (m model) routingWheelCanMove(b tea.MouseButton) bool {
+	switch b {
+	case tea.MouseButtonWheelUp:
+		return m.vp.YOffset < m.vp.TotalLineCount()-m.vp.Height
+	case tea.MouseButtonWheelDown:
+		return m.vp.YOffset > 0
+	default:
+		return false
+	}
+}
+
 // wheelStep translates an admitted wheel event into the matching facet action:
 // vertical scroll moves the selection, horizontal scroll changes the value.
 // The raw mapping is INVERTED on both axes — operator-confirmed trackpad
@@ -2108,24 +2185,29 @@ func (m model) wheelInRouting(x, y int) bool {
 // to the next (right) option, WheelRight to the previous. Arrow keys keep
 // their literal semantics; the handlers themselves are untouched and merely
 // rationed by the wheelGate.
-func (m *model) wheelStep(b tea.MouseButton, t time.Time) {
+func (m *model) applyWheelStep(b tea.MouseButton) {
 	switch b {
 	case tea.MouseButtonWheelUp:
-		if m.wheel.admit(wheelAxisV, t) {
-			m.moveDown()
-		}
+		m.moveDown()
 	case tea.MouseButtonWheelDown:
-		if m.wheel.admit(wheelAxisV, t) {
-			m.moveUp()
-		}
+		m.moveUp()
 	case tea.MouseButtonWheelLeft:
-		if m.wheel.admit(wheelAxisH, t) {
-			m.cycleFacet(1)
-		}
+		m.cycleFacet(1)
 	case tea.MouseButtonWheelRight:
-		if m.wheel.admit(wheelAxisH, t) {
-			m.cycleFacet(-1)
-		}
+		m.cycleFacet(-1)
+	}
+}
+
+func (m *model) wheelStep(b tea.MouseButton, t time.Time) {
+	axis := wheelAxisNone
+	switch b {
+	case tea.MouseButtonWheelUp, tea.MouseButtonWheelDown:
+		axis = wheelAxisV
+	case tea.MouseButtonWheelLeft, tea.MouseButtonWheelRight:
+		axis = wheelAxisH
+	}
+	if axis != wheelAxisNone && m.wheel.admit(axis, t) {
+		m.applyWheelStep(b)
 	}
 }
 
@@ -2411,10 +2493,11 @@ func main() {
 		sel:            loadSelectionState(selectionState, facets),
 		selectionState: selectionState,
 	}
-	// Cell-motion mouse reporting feeds the trackpad/wheel facet control (see
-	// wheelGate); it is the narrowest mode that carries wheel events. The
-	// preview still scrolls via pgup/pgdown / ctrl+u/ctrl+d.
-	final, err := clikit.Run(m, clikit.WithAltScreen(), clikit.WithMouseCellMotion())
+	// Cell-motion mouse reporting carries wheel events. Filter rejected
+	// momentum and unused motion before Bubble Tea's redraw-after-Update loop.
+	inputFilter := &wheelInputFilter{}
+	final, err := clikit.Run(m, clikit.WithAltScreen(), clikit.WithMouseCellMotion(),
+		clikit.WithMessageFilter(inputFilter.Filter))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "code:", err)
 		os.Exit(1)

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -1,20 +1,21 @@
 package main
 
 import (
-	"fmt"
-	"path/filepath"
-	"reflect"
-	"regexp"
-	"strings"
-	"testing"
-	"time"
-
 	clikit "cli-kit"
+	"fmt"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"io"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
 )
 
 // ansiRe strips SGR sequences so tests assert on visible text regardless of the
@@ -956,6 +957,208 @@ func TestWheelThroughUpdate(t *testing.T) {
 	if cmd != nil || m.fcur != 1 || !reflect.DeepEqual(m.sel, sel) {
 		t.Fatal("non-wheel mouse traffic must be ignored")
 	}
+}
+
+func TestWheelInputFilterDetentAndRearm(t *testing.T) {
+	m := layoutModel()
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	now := time.Unix(1000, 0)
+	filter := wheelInputFilter{now: func() time.Time { return now }}
+	wheel := func(b tea.MouseButton) tea.MouseMsg {
+		return tea.MouseMsg{Action: tea.MouseActionPress, Button: b, X: 2, Y: topGap + 2}
+	}
+
+	first := filter.Filter(m, wheel(tea.MouseButtonWheelUp))
+	if _, ok := first.(admittedWheelMsg); !ok {
+		t.Fatalf("first gesture event = %T, want admittedWheelMsg", first)
+	}
+	nm, _ := m.Update(first)
+	m = nm.(model)
+	if m.fcur != 1 {
+		t.Fatalf("first wheel-up gesture did not move down: fcur = %d", m.fcur)
+	}
+	for range 100 {
+		if got := filter.Filter(m, wheel(tea.MouseButtonWheelUp)); got != nil {
+			t.Fatalf("same-axis momentum reached Update as %T", got)
+		}
+		if got := filter.Filter(m, wheel(tea.MouseButtonWheelRight)); got != nil {
+			t.Fatalf("axis jitter reached Update as %T", got)
+		}
+		if got := filter.Filter(m, tea.MouseMsg{Action: tea.MouseActionMotion, X: 3, Y: topGap + 2}); got != nil {
+			t.Fatalf("unused mouse motion reached Update as %T", got)
+		}
+	}
+	now = now.Add(wheelIdle + time.Millisecond)
+	second := filter.Filter(m, wheel(tea.MouseButtonWheelDown))
+	if _, ok := second.(admittedWheelMsg); !ok {
+		t.Fatalf("second gesture after release = %T, want admittedWheelMsg", second)
+	}
+	nm, _ = m.Update(second)
+	m = nm.(model)
+	if m.fcur != 0 {
+		t.Fatalf("re-armed wheel-down gesture did not move up: fcur = %d", m.fcur)
+	}
+}
+
+func TestFilteredWheelPreservesSelectionPersistence(t *testing.T) {
+	m := layoutModel()
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	m.selectionState = filepath.Join(t.TempDir(), "selection.json")
+	now := time.Unix(1000, 0)
+	filter := wheelInputFilter{now: func() time.Time { return now }}
+	left := tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelLeft, X: 2, Y: topGap + 2}
+
+	for range 100 {
+		if msg := filter.Filter(m, left); msg != nil {
+			nm, _ := m.Update(msg)
+			m = nm.(model)
+		}
+	}
+	if got := loadSelectionState(m.selectionState, m.facets)["lane"]; got != "claude-led" {
+		t.Fatalf("persisted lane after admitted wheel-left = %q, want claude-led", got)
+	}
+
+	now = now.Add(wheelIdle + time.Millisecond)
+	right := tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelRight, X: 2, Y: topGap + 2}
+	nm, _ := m.Update(filter.Filter(m, right))
+	m = nm.(model)
+	if got := loadSelectionState(m.selectionState, m.facets)["lane"]; got != "mixed" {
+		t.Fatalf("persisted lane after re-armed wheel-right = %q, want mixed", got)
+	}
+}
+
+func TestWheelInputFilterKeepsRoutingContinuous(t *testing.T) {
+	m := layoutModel()
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	m.vp.Height = 2
+	m.vp.SetContent("zero\none\ntwo\nthree")
+	filter := wheelInputFilter{}
+	x, y := m.w-2, topGap+2
+	wheel := func(b tea.MouseButton) tea.MouseMsg {
+		return tea.MouseMsg{Action: tea.MouseActionPress, Button: b, X: x, Y: y}
+	}
+
+	for want := 1; want <= 2; want++ {
+		msg := filter.Filter(m, wheel(tea.MouseButtonWheelUp))
+		if _, ok := msg.(tea.MouseMsg); !ok {
+			t.Fatalf("routing event %d = %T, want ordinary MouseMsg", want, msg)
+		}
+		nm, _ := m.Update(msg)
+		m = nm.(model)
+		if m.vp.YOffset != want {
+			t.Fatalf("routing event %d: YOffset = %d, want %d", want, m.vp.YOffset, want)
+		}
+	}
+	if got := filter.Filter(m, wheel(tea.MouseButtonWheelUp)); got != nil {
+		t.Fatalf("clamped routing event reached redraw as %T", got)
+	}
+	if got := filter.Filter(m, wheel(tea.MouseButtonWheelLeft)); got != nil {
+		t.Fatalf("inert routing horizontal event reached redraw as %T", got)
+	}
+	if got := filter.Filter(m, wheel(tea.MouseButtonWheelDown)); got == nil {
+		t.Fatal("routing wheel-down must remain continuous away from the clamp")
+	}
+}
+
+type programResult struct {
+	model tea.Model
+	err   error
+}
+
+type burstProbe struct {
+	model
+	views   *atomic.Int64
+	keySeen chan int64
+}
+
+func (p burstProbe) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if key, ok := msg.(tea.KeyMsg); ok && key.String() == "j" {
+		p.keySeen <- p.views.Load()
+	}
+	nm, cmd := p.model.Update(msg)
+	p.model = nm.(model)
+	return p, cmd
+}
+
+func (p burstProbe) View() string {
+	p.views.Add(1)
+	return p.model.View()
+}
+
+// TestRawMouseBurstRemainsResponsive drives the real Bubble Tea ANSI parser
+// with a trackpad-like wheel/jitter/motion burst, then a keyboard command and a
+// second gesture after release. Rejected events must never reach Update/View.
+func TestRawMouseBurstRemainsResponsive(t *testing.T) {
+	m := layoutModel()
+	wide, _, _, _ := layoutSizes(t, m)
+	m = resize(t, m, wide.w, wide.h)
+	m.usageCmd = "" // keep the program deterministic: no background fetch/ticks
+	var views atomic.Int64
+	keySeen := make(chan int64, 1)
+	clock := atomic.Int64{}
+	clock.Store(time.Unix(1000, 0).UnixNano())
+	filter := wheelInputFilter{now: func() time.Time { return time.Unix(0, clock.Load()) }}
+	inR, inW := io.Pipe()
+	p := tea.NewProgram(
+		burstProbe{model: m, views: &views, keySeen: keySeen},
+		tea.WithInput(inR),
+		tea.WithOutput(io.Discard),
+		tea.WithFilter(filter.Filter),
+	)
+	done := make(chan programResult, 1)
+	go func() {
+		final, err := p.Run()
+		done <- programResult{model: final, err: err}
+	}()
+
+	started := time.Now()
+	var redrawsAtKey int64
+	for range 300 {
+		fmt.Fprint(inW, "\x1b[<64;3;4M") // vertical wheel
+		fmt.Fprint(inW, "\x1b[<67;3;4M") // horizontal axis jitter
+		fmt.Fprint(inW, "\x1b[<35;4;4M") // cell motion with no button
+	}
+	fmt.Fprint(inW, "j")
+	select {
+	case redrawsAtKey = <-keySeen:
+		if redrawsAtKey > 3 {
+			t.Fatalf("keyboard waited behind %d redraws; rejected burst events reached View", redrawsAtKey)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("keyboard input was starved after the first trackpad gesture")
+	}
+
+	clock.Add(int64(wheelIdle + time.Millisecond))
+	for range 300 {
+		fmt.Fprint(inW, "\x1b[<65;3;4M") // later opposite vertical gesture
+		fmt.Fprint(inW, "\x1b[<66;3;4M") // horizontal axis jitter
+		fmt.Fprint(inW, "\x1b[<35;4;4M") // cell motion
+	}
+	time.Sleep(10 * time.Millisecond) // force a separate ANSI key read
+	fmt.Fprint(inW, "q")
+	inW.Close()
+
+	var result programResult
+	select {
+	case result = <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Bubble Tea event loop stayed backlogged after the second gesture")
+	}
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	final := result.model.(burstProbe).model
+	if final.fcur != 1 {
+		t.Fatalf("want one first-gesture step + keyboard + one re-armed step: fcur = %d, want 1", final.fcur)
+	}
+	if got := views.Load(); got > 8 {
+		t.Fatalf("raw burst produced %d views, want a bounded redraw count <= 8", got)
+	}
+	t.Logf("1800 raw mouse messages + keyboard + second gesture: %d views, key after %d views, %s total",
+		views.Load(), redrawsAtKey, time.Since(started))
 }
 
 // ── usage identity · collapsible sections · contextual help (#198) ──────────


### PR DESCRIPTION
## Summary
- filter rejected generator momentum and unused mouse motion before Bubble Tea's unconditional Update/View redraw
- preserve one-step-per-gesture detents, axis locking, inverted directions, persistence, and continuous Routing scrolling
- expose a typed optional `clikit` message filter rather than duplicating its Bubble Tea host

## Root cause
The old gate rejected events inside `Update`, but Bubble Tea still called `View` for every rejected wheel/motion message. Trackpad bursts backpressured the unbuffered input loop, leaving keyboard input queued behind hundreds of full redraws.

## Verification
- deterministic before case: 900 mouse messages caused 916 View calls and 3.77s latency
- after: 1,800 messages across two gestures plus keyboard/quit caused 6 View calls; keyboard landed after 2
- focused/full code-tui and cli-kit Go tests passed
- `nix build .#code-tui --no-link` and Go formatting check passed
- truecolor 150x44 tmux smoke drove realistic SGR wheel/motion bursts, immediate `j`, release, and second gesture; response was immediate with no footer/width overflow

No static layout changed.