### PR TITLE
docs(omp): record v17 default override rationale

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -21,9 +21,9 @@ concurrency:
 jobs:
   # Docs-only changes skip the 3-platform matrix (#169). Classification fails
   # closed: any API error, empty file list, or non-PR event runs the full
-  # matrix. Only `docs/**` and `README.md` are inert; every other Markdown
-  # file is treated as code because it can be a derivation input (deployed
-  # agents/skills, omp rules, home/claude/CLAUDE.md).
+  # matrix. `README.md` and `docs/**` except the versioned `docs/omp/**` wiki
+  # are inert. The OMP wiki feeds package/capability metadata, so it runs the
+  # full matrix like every other derivation input.
   changes:
     name: classify
     runs-on: ubuntu-24.04
@@ -45,6 +45,7 @@ jobs:
               code=false
               while IFS= read -r f; do
                 case "$f" in
+                  docs/omp/*) code=true ;;
                   docs/* | README.md) ;;
                   *) code=true ;;
                 esac

--- a/docs/omp/cli.md
+++ b/docs/omp/cli.md
@@ -195,6 +195,32 @@ managed defaults and plain-profile seed: repository policy requires scoped,
 syntax-aware search, and the strict guard trades occasional extra targeted
 reads for protection against edits anchored on unseen source lines.
 
+### Why these two v17 defaults are overridden
+
+The overrides are deliberate but revisitable:
+
+- **`astGrep.enabled: true`** — upstream changed the default in
+  [e4bbe34](https://github.com/can1357/oh-my-pi/commit/e4bbe34f6118667245694289c1eb2eff557b9b70)
+  without recording a rationale. One known cost is that broad native AST
+  searches currently materialize every match before paging
+  ([upstream #3932](https://github.com/can1357/oh-my-pi/issues/3932)).
+  Repository policy already mitigates that cost by requiring narrow paths and
+  prohibiting broad repository-root AST scans. Within those bounds, structural
+  matching is safer than text substitution and remains worth exposing. Revisit
+  this override if scoped searches show material resource cost or OMP replaces
+  the tool with a bounded implementation.
+- **`edit.enforceSeenLines: true`** — upstream made the guard opt-in in
+  [d50cc4](https://github.com/can1357/oh-my-pi/commit/d50cc4e2d3b62e597f7dc9cf05f4f90fd2dcfedd)
+  after real false rejections and extra read/retry round trips, including
+  [upstream #4224](https://github.com/can1357/oh-my-pi/issues/4224) and
+  [upstream #2773](https://github.com/can1357/oh-my-pi/issues/2773). These
+  dotfiles accept that friction because rejecting an edit anchored inside
+  elided or unread source is safer than validating only the snapshot hash. This
+  repository has also lost invisible Nerd Font literals when a source line was
+  reconstructed instead of byte-preserved. Revisit the override if upstream
+  eliminates the false-rejection paths or a replacement provides equivalent
+  unseen-source protection with fewer round trips.
+
 ## Invocation examples, with surface made explicit
 
 ```console

--- a/scripts/docs-drift-guard.sh
+++ b/scripts/docs-drift-guard.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # Guard the docs-only CI fast path invariant (#169): a change confined to
-# docs/** and README.md must not alter any Nix derivation other than the
-# intentional whole-tree lints (docs-links, production-facts), which scan
-# documentation on purpose and are built directly by the fast path. Any
-# other drift means skipping the platform matrix would silently skip real
-# verification, so the guard fails and ci-gate blocks the merge.
+# README.md or docs/** outside the versioned docs/omp/** wiki must not alter
+# any Nix derivation other than the intentional whole-tree lints (docs-links,
+# production-facts), which scan documentation on purpose and are built directly
+# by the fast path. docs/omp/** is an intentional derivation input and the path
+# classifier sends it through the full matrix instead.
 #
 # The check is evaluation-only: it instantiates every flake check on every
 # CI platform (drvPath, no builds) at the base and head revisions and
@@ -48,10 +48,10 @@ compare() {
   if [ -n "$drift" ]; then
     echo "docs drift guard: documentation changes altered non-docs derivations:" >&2
     while IFS= read -r entry; do echo "  $entry" >&2; done <<< "$drift"
-    echo "A docs/** or README.md path has become a derivation input; either" >&2
-    echo "move it out of the inert set in .github/workflows/nix.yml (classify" >&2
-    echo "job) or, for a new intentional whole-tree lint, add it to this" >&2
-    echo "script's exclusions and build it in the docs fast path." >&2
+    echo "An inert docs path has become a derivation input; either move it out" >&2
+    echo "of the inert set in .github/workflows/nix.yml (classify job) or, for" >&2
+    echo "a new intentional whole-tree lint, add it to this script's exclusions" >&2
+    echo "and build it in the docs fast path." >&2
     return 1
   fi
   echo "docs drift guard: no derivation drift outside the intentional whole-tree lints"


### PR DESCRIPTION
## What

Record why these dotfiles deliberately override two OMP v17 defaults:

- keep `astGrep.enabled` on despite the known broad-search allocation cost, because repository policy requires scoped structural search
- keep `edit.enforceSeenLines` on despite documented false rejections and extra reads, because unseen-source edit protection is the preferred tradeoff here

The notes link the upstream commits and issues and state concrete conditions for revisiting each decision.

## Verification

- `nix build .#checks.x86_64-linux.docs-links`