### PR TITLE
fix(atyrode): make activation preview opt-in and cancellable

### DIFF
--- a/pkgs/atyrode-tui/README.md
+++ b/pkgs/atyrode-tui/README.md
@@ -16,28 +16,34 @@ and checkout-specific behavior remain aligned.
 
 ## Apply panel
 
-Startup resolves the apply plan first, then starts two read-only operations
-asynchronously:
+Startup runs only `atyrode apply --plan --json`. That command supplies the host,
+system, immutable target revision, backend, and active capabilities rendered in
+the plan panel; remote plans include the full commit as `resolvedRevision`.
+Once the plan is validated, apply confirmation is immediately available.
 
-1. `atyrode apply --plan --json` supplies the host, system, target revision,
-   backend, and active capabilities rendered in the plan panel. Remote plans
-   include the full commit as `resolvedRevision`.
-2. `atyrode apply --ref <resolvedRevision> --preview-json` runs the same
-   read-only `nh … --dry` preview and returns the stable schema described below.
-   The TUI renders that structure rather than parsing terminal text.
-3. `atyrode inventory --ref <resolvedRevision> --json` supplies the complete
-   capability manifest for that exact commit. The inventory load runs alongside
-   the preview and cannot block or disable apply confirmation.
+The expensive read-only inspections are opt-in so a constrained host never
+starts multiple Nix evaluations merely by opening the cockpit:
 
-No activation occurs during startup. Pressing `a` or `enter` opens a confirmation
-step; only `y` then runs `atyrode apply --ref <resolvedRevision>` in the terminal.
-The preview and activation therefore address the same immutable commit even if
+- Press `v` to start `atyrode apply --ref <resolvedRevision> --preview-json`.
+  It runs the same read-only `nh … --dry` preview and returns the stable schema
+  described below. Press `v` again to cancel it.
+- Press `c` (or `Tab`) to open capabilities and lazily start
+  `atyrode inventory --ref <resolvedRevision> --json`.
+
+Preview and inventory requests never overlap. Their subprocess groups are
+cancelled on refresh, quit, or apply, and stale replies are ignored. A failed
+optional inspection stays local to its panel and never disables the validated
+apply plan.
+
+No activation occurs during startup or inspection. Pressing `a` or `enter`
+opens a confirmation step; only `y` then runs
+`atyrode apply --ref <resolvedRevision>` in the terminal. The preview,
+inventory, and activation therefore address the same immutable commit even if
 the published branch advances while the cockpit is open. `n` or `esc` cancels
-confirmation, `r` resolves and previews
-the branch again, arrow keys or `j`/`k` scroll the focused pane, and `d` toggles
-between the operator summary and normalized technical details. Press `c` to
-open or focus capabilities and `c`/`esc` to return to the preview without
-resetting either pane.
+confirmation, `r` resolves the branch again, arrow keys or `j`/`k` scroll the
+focused pane, and `d` toggles normalized technical details after a preview is
+loaded. Press `c` to open or focus capabilities and `c`/`esc` to return to the
+preview without resetting either pane.
 
 ## Capability panel
 

--- a/pkgs/atyrode-tui/main.go
+++ b/pkgs/atyrode-tui/main.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 
 	inventorydata "atyrode-tui/inventory"
 	previewdata "atyrode-tui/preview"
@@ -23,7 +24,6 @@ type phase int
 
 const (
 	loadingPlan phase = iota
-	loadingPreview
 	ready
 	confirming
 	applying
@@ -52,8 +52,10 @@ type planMsg struct {
 }
 
 type previewMsg struct {
-	preview previewdata.Document
-	err     error
+	revision   string
+	generation uint64
+	preview    previewdata.Document
+	err        error
 }
 type inventoryMsg struct {
 	revision   string
@@ -72,7 +74,24 @@ const (
 
 type applyDoneMsg struct{ err error }
 
-type outputFunc func(string, ...string) ([]byte, error)
+type commandRunner interface {
+	Output(context.Context, string, ...string) ([]byte, error)
+}
+
+type execCommandRunner struct{}
+
+func (execCommandRunner) Output(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	return cmd.CombinedOutput()
+}
+
 type applyFunc func(string, ...string) tea.Cmd
 
 type askGroundingFunc func(context.Context, string) ([]byte, error)
@@ -126,34 +145,40 @@ func buildAskGrounding(help []byte) (clikit.DocCorpus, error) {
 
 type model struct {
 	cli    string
-	output outputFunc
+	runner commandRunner
 	apply  applyFunc
 	asker  clikit.Asker
 	phase  phase
 	plan   applyPlan
 
-	preview              previewdata.Document
-	inventory            inventorydata.Document
-	inventoryLoading     bool
-	inventoryErr         error
-	inventoryGeneration  uint64
+	preview             previewdata.Document
+	previewLoading      bool
+	previewErr          error
+	previewGeneration   uint64
+	previewCancel       context.CancelFunc
+	inventory           inventorydata.Document
+	inventoryRequested  bool
+	inventoryLoading    bool
+	inventoryErr        error
+	inventoryGeneration uint64
+	inventoryCancel     context.CancelFunc
+
 	inventoryDiagnostic  string
 	inventoryDetailsOpen bool
-
-	details            bool
-	capabilitiesOpen   bool
-	focus              pane
-	previewCursor      int
-	capabilityCursor   int
-	selectedCapability int
-	width              int
-	height             int
-	err                error
-	status             string
+	details              bool
+	capabilitiesOpen     bool
+	focus                pane
+	previewCursor        int
+	capabilityCursor     int
+	selectedCapability   int
+	width                int
+	height               int
+	err                  error
+	status               string
 }
 
-func commandOutput(name string, args ...string) ([]byte, error) {
-	return exec.Command(name, args...).CombinedOutput()
+func commandOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return execCommandRunner{}.Output(ctx, name, args...)
 }
 
 func execApply(cli string, args ...string) tea.Cmd {
@@ -178,7 +203,7 @@ func newModel(cli string) model {
 	}
 	return model{
 		cli:    cli,
-		output: commandOutput,
+		runner: execCommandRunner{},
 		apply:  execApply,
 		asker:  asker,
 		phase:  loadingPlan,
@@ -194,8 +219,10 @@ func (model) BoxTitle() string { return "ASK ATYRODE · read-only" }
 func (m model) Init() tea.Cmd { return m.loadPlan() }
 
 func (m model) loadPlan() tea.Cmd {
+	runner := m.runner
+	cli := m.cli
 	return func() tea.Msg {
-		out, err := m.output(m.cli, "apply", "--plan", "--json")
+		out, err := runner.Output(context.Background(), cli, "apply", "--plan", "--json")
 		if err != nil {
 			return planMsg{err: commandError("load apply plan", out, err)}
 		}
@@ -210,29 +237,49 @@ func (m model) loadPlan() tea.Cmd {
 	}
 }
 
-func (m model) loadPreview() tea.Cmd {
+func (m *model) startPreview() tea.Cmd {
+	if m.previewLoading || m.preview.SchemaVersion != 0 || m.inventoryLoading {
+		return nil
+	}
+	m.previewGeneration++
+	generation := m.previewGeneration
+	revision, plan := m.plan.ResolvedRevision, m.plan
+	ctx, cancel := context.WithCancel(context.Background())
+	m.previewCancel = cancel
+	m.previewLoading, m.previewErr = true, nil
+	runner, cli, args := m.runner, m.cli, m.applyArgs(true)
 	return func() tea.Msg {
-		out, err := m.output(m.cli, m.applyArgs(true)...)
+		out, err := runner.Output(ctx, cli, args...)
 		if err != nil {
-			return previewMsg{err: commandError("preview apply", out, err)}
+			return previewMsg{revision: revision, generation: generation, err: commandError("preview apply", out, err)}
 		}
 		var result previewdata.Document
 		if err := json.Unmarshal(out, &result); err != nil {
-			return previewMsg{err: fmt.Errorf("decode activation preview: %w", err)}
+			return previewMsg{revision: revision, generation: generation, err: fmt.Errorf("decode activation preview: %w", err)}
 		}
 		if result.SchemaVersion != previewdata.SchemaVersion {
-			return previewMsg{err: fmt.Errorf("decode activation preview: unsupported schema version %d", result.SchemaVersion)}
+			return previewMsg{revision: revision, generation: generation, err: fmt.Errorf("decode activation preview: unsupported schema version %d", result.SchemaVersion)}
 		}
-		if result.ResolvedRevision != m.plan.ResolvedRevision || result.Host != m.plan.Host || result.System != m.plan.System {
-			return previewMsg{err: fmt.Errorf("decode activation preview: plan identity changed")}
+		if result.ResolvedRevision != plan.ResolvedRevision || result.Host != plan.Host || result.System != plan.System {
+			return previewMsg{revision: revision, generation: generation, err: fmt.Errorf("decode activation preview: plan identity changed")}
 		}
-		return previewMsg{preview: result}
+		return previewMsg{revision: revision, generation: generation, preview: result}
 	}
 }
-func (m model) loadInventory() tea.Cmd {
+func (m *model) startInventory() tea.Cmd {
+	if m.inventoryRequested || m.previewLoading {
+		return nil
+	}
+	m.inventoryRequested, m.inventoryLoading, m.inventoryErr = true, true, nil
+	m.inventoryDiagnostic, m.inventoryDetailsOpen = "", false
+	m.inventoryGeneration++
 	revision, generation := m.plan.ResolvedRevision, m.inventoryGeneration
+	plan := m.plan
+	ctx, cancel := context.WithCancel(context.Background())
+	m.inventoryCancel = cancel
+	runner, cli := m.runner, m.cli
 	return func() tea.Msg {
-		out, err := m.output(m.cli, "inventory", "--ref", revision, "--json")
+		out, err := runner.Output(ctx, cli, "inventory", "--ref", revision, "--json")
 		if err != nil {
 			return inventoryMsg{
 				revision:   revision,
@@ -243,15 +290,42 @@ func (m model) loadInventory() tea.Cmd {
 		}
 		result, err := inventorydata.Parse(out, inventorydata.Expected{
 			Revision:           revision,
-			System:             m.plan.System,
-			Host:               m.plan.Host,
-			ActiveCapabilities: m.plan.Capabilities,
+			System:             plan.System,
+			Host:               plan.Host,
+			ActiveCapabilities: plan.Capabilities,
 		})
 		if err != nil {
 			return inventoryMsg{revision: revision, generation: generation, err: err}
 		}
 		return inventoryMsg{revision: revision, generation: generation, inventory: result}
 	}
+}
+
+func (m *model) cancelPreview() {
+	if m.previewCancel != nil {
+		m.previewCancel()
+		m.previewCancel = nil
+	}
+	if m.previewLoading {
+		m.previewGeneration++
+		m.previewLoading = false
+	}
+}
+
+func (m *model) cancelInventory() {
+	if m.inventoryCancel != nil {
+		m.inventoryCancel()
+		m.inventoryCancel = nil
+	}
+	if m.inventoryLoading {
+		m.inventoryGeneration++
+		m.inventoryLoading = false
+	}
+}
+
+func (m *model) cancelInspections() {
+	m.cancelPreview()
+	m.cancelInventory()
 }
 
 func (m model) applyArgs(preview bool) []string {
@@ -335,24 +409,33 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.phase, m.err = failed, msg.err
 			return m, nil
 		}
-		m.plan, m.phase, m.err = msg.plan, loadingPreview, nil
+		m.plan, m.phase, m.err = msg.plan, ready, nil
+		m.previewGeneration++
+		m.preview, m.previewLoading, m.previewErr, m.previewCancel = previewdata.Document{}, false, nil, nil
 		m.inventoryGeneration++
-		m.inventory, m.inventoryErr, m.inventoryLoading = inventorydata.Document{}, nil, true
+		m.inventory, m.inventoryRequested, m.inventoryLoading = inventorydata.Document{}, false, false
+		m.inventoryErr, m.inventoryCancel = nil, nil
 		m.inventoryDiagnostic, m.inventoryDetailsOpen = "", false
-		return m, tea.Batch(m.loadPreview(), m.loadInventory())
+		m.previewCursor, m.capabilityCursor, m.selectedCapability = 0, 0, 0
+		m.details, m.capabilitiesOpen, m.focus = false, false, previewPane
+		return m, nil
 	case previewMsg:
-		if msg.err != nil {
-			m.phase, m.err = failed, msg.err
+		if msg.generation != m.previewGeneration || msg.revision != m.plan.ResolvedRevision {
 			return m, nil
 		}
-		m.preview = msg.preview
-		m.phase, m.err, m.previewCursor, m.details = ready, nil, 0, false
+		m.previewLoading, m.previewCancel = false, nil
+		if msg.err != nil {
+			m.preview, m.previewErr = previewdata.Document{}, msg.err
+		} else {
+			m.preview, m.previewErr = msg.preview, nil
+			m.previewCursor, m.details = 0, false
+		}
 		return m, nil
 	case inventoryMsg:
 		if msg.generation != m.inventoryGeneration || msg.revision != m.plan.ResolvedRevision {
 			return m, nil
 		}
-		m.inventoryLoading = false
+		m.inventoryLoading, m.inventoryCancel = false, nil
 		m.inventoryDiagnostic, m.inventoryDetailsOpen = msg.diagnostic, false
 		if msg.err != nil {
 			m.inventory, m.inventoryErr = inventorydata.Document{}, msg.err
@@ -374,16 +457,28 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c", "q":
+			m.cancelInspections()
 			return m, tea.Quit
 		case "r":
 			if m.phase != applying {
+				m.cancelInspections()
 				m.phase, m.err, m.status, m.preview, m.inventory = loadingPlan, nil, "", previewdata.Document{}, inventorydata.Document{}
+				m.previewGeneration++
 				m.inventoryGeneration++
-				m.inventoryErr, m.inventoryLoading, m.details = nil, false, false
+				m.previewErr, m.previewLoading, m.details = nil, false, false
+				m.inventoryErr, m.inventoryRequested, m.inventoryLoading = nil, false, false
 				m.inventoryDiagnostic, m.inventoryDetailsOpen = "", false
 				m.capabilitiesOpen, m.focus = false, previewPane
 				m.previewCursor, m.capabilityCursor, m.selectedCapability = 0, 0, 0
 				return m, m.loadPlan()
+			}
+		case "v":
+			if m.previewLoading {
+				m.cancelPreview()
+				return m, nil
+			}
+			if (m.phase == ready || m.phase == applied) && m.preview.SchemaVersion == 0 && !m.inventoryLoading {
+				return m, m.startPreview()
 			}
 		case "c":
 			if m.phase == ready || m.phase == confirming || m.phase == applied {
@@ -394,6 +489,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				} else {
 					m.focus, m.capabilitiesOpen = capabilityPane, true
+					return m, m.startInventory()
 				}
 			}
 		case "tab":
@@ -402,6 +498,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.focus = previewPane
 				} else {
 					m.focus, m.capabilitiesOpen = capabilityPane, true
+					return m, m.startInventory()
 				}
 			}
 		case "[", "left":
@@ -425,15 +522,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				(m.phase == ready || m.phase == confirming || m.phase == applied) {
 				m.inventoryDetailsOpen = !m.inventoryDetailsOpen
 				m.capabilityCursor = 0
-			} else if m.focus == previewPane && (m.phase == ready || m.phase == confirming || m.phase == applied) {
+			} else if m.focus == previewPane && m.preview.SchemaVersion != 0 &&
+				(m.phase == ready || m.phase == confirming || m.phase == applied) {
 				m.details, m.previewCursor = !m.details, 0
 			}
 		case "a", "enter":
 			if m.phase == ready {
+				m.cancelPreview()
 				m.phase = confirming
 			}
 		case "y":
 			if m.phase == confirming {
+				m.cancelInspections()
 				m.phase, m.err = applying, nil
 				return m, m.apply(m.cli, m.applyArgs(false)...)
 			}
@@ -669,27 +769,61 @@ func (m model) previewHeight() int {
 }
 
 func (m model) previewBox(width int) string {
+	previewWidth := max(1, panelContentWidth(width)-4)
 	var body string
-	switch m.phase {
-	case loadingPlan:
-		body = clikit.StDim.Render("Loading apply plan…")
-	case loadingPreview:
-		body = clikit.StDim.Render("Building read-only activation preview…")
-	case applying:
-		body = clikit.StWarn.Render("Apply is running in the terminal…")
-	default:
-		if m.preview.SchemaVersion == 0 {
-			body = clikit.StDim.Render("Preview unavailable.")
-		} else {
-			previewWidth := max(1, panelContentWidth(width)-4)
-			body = clikit.WindowList(m.previewRowsForWidth(max(1, previewWidth-1)), m.previewCursor, m.previewHeight(), previewWidth)
-		}
+	if m.preview.SchemaVersion != 0 {
+		body = clikit.WindowList(m.previewRowsForWidth(max(1, previewWidth-1)), m.previewCursor, m.previewHeight(), previewWidth)
+	} else {
+		body = clikit.WindowList(m.previewStatusRows(max(1, previewWidth-1)), 0, m.previewHeight(), previewWidth)
 	}
 	label := iconStyle.Render("\uf0ad") + "  " + titleStyle.Render("ACTIVATION PREVIEW")
 	if m.focus == previewPane {
 		label += clikit.StHead.Render("  ·  FOCUSED")
 	}
 	return panel(width, label+"\n"+body)
+}
+
+func (m model) previewStatusRows(width int) []string {
+	rows := make([]string, 0, 10)
+	switch {
+	case m.phase == loadingPlan:
+		appendWrappedRow(&rows, clikit.StDim.Render("Loading apply plan…"), width)
+	case m.phase == applying:
+		appendWrappedRow(&rows, clikit.StWarn.Render("Apply is running in the terminal…"), width)
+	case m.previewLoading:
+		appendWrappedRow(&rows, titleStyle.Render("Loading optional dry preview…"), width)
+		rows = append(rows, "")
+		appendWrappedRow(&rows, clikit.StDim.Render("The exact-revision Nix evaluation is running in the background."), width)
+		appendWrappedRow(&rows, "Apply controls remain available. Press v to cancel.", width)
+	case m.previewErr != nil:
+		appendWrappedRow(&rows, clikit.StBrk.Bold(true).Render("Preview unavailable"), width)
+		rows = append(rows, "")
+		reason := strings.Split(stripTerminalControls(m.previewErr.Error()), "\n")
+		if len(reason) > maxErrorLines {
+			reason = reason[:maxErrorLines]
+		}
+		for _, line := range reason {
+			appendWrappedRow(&rows, clikit.StDim.Render(line), width)
+		}
+		rows = append(rows, "")
+		appendWrappedRow(&rows, "Press v to retry. Apply remains available.", width)
+	default:
+		marker := "Preview not loaded"
+		if m.phase == confirming {
+			marker = "Optional dry preview was not run."
+		}
+		appendWrappedRow(&rows, titleStyle.Render(marker), width)
+		rows = append(rows, "")
+		appendWrappedRow(&rows, clikit.StDim.Render("The validated exact-revision plan is ready."), width)
+		if m.phase == confirming {
+			appendWrappedRow(&rows, "Apply can continue without the optional package/action diff.", width)
+		} else if m.inventoryLoading {
+			appendWrappedRow(&rows, "Capability inventory is loading. Preview waits to avoid duplicate Nix evaluation.", width)
+		} else {
+			appendWrappedRow(&rows, "Press v to load the optional package/action diff.", width)
+		}
+	}
+	return rows
 }
 func (m model) capabilityPanelWidth() int {
 	_, total := m.horizontalLayout()
@@ -719,6 +853,15 @@ func (m model) capabilityRows() []string {
 func (m model) capabilityRowsForWidth(width int) []string {
 	rows := make([]string, 0, 32)
 	switch {
+	case !m.inventoryRequested:
+		appendWrappedRow(&rows, titleStyle.Render("Inventory not loaded"), width)
+		rows = append(rows, "")
+		if m.previewLoading {
+			appendWrappedRow(&rows, clikit.StDim.Render("Cancel the running preview with v before loading capabilities."), width)
+		} else {
+			appendWrappedRow(&rows, clikit.StDim.Render("Press c to load exact-revision capability details."), width)
+		}
+		return rows
 	case m.inventoryLoading:
 		appendWrappedRow(&rows, clikit.StDim.Render("Loading exact-revision inventory…"), width)
 		return rows
@@ -1054,40 +1197,50 @@ func (m model) footer() string {
 		}
 		if m.width < 60 {
 			if m.phase == confirming {
-				return clikit.StWarn.Render("[/] cycle  ·  c back  ·  y/n apply")
+				return clikit.StWarn.Render("c back  ·  y/n apply")
 			}
-			return clikit.StDim.Render(controls)
-		}
-		if m.phase == confirming && m.width < 68 {
-			return clikit.StWarn.Render("[/] cycle  ·  c back  ·  y/n apply")
+			return clikit.StDim.Render("c back  ·  a apply  ·  q")
 		}
 		if m.phase == confirming {
 			controls += "  ·  y confirm  ·  n cancel"
 			return clikit.StWarn.Render(controls)
 		}
-		return clikit.StDim.Render(controls + "  ·  ^O ask  ·  q")
+		return clikit.StDim.Render(controls + "  ·  enter apply  ·  q")
 	}
 	switch m.phase {
 	case confirming:
 		if m.width < 80 {
-			return clikit.StWarn.Render("y confirm  ·  n cancel  ·  c capabilities")
+			return clikit.StWarn.Render("Apply plan?  y confirm  ·  n cancel")
 		}
-		return clikit.StWarn.Render("Apply this configuration?  y confirm  ·  n cancel  ·  d " + mode + "  ·  c capabilities  ·  ^O ask")
+		return clikit.StWarn.Render("Apply this configuration?  y confirm  ·  n cancel  ·  c capabilities  ·  ^O ask")
 	case applying:
 		return clikit.StDim.Render("Applying…  ·  ^O ask")
 	case applied:
 		if m.width < 60 {
-			return clikit.StOk.Render(m.status) + "\n" + clikit.StDim.Render("c capabilities  ·  r refresh  ·  q")
+			return clikit.StOk.Render(m.status) + "\n" + clikit.StDim.Render("c caps  ·  r refresh  ·  q")
 		}
-		return clikit.StOk.Render(m.status) + "\n" + clikit.StDim.Render("c capabilities  ·  d "+mode+"  ·  r refresh  ·  ^O ask  ·  q quit")
+		return clikit.StOk.Render(m.status) + "\n" + clikit.StDim.Render("c capabilities  ·  r refresh  ·  ^O ask  ·  q quit")
 	case ready:
+		previewControl := "v preview"
+		if m.previewLoading {
+			previewControl = "v cancel preview"
+		} else if m.preview.SchemaVersion != 0 {
+			previewControl = "d " + mode
+		}
 		if m.width < 60 {
-			return clikit.StDim.Render("c capabilities  ·  enter apply  ·  q")
+			if m.previewLoading {
+				return clikit.StDim.Render("v cancel  ·  a apply  ·  q")
+			}
+			return clikit.StDim.Render(previewControl + "  ·  c caps  ·  a apply  ·  q")
 		}
 		if m.width < 112 {
-			return clikit.StDim.Render("↑/↓ preview  ·  c capabilities  ·  d " + mode + "  ·  enter apply  ·  q")
+			mediumControl := previewControl
+			if m.previewLoading {
+				mediumControl = "v cancel"
+			}
+			return clikit.StDim.Render("↑/↓ scroll  ·  " + mediumControl + "  ·  c capabilities  ·  enter apply  ·  q")
 		}
-		return clikit.StDim.Render("↑/↓ preview  ·  Tab/c capabilities  ·  d " + mode + "  ·  enter apply  ·  r refresh  ·  ^O ask  ·  q")
+		return clikit.StDim.Render("↑/↓ preview  ·  " + previewControl + "  ·  Tab/c capabilities  ·  enter apply  ·  r refresh  ·  ^O ask  ·  q")
 	default:
 		return clikit.StDim.Render("^O ask  ·  q quit")
 	}

--- a/pkgs/atyrode-tui/main_test.go
+++ b/pkgs/atyrode-tui/main_test.go
@@ -19,6 +19,12 @@ import (
 
 const testRevision = "feedfacefeedfacefeedfacefeedfacefeedface"
 
+type runnerFunc func(context.Context, string, ...string) ([]byte, error)
+
+func (f runnerFunc) Output(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return f(ctx, name, args...)
+}
+
 func testPreviewDocument() previewdata.Document {
 	return previewdata.Document{
 		SchemaVersion:    previewdata.SchemaVersion,
@@ -187,51 +193,54 @@ func TestGroundedAskerCancellationClosesStream(t *testing.T) {
 	}
 }
 
-func TestInitLoadsPlanThenDryRunPreview(t *testing.T) {
+func TestInitLoadsOnlyPlanAndPreviewIsExplicit(t *testing.T) {
 	var calls [][]string
 	m := newModel("/bin/atyrode")
-	m.output = func(name string, args ...string) ([]byte, error) {
+	m.runner = runnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
 		calls = append(calls, append([]string{name}, args...))
-		switch len(calls) {
-		case 1:
+		switch {
+		case reflect.DeepEqual(args, []string{"apply", "--plan", "--json"}):
 			return []byte(`{"host":"workstation","system":"x86_64-linux","user":"alex","capabilities":["base","agents"],"installable":"github:atyrode/dotfiles/feedfacefeedfacefeedfacefeedfacefeedface#workstation","revision":"feedfacefeed","resolvedRevision":"feedfacefeedfacefeedfacefeedfacefeedface","source":"remote"}`), nil
-		case 2:
-			result, err := json.Marshal(testPreviewDocument())
-			if err != nil {
-				t.Fatal(err)
-			}
-			return result, nil
-		case 3:
-			result, err := json.Marshal(testInventoryDocument())
-			if err != nil {
-				t.Fatal(err)
-			}
-			return result, nil
+		case reflect.DeepEqual(args, []string{"apply", "--ref", testRevision, "--preview-json"}):
+			return json.Marshal(testPreviewDocument())
 		default:
-			t.Fatal("unexpected command")
+			t.Fatalf("unexpected command: %s %v", name, args)
 			return nil, nil
 		}
-	}
+	})
 
 	plan := m.Init()().(planMsg)
 	next, cmd := m.Update(plan)
 	m = next.(model)
-	batch := cmd().(tea.BatchMsg)
-	for _, load := range batch {
-		next, _ = m.Update(load())
-		m = next.(model)
+	if cmd != nil || m.phase != ready {
+		t.Fatalf("plan completion phase/cmd = %v/%v, want ready/nil", m.phase, cmd)
+	}
+	if want := [][]string{{"/bin/atyrode", "apply", "--plan", "--json"}}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("startup commands = %#v, want %#v", calls, want)
+	}
+	unloaded := stripTerminalControls(m.View())
+	for _, want := range []string{"workstation", "feedfacefeed", "Preview not loaded", "v preview", "enter apply"} {
+		if !strings.Contains(unloaded, want) {
+			t.Errorf("unloaded ready view missing %q", want)
+		}
 	}
 
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+	m = next.(model)
+	if !m.previewLoading || cmd == nil || m.phase != ready {
+		t.Fatalf("preview start loading/cmd/phase = %t/%v/%v", m.previewLoading, cmd, m.phase)
+	}
+	next, _ = m.Update(cmd())
+	m = next.(model)
 	wantCalls := [][]string{
 		{"/bin/atyrode", "apply", "--plan", "--json"},
 		{"/bin/atyrode", "apply", "--ref", testRevision, "--preview-json"},
-		{"/bin/atyrode", "inventory", "--ref", testRevision, "--json"},
 	}
 	if !reflect.DeepEqual(calls, wantCalls) {
 		t.Fatalf("commands = %#v, want %#v", calls, wantCalls)
 	}
-	if m.phase != ready {
-		t.Fatalf("phase = %v, want ready", m.phase)
+	if m.phase != ready || m.previewLoading || m.preview.SchemaVersion == 0 {
+		t.Fatalf("preview completion state = phase %v loading %t schema %d", m.phase, m.previewLoading, m.preview.SchemaVersion)
 	}
 	view := stripTerminalControls(m.View())
 	for _, want := range []string{"ACTIVATION PREVIEW", "Applying revision feedfacefeed", "Preview built", "1 added", "2 updated", "1 removed", "Disk usage decreases by 5.59 MiB"} {
@@ -239,24 +248,13 @@ func TestInitLoadsPlanThenDryRunPreview(t *testing.T) {
 			t.Errorf("visible summary missing %q", want)
 		}
 	}
-	allRows := stripTerminalControls(strings.Join(m.previewRowsForWidth(80), "\n"))
-	for _, want := range []string{"Added (1)", "Updated (2)", "Removed (1)", "alpha", "1.0 → 2.0", "delta", "5.0"} {
-		if !strings.Contains(allRows, want) {
-			t.Errorf("summary rows missing %q", want)
-		}
-	}
-	for _, hidden := range []string{"/nix/store/old-home-manager-generation", "/nix/store/new-home-manager-generation"} {
-		if strings.Contains(view, hidden) {
-			t.Errorf("summary exposed generation path %q", hidden)
-		}
-	}
 }
 
 func TestRemotePlanRequiresResolvedRevision(t *testing.T) {
 	m := newModel("atyrode")
-	m.output = func(string, ...string) ([]byte, error) {
+	m.runner = runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
 		return []byte(`{"source":"remote","revision":"feedfacefeed"}`), nil
-	}
+	})
 	msg := m.Init()().(planMsg)
 	if msg.err == nil || !strings.Contains(msg.err.Error(), "full resolved revision") {
 		t.Fatalf("missing resolved revision error = %v", msg.err)
@@ -265,20 +263,22 @@ func TestRemotePlanRequiresResolvedRevision(t *testing.T) {
 
 func TestPreviewMustMatchPlannedIdentity(t *testing.T) {
 	m := newModel("atyrode")
-	m.phase = loadingPreview
+	m.phase = ready
 	m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", Source: "remote", ResolvedRevision: testRevision}
 	result := testPreviewDocument()
 	result.ResolvedRevision = strings.Repeat("b", 40)
-	m.output = func(string, ...string) ([]byte, error) {
+	m.runner = runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
 		return json.Marshal(result)
+	})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+	m = next.(model)
+	next, _ = m.Update(cmd())
+	m = next.(model)
+	if m.previewErr == nil || !strings.Contains(m.previewErr.Error(), "plan identity changed") {
+		t.Fatalf("identity mismatch error = %v", m.previewErr)
 	}
-	msg := m.loadPreview()().(previewMsg)
-	if msg.err == nil || !strings.Contains(msg.err.Error(), "plan identity changed") {
-		t.Fatalf("identity mismatch error = %v", msg.err)
-	}
-	next, _ := m.Update(msg)
-	if next.(model).phase != failed {
-		t.Fatal("identity mismatch did not fail closed")
+	if m.phase != ready {
+		t.Fatal("identity mismatch blocked the validated plan")
 	}
 }
 
@@ -325,18 +325,123 @@ func TestApplyRequiresExplicitConfirmation(t *testing.T) {
 	}
 }
 
-func TestPreviewFailureNeverEnablesApply(t *testing.T) {
+func TestPreviewFailureIsPanelLocalAndApplyRemainsAvailable(t *testing.T) {
 	m := newModel("atyrode")
-	m.phase = loadingPreview
-	next, _ := m.Update(previewMsg{err: errors.New("dry run failed")})
+	m.phase = ready
+	m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", ResolvedRevision: testRevision}
+	m.previewGeneration = 3
+	next, _ := m.Update(previewMsg{revision: testRevision, generation: 3, err: errors.New("dry run failed")})
 	m = next.(model)
-	if m.phase != failed {
-		t.Fatalf("phase = %v, want failed", m.phase)
+	if m.phase != ready || m.previewErr == nil || m.err != nil {
+		t.Fatalf("preview failure escaped panel: phase=%v previewErr=%v err=%v", m.phase, m.previewErr, m.err)
 	}
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = next.(model)
-	if m.phase != failed || cmd != nil {
-		t.Fatal("failed preview allowed apply")
+	if m.phase != confirming || cmd != nil {
+		t.Fatal("failed preview blocked apply confirmation")
+	}
+	view := stripTerminalControls(m.View())
+	for _, want := range []string{"Preview unavailable", "dry run failed", "y confirm"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("local failure view missing %q", want)
+		}
+	}
+}
+
+func TestPreviewLoadingRemainsResponsiveAndCancellationIsStaleSafe(t *testing.T) {
+	for _, key := range []string{"a", "v", "r", "q"} {
+		t.Run(key, func(t *testing.T) {
+			started, cancelled := make(chan struct{}), make(chan struct{})
+			m := newModel("atyrode")
+			m.phase = ready
+			m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", Source: "remote", ResolvedRevision: testRevision}
+			m.runner = runnerFunc(func(ctx context.Context, _ string, args ...string) ([]byte, error) {
+				if !reflect.DeepEqual(args, []string{"apply", "--ref", testRevision, "--preview-json"}) {
+					t.Fatalf("preview args = %#v", args)
+				}
+				close(started)
+				<-ctx.Done()
+				close(cancelled)
+				return nil, ctx.Err()
+			})
+
+			next, previewCmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+			m = next.(model)
+			if previewCmd == nil || !m.previewLoading || m.phase != ready {
+				t.Fatal("preview did not start in non-blocking ready state")
+			}
+			result := make(chan tea.Msg, 1)
+			go func() { result <- previewCmd() }()
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("preview runner did not start")
+			}
+
+			m = press(m, "j")
+			if m.phase != ready || !strings.Contains(stripTerminalControls(m.View()), "Apply controls remain available") {
+				t.Fatal("loading preview made the model unresponsive")
+			}
+			next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)})
+			m = next.(model)
+			select {
+			case <-cancelled:
+			case <-time.After(time.Second):
+				t.Fatalf("%q did not cancel preview context", key)
+			}
+			if m.previewLoading {
+				t.Fatalf("%q left preview loading", key)
+			}
+			if key == "a" && m.phase != confirming {
+				t.Fatalf("apply key phase = %v, want confirming", m.phase)
+			}
+			stale := <-result
+			next, _ = m.Update(stale)
+			after := next.(model)
+			if after.previewErr != nil || after.preview.SchemaVersion != 0 {
+				t.Fatalf("stale cancellation reply changed preview: %#v / %v", after.preview, after.previewErr)
+			}
+		})
+	}
+}
+
+func TestPreviewRepliesAreScopedToRevisionAndGeneration(t *testing.T) {
+	m := newModel("atyrode")
+	m.phase = ready
+	m.plan.ResolvedRevision = testRevision
+	m.previewGeneration = 9
+	current := testPreviewDocument()
+	next, _ := m.Update(previewMsg{revision: testRevision, generation: 9, preview: current})
+	m = next.(model)
+	for _, stale := range []previewMsg{
+		{revision: strings.Repeat("a", 40), generation: 9, err: errors.New("wrong revision")},
+		{revision: testRevision, generation: 8, err: errors.New("old failure")},
+		{revision: testRevision, generation: 10, preview: previewdata.Document{SchemaVersion: previewdata.SchemaVersion}},
+	} {
+		next, _ = m.Update(stale)
+		m = next.(model)
+		if !reflect.DeepEqual(m.preview, current) || m.previewErr != nil {
+			t.Fatalf("stale preview reply mutated current state: %#v / %v", m.preview, m.previewErr)
+		}
+	}
+}
+
+func TestConfirmationExplainsOptionalPreviewStatus(t *testing.T) {
+	m := newModel("atyrode")
+	m.phase = ready
+	m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", ResolvedRevision: testRevision}
+	m = press(m, "enter")
+	without := stripTerminalControls(m.View())
+	if !strings.Contains(without, "Optional dry preview was not run.") || !strings.Contains(without, "y confirm") {
+		t.Fatalf("no-preview confirmation was not explicit: %q", without)
+	}
+
+	m.phase, m.preview = ready, testPreviewDocument()
+	m = press(m, "enter")
+	with := stripTerminalControls(m.View())
+	if !strings.Contains(with, "Preview built") || !strings.Contains(with, "y confirm") ||
+		strings.Contains(with, "Optional dry preview was not run.") {
+		t.Fatalf("loaded-preview confirmation status = %q", with)
 	}
 }
 
@@ -438,10 +543,10 @@ func TestStripTerminalControlsUsesANSIParser(t *testing.T) {
 func TestLongPlanFailureStaysInsideNarrowWindow(t *testing.T) {
 	m := newModel("atyrode")
 	m.width, m.height = 44, 26
-	m.output = func(string, ...string) ([]byte, error) {
+	m.runner = runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
 		output := "\x1b]0;unsafe\x07" + strings.Repeat("plan-failure-with-an-unbroken-path/", 12)
 		return []byte(output), errors.New("exit status 69")
-	}
+	})
 	msg := m.Init()().(planMsg)
 	next, _ := m.Update(msg)
 	assertFailureViewContained(t, next.(model))
@@ -449,16 +554,29 @@ func TestLongPlanFailureStaysInsideNarrowWindow(t *testing.T) {
 
 func TestLongPreviewFailureStaysInsideNarrowWindow(t *testing.T) {
 	m := newModel("atyrode")
-	m.width, m.height = 44, 26
+	m.width, m.height, m.phase = 44, 26, ready
 	m.plan = applyPlan{
 		Host: "fixture", System: "x86_64-linux", User: "alex",
 		Capabilities: []string{"base"}, Source: "remote", Revision: "feedfacefeed",
 		ResolvedRevision: testRevision,
 	}
 	output := "\x1bPignored\x1b\\" + strings.Repeat("/nix/store/preview-failure-without-breakpoints", 10)
+	m.previewGeneration = 4
 	err := commandError("preview apply", []byte(output), errors.New("exit status 1"))
-	next, _ := m.Update(previewMsg{err: err})
-	assertFailureViewContained(t, next.(model))
+	next, _ := m.Update(previewMsg{revision: testRevision, generation: 4, err: err})
+	m = next.(model)
+	if m.phase != ready || m.previewErr == nil {
+		t.Fatalf("preview error blocked ready state: phase=%v err=%v", m.phase, m.previewErr)
+	}
+	lines := strings.Split(m.View(), "\n")
+	if len(lines) > m.height {
+		t.Errorf("preview failure view rendered %d rows into height %d", len(lines), m.height)
+	}
+	for _, line := range lines {
+		if width := lipgloss.Width(line); width > m.width-1 {
+			t.Errorf("preview failure row width = %d, safe window = %d: %q", width, m.width-1, stripTerminalControls(line))
+		}
+	}
 }
 
 func assertFailureViewContained(t *testing.T, m model) {
@@ -546,6 +664,7 @@ func readyInventoryModel(width int) model {
 		Revision: testRevision, System: "x86_64-linux", Host: "workstation",
 		ActiveCapabilities: m.plan.Capabilities,
 	})
+	m.inventoryRequested = true
 	return m
 }
 
@@ -694,6 +813,137 @@ func TestInventoryLoadingAndFailureNeverAlterApplyConfirmation(t *testing.T) {
 	}
 }
 
+func TestCapabilityInventoryIsLazyExactRevisionAndRequestedOnce(t *testing.T) {
+	var calls [][]string
+	m := newModel("/bin/atyrode")
+	m.phase = ready
+	m.plan = applyPlan{
+		Host: "workstation", System: "x86_64-linux", Source: "remote",
+		ResolvedRevision: testRevision, Capabilities: []string{"base", "agents", "server"},
+	}
+	m.runner = runnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string{name}, args...))
+		return json.Marshal(testInventoryDocument())
+	})
+	if m.inventoryRequested || m.inventoryLoading {
+		t.Fatal("inventory was requested before capability inspection")
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	m = next.(model)
+	if cmd == nil || !m.inventoryRequested || !m.inventoryLoading || m.focus != capabilityPane {
+		t.Fatalf("first c state = cmd %v requested %t loading %t focus %v", cmd, m.inventoryRequested, m.inventoryLoading, m.focus)
+	}
+	next, _ = m.Update(cmd())
+	m = next.(model)
+	want := [][]string{{"/bin/atyrode", "inventory", "--ref", testRevision, "--json"}}
+	if !reflect.DeepEqual(calls, want) || m.inventoryLoading || len(m.inventory.Capabilities) != 3 {
+		t.Fatalf("inventory calls/state = %#v loading=%t capabilities=%d", calls, m.inventoryLoading, len(m.inventory.Capabilities))
+	}
+	m = press(m, "c")
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	m = next.(model)
+	if cmd != nil || len(calls) != 1 {
+		t.Fatalf("reopening inventory started another request: cmd=%v calls=%#v", cmd, calls)
+	}
+}
+
+func TestInspectionRequestsNeverOverlap(t *testing.T) {
+	previewing := newModel("atyrode")
+	previewing.phase = ready
+	previewing.plan.ResolvedRevision = testRevision
+	previewing.previewLoading = true
+	next, cmd := previewing.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	previewing = next.(model)
+	if cmd != nil || previewing.inventoryRequested {
+		t.Fatal("capability inspection overlapped a running preview")
+	}
+
+	inventoryLoading := newModel("atyrode")
+	inventoryLoading.phase = ready
+	inventoryLoading.plan.ResolvedRevision = testRevision
+	inventoryLoading.inventoryRequested, inventoryLoading.inventoryLoading = true, true
+	next, cmd = inventoryLoading.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+	inventoryLoading = next.(model)
+	if cmd != nil || inventoryLoading.previewLoading {
+		t.Fatal("preview overlapped a running capability inventory")
+	}
+}
+
+func TestInventoryContextIsCancelledByRefreshAndQuit(t *testing.T) {
+	for _, key := range []string{"r", "q"} {
+		t.Run(key, func(t *testing.T) {
+			started, cancelled := make(chan struct{}), make(chan struct{})
+			m := newModel("atyrode")
+			m.phase = ready
+			m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", ResolvedRevision: testRevision}
+			m.runner = runnerFunc(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+				close(started)
+				<-ctx.Done()
+				close(cancelled)
+				return nil, ctx.Err()
+			})
+			next, inventoryCmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+			m = next.(model)
+			result := make(chan tea.Msg, 1)
+			go func() { result <- inventoryCmd() }()
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("inventory runner did not start")
+			}
+			next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)})
+			m = next.(model)
+			select {
+			case <-cancelled:
+			case <-time.After(time.Second):
+				t.Fatalf("%q did not cancel inventory context", key)
+			}
+			stale := <-result
+			next, _ = m.Update(stale)
+			after := next.(model)
+			if len(after.inventory.Capabilities) != 0 || after.inventoryErr != nil {
+				t.Fatalf("stale inventory cancellation reply changed state: %#v / %v", after.inventory, after.inventoryErr)
+			}
+		})
+	}
+}
+
+func TestPreviewStatesStayResponsiveAtRepresentativeWidths(t *testing.T) {
+	states := []struct {
+		name string
+		set  func(*model)
+		want string
+	}{
+		{name: "unloaded", set: func(m *model) { m.preview = previewdata.Document{} }, want: "Preview not loaded"},
+		{name: "loading", set: func(m *model) { m.preview, m.previewLoading = previewdata.Document{}, true }, want: "Loading optional dry"},
+		{name: "failure", set: func(m *model) { m.preview, m.previewErr = previewdata.Document{}, errors.New("fixture failure") }, want: "Preview unavailable"},
+		{name: "loaded", set: func(m *model) { m.preview = testPreviewDocument() }, want: "Preview built"},
+	}
+	for _, width := range []int{140, 100, 72, 44} {
+		for _, state := range states {
+			t.Run(fmt.Sprintf("%d/%s", width, state.name), func(t *testing.T) {
+				m := readyInventoryModel(width)
+				m.height = 30
+				m.previewLoading, m.previewErr = false, nil
+				state.set(&m)
+				rendered := m.View()
+				if !strings.Contains(flattened(stripTerminalControls(rendered)), state.want) {
+					t.Fatalf("state marker %q missing from:\n%s", state.want, stripTerminalControls(rendered))
+				}
+				lines := strings.Split(rendered, "\n")
+				if len(lines) > m.height {
+					t.Fatalf("rendered %d rows into height %d", len(lines), m.height)
+				}
+				for _, line := range lines {
+					if got := lipgloss.Width(line); got > width-1 {
+						t.Fatalf("row overflowed width %d at %d: %q", width, got, stripTerminalControls(line))
+					}
+				}
+			})
+		}
+	}
+}
+
 func TestCapabilityResponsiveLayoutsStayWithinTerminal(t *testing.T) {
 	for _, width := range []int{140, 100, 72, 44} {
 		m := readyInventoryModel(width)
@@ -756,7 +1006,7 @@ func TestInventoryRepliesAreScopedToRevisionAndGeneration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := newModel("atyrode")
 			m.plan.ResolvedRevision = currentRevision
-			m.inventoryGeneration, m.inventoryLoading = 8, true
+			m.inventoryGeneration, m.inventoryRequested, m.inventoryLoading = 8, true, true
 
 			next, _ := m.Update(tt.current)
 			m = next.(model)
@@ -778,19 +1028,22 @@ func TestInventoryRepliesAreScopedToRevisionAndGeneration(t *testing.T) {
 	}
 }
 
-func TestRefreshInvalidatesPriorInventoryWhileReplacementLoads(t *testing.T) {
+func TestRefreshInvalidatesPriorInventoryAndKeepsReplacementLazy(t *testing.T) {
 	m := readyInventoryModel(100)
-	m.inventoryGeneration = 11
+	cancelled := false
+	m.inventoryGeneration, m.inventoryLoading = 11, true
+	m.inventoryCancel = func() { cancelled = true }
 	m = press(m, "r")
-	if m.phase != loadingPlan || m.inventoryGeneration != 12 {
-		t.Fatalf("refresh phase/generation = %v/%d", m.phase, m.inventoryGeneration)
+	if m.phase != loadingPlan || m.inventoryGeneration != 13 || !cancelled {
+		t.Fatalf("refresh phase/generation/cancel = %v/%d/%t", m.phase, m.inventoryGeneration, cancelled)
 	}
 
 	replacement := m.plan
-	next, _ := m.Update(planMsg{plan: replacement})
+	next, cmd := m.Update(planMsg{plan: replacement})
 	m = next.(model)
-	if !m.inventoryLoading || m.inventoryGeneration != 13 {
-		t.Fatalf("replacement request loading/generation = %t/%d", m.inventoryLoading, m.inventoryGeneration)
+	if cmd != nil || m.inventoryRequested || m.inventoryLoading || m.inventoryGeneration != 14 {
+		t.Fatalf("replacement inventory state requested/loading/generation/cmd = %t/%t/%d/%v",
+			m.inventoryRequested, m.inventoryLoading, m.inventoryGeneration, cmd)
 	}
 
 	stale := []inventoryMsg{
@@ -799,14 +1052,13 @@ func TestRefreshInvalidatesPriorInventoryWhileReplacementLoads(t *testing.T) {
 			inventory: inventorydata.Document{Capabilities: []inventorydata.Capability{{Name: "stale"}}},
 		},
 		{revision: testRevision, generation: 11, err: errors.New("stale failure"), diagnostic: "stale detail"},
-		{revision: strings.Repeat("b", 40), generation: 13, err: errors.New("wrong revision")},
 	}
 	for _, msg := range stale {
 		next, _ = m.Update(msg)
 		m = next.(model)
-		if !m.inventoryLoading || len(m.inventory.Capabilities) != 0 || m.inventoryErr != nil || m.inventoryDiagnostic != "" {
-			t.Fatalf("stale reply mutated replacement state: loading=%t inventory=%#v err=%v diagnostic=%q",
-				m.inventoryLoading, m.inventory, m.inventoryErr, m.inventoryDiagnostic)
+		if m.inventoryRequested || m.inventoryLoading || len(m.inventory.Capabilities) != 0 || m.inventoryErr != nil || m.inventoryDiagnostic != "" {
+			t.Fatalf("stale reply mutated lazy replacement: requested=%t loading=%t inventory=%#v err=%v diagnostic=%q",
+				m.inventoryRequested, m.inventoryLoading, m.inventory, m.inventoryErr, m.inventoryDiagnostic)
 		}
 	}
 }
@@ -849,11 +1101,13 @@ func TestInventoryFailureDiagnosticsAreExplicitSanitizedAndBounded(t *testing.T)
 		"SIXTH SECRET",
 	}, "\n")
 	m := readyInventoryModel(100)
-	m.inventoryGeneration, m.inventoryLoading = 5, true
-	m.output = func(string, ...string) ([]byte, error) {
+	m.inventory, m.inventoryRequested, m.inventoryLoading = inventorydata.Document{}, false, false
+	m.inventoryGeneration = 5
+	m.runner = runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
 		return []byte(raw), errors.New("exit status 27")
-	}
-	msg := m.loadInventory()().(inventoryMsg)
+	})
+	cmd := m.startInventory()
+	msg := cmd().(inventoryMsg)
 	if msg.err == nil || msg.err.Error() != "inventory unavailable: exit status 27" {
 		t.Fatalf("primary inventory error = %v", msg.err)
 	}
@@ -917,7 +1171,7 @@ func TestInventoryFailureDiagnosticsAreExplicitSanitizedAndBounded(t *testing.T)
 	if m.phase != confirming {
 		t.Fatal("diagnostic toggle cancelled apply confirmation")
 	}
-	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	m = next.(model)
 	if m.phase != applying || applies != 1 || cmd == nil {
 		t.Fatalf("diagnostic view blocked confirmed apply: phase=%v applies=%d", m.phase, applies)


### PR DESCRIPTION
## What

- load only the validated apply plan when the cockpit opens
- make the expensive activation preview explicit with `v`, cancellable, and stale-reply safe
- load capability inventory only when its pane is opened
- prevent preview and inventory Nix evaluations from overlapping
- keep apply confirmation available while optional inspections load or fail
- document the lazy inspection workflow

## Verification

- `CGO_ENABLED=0 nix shell nixpkgs#go -c go test ./...` in `pkgs/atyrode-tui`
- `nix build .#atyrode-tui`
- 44×30 tmux smoke: started a deliberately blocked preview, confirmed the footer stayed within bounds, entered apply confirmation while it was running, and observed the preview process group cancel
- rendered the confirmation frame with `freeze --language ansi`; no bottom overflow