### PR TITLE
fix(code): harden auth vault identities

### DIFF
--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -85,6 +85,7 @@ let
                 default = { };
               };
               xdg.stateHome = lib.mkOption { type = lib.types.str; };
+              xdg.configHome = lib.mkOption { type = lib.types.str; };
               xdg.cacheHome = lib.mkOption { type = lib.types.str; };
               xdg.configFile = lib.mkOption {
                 type = lib.types.attrsOf lib.types.anything;
@@ -105,6 +106,7 @@ let
             };
 
             config = {
+              xdg.configHome = "/tmp/check-agent-auth-vaults/xdg-config";
               xdg.stateHome = "/tmp/check-agent-auth-vaults/xdg-state";
               xdg.cacheHome = "/tmp/check-agent-auth-vaults/xdg-cache";
               atyrode.agentTools = {
@@ -138,11 +140,9 @@ let
       };
     }
   );
-  authVaultManifest = pkgs.writeText "code-auth-vaults.json" (
-    linuxAgentTools.xdg.configFile."atyrode/code-auth-vaults.json".text
-  );
-  linuxBrokerServices = linuxAgentTools.systemd.user.services;
-  darwinBrokerAgents = darwinAgentTools.launchd.agents;
+  linuxBrokerSupervisor =
+    linuxAgentTools.systemd.user.services.atyrode-omp-auth-brokers.Service.ExecStart;
+  darwinBrokerAgent = darwinAgentTools.launchd.agents.atyrode-omp-auth-brokers;
 in
 {
   auth-vaults =
@@ -151,62 +151,54 @@ in
         nativeBuildInputs = [ pkgs.jq ];
       }
       ''
-        manifest=${authVaultManifest}
-        jq -e '
-          length == 3
-          and map(.id) == ["mine", "mum", "victor"]
-          and map(.profile) == ["default", "mum", "victor"]
-          and map(.label) == ["mine", "mum", "victor"]
-          and map(.claude) == ["Alex", "Mum", "Victor + Alex"]
-          and all(.codex == "Alex")
-          and (map(.brokerUrl) | unique | length) == 3
-          and all(.brokerUrl | test("^http://127[.]0[.]0[.]1:[0-9]+$"))
-          and all(.tokenFile | startswith("/tmp/check-agent-auth-vaults/xdg-state/atyrode/code-auth-vaults/"))
-          and all(.snapshotCache | startswith("/tmp/check-agent-auth-vaults/xdg-cache/atyrode/code-auth-vaults/"))
-          and (map(.snapshotCache) | unique | length) == 3
-          and all((keys | sort) == [
-            "brokerUrl", "claude", "codex", "id", "label", "profile",
-            "snapshotCache", "tokenFile"
-          ])
-          and all(has("token") | not)
-        ' "$manifest" >/dev/null
-
-        mine_linux=${lib.escapeShellArg linuxBrokerServices.atyrode-omp-auth-broker-mine.Service.ExecStart}
-        mum_linux=${lib.escapeShellArg linuxBrokerServices.atyrode-omp-auth-broker-mum.Service.ExecStart}
-        victor_linux=${lib.escapeShellArg linuxBrokerServices.atyrode-omp-auth-broker-victor.Service.ExecStart}
-        test ${lib.escapeShellArg (toString darwinBrokerAgents.atyrode-omp-auth-broker-mine.enable)} = 1
-        test ${lib.escapeShellArg (toString darwinBrokerAgents.atyrode-omp-auth-broker-mum.enable)} = 1
-        test ${lib.escapeShellArg (toString darwinBrokerAgents.atyrode-omp-auth-broker-victor.enable)} = 1
-        test ${lib.escapeShellArg (builtins.head darwinBrokerAgents.atyrode-omp-auth-broker-mine.config.ProgramArguments)} = "$mine_linux"
-        test ${lib.escapeShellArg (builtins.head darwinBrokerAgents.atyrode-omp-auth-broker-mum.config.ProgramArguments)} = "$mum_linux"
-        test ${lib.escapeShellArg (builtins.head darwinBrokerAgents.atyrode-omp-auth-broker-victor.config.ProgramArguments)} = "$victor_linux"
-
-        grep -Fq -- '--profile default auth-broker token' "$mine_linux"
-        grep -Fq -- '--profile mum auth-broker token' "$mum_linux"
-        grep -Fq -- '--profile victor auth-broker token' "$victor_linux"
-        grep -Fq -- '--profile default auth-broker serve --bind=127.0.0.1:46171' "$mine_linux"
-        grep -Fq -- '--profile mum auth-broker serve --bind=127.0.0.1:46172' "$mum_linux"
-        grep -Fq -- '--profile victor auth-broker serve --bind=127.0.0.1:46173' "$victor_linux"
-        grep -Fq 'chmod 0600 "$token_tmp"' "$mine_linux"
-        grep -Fq 'mv -f "$token_tmp"' "$mine_linux"
+        supervisor=${lib.escapeShellArg linuxBrokerSupervisor}
+        test ${lib.escapeShellArg (toString darwinBrokerAgent.enable)} = 1
+        test ${lib.escapeShellArg (builtins.head darwinBrokerAgent.config.ProgramArguments)} = "$supervisor"
+        grep -Fq 'code-auth-vaults.json' "$supervisor"
+        grep -Fq 'chmod 0600 "$token_tmp"' "$supervisor"
+        grep -Fq 'auth-broker serve --bind="$bind"' "$supervisor"
 
         rm -rf /tmp/check-agent-auth-vaults
-        # The stub makes token acquisition observable without introducing a
-        # credential: the wrapper persists its output, then starts the server.
-        "$mine_linux" > "$TMPDIR/mine-serve.out"
-        token=/tmp/check-agent-auth-vaults/xdg-state/atyrode/code-auth-vaults/mine/token
-        test "$(stat -c %a "$token")" = 600
-        grep -Fxq -- '--profile' "$token"
-        grep -Fxq default "$token"
-        grep -Fq 'auth-broker' "$token"
-        grep -Fq 'token' "$token"
-        grep -Fq -- '--profile' "$TMPDIR/mine-serve.out"
-        grep -Fq 'serve' "$TMPDIR/mine-serve.out"
-        grep -Fq -- '--bind=127.0.0.1:46171' "$TMPDIR/mine-serve.out"
+        mkdir -p /tmp/check-agent-auth-vaults/xdg-config/atyrode
+        cat > /tmp/check-agent-auth-vaults/xdg-config/atyrode/code-auth-vaults.json <<'JSON'
+        [
+          {
+            "id": "primary",
+            "label": "primary",
+            "profile": "default",
+            "claude": "Operator",
+            "codex": "Operator",
+            "brokerUrl": "http://127.0.0.1:47101",
+            "tokenFile": "/tmp/check-agent-auth-vaults/state/primary/token",
+            "snapshotCache": "/tmp/check-agent-auth-vaults/cache/primary.json"
+          },
+          {
+            "id": "secondary",
+            "label": "secondary",
+            "profile": "team",
+            "claude": "Collaborator",
+            "codex": "Operator",
+            "brokerUrl": "http://127.0.0.1:47102",
+            "tokenFile": "/tmp/check-agent-auth-vaults/state/secondary/token",
+            "snapshotCache": "/tmp/check-agent-auth-vaults/cache/secondary.json"
+          }
+        ]
+        JSON
+        chmod 0600 /tmp/check-agent-auth-vaults/xdg-config/atyrode/code-auth-vaults.json
+
+        "$supervisor" > "$TMPDIR/broker-serve.out"
+
+        primary=/tmp/check-agent-auth-vaults/state/primary/token
+        secondary=/tmp/check-agent-auth-vaults/state/secondary/token
+        test "$(stat -c %a "$primary")" = 600
+        test "$(stat -c %a "$secondary")" = 600
+        grep -Fxq default "$primary"
+        grep -Fxq team "$secondary"
+        grep -Fq 'auth-broker' "$primary"
+        grep -Fq 'token' "$secondary"
 
         touch "$out"
       '';
-
   omp-stack =
     pkgs.runCommand "check-omp-stack"
       {
@@ -278,7 +270,7 @@ in
           ${pkgs.omp-configured}/bin/code
         grep -Fq 'export CODE_OMP_RAW="$omp_bin"' ${pkgs.omp-configured}/bin/code
         grep -Fq -- '--profile default usage --json' ${pkgs.omp-configured}/bin/code
-        grep -Fq 'code-auth-vaults.json' ${pkgs.omp-configured}/bin/code
+        ! grep -Fq 'CODE_AUTH_VAULTS=' ${pkgs.omp-configured}/bin/code
         ! grep -Fq 'CODE_AUTH_PROFILES' ${pkgs.omp-configured}/bin/code
         ! grep -Fq 'code-auth-profiles.json' ${pkgs.omp-configured}/bin/code
         test ! -e ${pkgs.omp-configured}/bin/pi
@@ -692,16 +684,16 @@ in
             unset OMP_PROFILE PI_CODING_AGENT_DIR PI_CONFIG_DIR
             # A resume hint emitted by a profiled session is usable verbatim.
             resume_id=019f6386-bbf6-7000-8e5c-8d88e87e3907
-            mkdir -p "$HOME/.omp/profiles/mum/agent/sessions/-dotfiles"
-            touch "$HOME/.omp/profiles/mum/agent/sessions/-dotfiles/2026-07-15T02-06-42-166Z_$resume_id.jsonl"
+            mkdir -p "$HOME/.omp/profiles/alternate/agent/sessions/-dotfiles"
+            touch "$HOME/.omp/profiles/alternate/agent/sessions/-dotfiles/2026-07-15T02-06-42-166Z_$resume_id.jsonl"
             ${configuredStub}/bin/omp --resume "''${resume_id:0:12}" > "$TMPDIR/actual"
-            printf '%s\n' --profile mum --resume "''${resume_id:0:12}" > "$TMPDIR/expected"
+            printf '%s\n' --profile alternate --resume "''${resume_id:0:12}" > "$TMPDIR/expected"
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
             # Explicit state selection always wins, even when another profile
             # contains the same resume target.
-            ${configuredStub}/bin/omp --profile mine --resume "$resume_id" > "$TMPDIR/actual"
-            printf '%s\n' --profile mine --resume "$resume_id" > "$TMPDIR/expected"
+            ${configuredStub}/bin/omp --profile explicit --resume "$resume_id" > "$TMPDIR/actual"
+            printf '%s\n' --profile explicit --resume "$resume_id" > "$TMPDIR/expected"
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
             default_id=029f6386-bbf6-7000-8e5c-8d88e87e3907
@@ -711,8 +703,8 @@ in
             printf '%s\n' "--resume=$default_id" > "$TMPDIR/expected"
             diff -u "$TMPDIR/expected" "$TMPDIR/actual"
 
-            mkdir -p "$HOME/.omp/profiles/mine/agent/sessions/-dotfiles"
-            touch "$HOME/.omp/profiles/mine/agent/sessions/-dotfiles/2026-07-15T04-00-00-000Z_$resume_id.jsonl"
+            mkdir -p "$HOME/.omp/profiles/candidate/agent/sessions/-dotfiles"
+            touch "$HOME/.omp/profiles/candidate/agent/sessions/-dotfiles/2026-07-15T04-00-00-000Z_$resume_id.jsonl"
             set +e
             ${configuredStub}/bin/omp -r"''${resume_id:0:12}" \
               > "$TMPDIR/ambiguous.out" 2> "$TMPDIR/ambiguous.err"

--- a/checks/agent-tools.nix
+++ b/checks/agent-tools.nix
@@ -24,6 +24,11 @@ let
             mkdir -p "$out/bin" "$out/share/zsh/site-functions"
             cat > "$out/bin/omp" <<'EOF'
         #!${pkgs.runtimeShell}
+        if [[ " $* " == *" auth-broker serve "* ]]; then
+          printf '%s\n' "$2" >> "''${BROKER_STUB_LOG:?}"
+          trap 'exit 0' INT TERM
+          while true; do sleep 1; done
+        fi
         printf '%s\n' "$@"
         EOF
             chmod +x "$out/bin/omp"
@@ -155,8 +160,9 @@ in
         test ${lib.escapeShellArg (toString darwinBrokerAgent.enable)} = 1
         test ${lib.escapeShellArg (builtins.head darwinBrokerAgent.config.ProgramArguments)} = "$supervisor"
         grep -Fq 'code-auth-vaults.json' "$supervisor"
-        grep -Fq 'chmod 0600 "$token_tmp"' "$supervisor"
+        grep -Fq '"$chmod" 0600 "$token_tmp"' "$supervisor"
         grep -Fq 'auth-broker serve --bind="$bind"' "$supervisor"
+        grep -Fq 'invalid OMP auth vault manifest; keeping current brokers' "$supervisor"
 
         rm -rf /tmp/check-agent-auth-vaults
         mkdir -p /tmp/check-agent-auth-vaults/xdg-config/atyrode
@@ -186,14 +192,61 @@ in
         JSON
         chmod 0600 /tmp/check-agent-auth-vaults/xdg-config/atyrode/code-auth-vaults.json
 
-        "$supervisor" > "$TMPDIR/broker-serve.out"
+        export BROKER_STUB_LOG="$TMPDIR/broker-starts"
+        : > "$BROKER_STUB_LOG"
+        "$supervisor" > "$TMPDIR/broker-serve.out" 2> "$TMPDIR/broker-serve.err" &
+        supervisor_pid=$!
+        trap 'kill "$supervisor_pid" 2>/dev/null || true' EXIT
+
+        for _ in $(seq 1 50); do
+          test "$(wc -l < "$BROKER_STUB_LOG")" -ge 2 && break
+          sleep 0.1
+        done
+        test "$(wc -l < "$BROKER_STUB_LOG")" = 2
+
+        manifest=/tmp/check-agent-auth-vaults/xdg-config/atyrode/code-auth-vaults.json
+        cp "$manifest" "$TMPDIR/valid-manifest.json"
+        jq '.[0].brokerUrl = "http://not-loopback:1"' "$manifest" > "$TMPDIR/invalid.json"
+        mv "$TMPDIR/invalid.json" "$manifest"
+        sleep 3
+        kill -0 "$supervisor_pid"
+        test "$(wc -l < "$BROKER_STUB_LOG")" = 2
+        grep -Fq 'keeping current brokers' "$TMPDIR/broker-serve.err"
+
+        cp "$TMPDIR/valid-manifest.json" "$TMPDIR/reverted.json"
+        mv "$TMPDIR/reverted.json" "$manifest"
+        sleep 3
+        kill -0 "$supervisor_pid"
+        test "$(wc -l < "$BROKER_STUB_LOG")" = 2
+
+        jq '.[0].label = "renamed" | . + [{
+          id: "third",
+          label: "third",
+          profile: "third",
+          brokerUrl: "http://127.0.0.1:47103",
+          tokenFile: "/tmp/check-agent-auth-vaults/state/third/token",
+          snapshotCache: "/tmp/check-agent-auth-vaults/cache/third.json"
+        }]' "$TMPDIR/valid-manifest.json" > "$TMPDIR/reloaded.json"
+        mv "$TMPDIR/reloaded.json" "$manifest"
+        for _ in $(seq 1 70); do
+          test "$(wc -l < "$BROKER_STUB_LOG")" -ge 5 && break
+          sleep 0.1
+        done
+        test "$(wc -l < "$BROKER_STUB_LOG")" = 5
+
+        kill "$supervisor_pid"
+        wait "$supervisor_pid"
+        trap - EXIT
 
         primary=/tmp/check-agent-auth-vaults/state/primary/token
         secondary=/tmp/check-agent-auth-vaults/state/secondary/token
+        third=/tmp/check-agent-auth-vaults/state/third/token
         test "$(stat -c %a "$primary")" = 600
         test "$(stat -c %a "$secondary")" = 600
+        test "$(stat -c %a "$third")" = 600
         grep -Fxq default "$primary"
         grep -Fxq team "$secondary"
+        grep -Fxq third "$third"
         grep -Fq 'auth-broker' "$primary"
         grep -Fq 'token' "$secondary"
 

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -135,6 +135,14 @@ enables or disables the highlighted vault, **Enter** selects it, and **`r`**
 refreshes all summaries. The first manifest entry is the non-disableable
 fallback. Selection and disabled state persist under the XDG state directory.
 
+At startup, `code` fills a per-vault usage cache in the background. Cycling or
+selecting a vault restores its own snapshot, refresh deadline, stale warning,
+and in-flight indicator immediately instead of issuing another request. The
+active vault refreshes when its five-minute deadline expires; **`r`** remains
+the explicit whole-manager refresh. Cached data stays visible while refreshing.
+When a retained Fable value is older than the latest response, its label reports
+relative age (for example, `cached 4m ago`) rather than a wall-clock timestamp.
+
 Vault definitions are machine-local, not repository data. Put a mode-0600 JSON
 array at `$XDG_CONFIG_HOME/atyrode/code-auth-vaults.json`; each entry supplies a
 display label, stable id and backing OMP profile, loopback broker URL, token
@@ -157,6 +165,16 @@ Only when Fable is absent, `code` performs a provider-scoped, read-only usage
 query against that vault's backing profile with ambient broker routing removed,
 then appends only the missing Fable limit. Broker identities, Codex usage, and
 all other limits remain authoritative.
+
+Fable is different from the shared 5-hour and 7-day windows: OMP learns that
+model-family limit from rate-limit headers observed during Claude requests.
+With trusted launches consolidated onto shared client profile `default`, a
+broker vault's backing profile can retain the correct credential identity while
+no longer receiving new header observations. In that state live OMP and broker
+reports for that backing profile legitimately contain only 5-hour/7-day data;
+`code` must show Fable unavailable rather than invent a current value. Historical
+records remain evidence that the account previously exposed the window, not a
+safe source for a live quota.
 
 Each backing OMP profile isolates provider credentials. Every trusted `code`
 launch still forces shared client profile `default`; sessions, resume history,

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -121,34 +121,41 @@ scaled by thinking level — above the `omp usage` panel (per-window `N% used`
 with green→red gradient bars, `free` on an idle bucket and `tight` at ≥80%).
 
 The usage widget names the active authentication vault. Press **`a`** to cycle
-enabled vaults. Press **`v`** for the full-screen vault manager: every configured
-vault gets a compact Claude/Codex usage summary, and **Space** enables or disables
-the highlighted vault, **Enter** selects it, **`r`** refreshes all summaries,
-**`c`** starts an Anthropic login, and **`o`** starts an OpenAI Codex login.
-`mine` is the non-disableable fallback. The selection and disabled set persist
-under the XDG state directory.
+enabled vaults. Press **`v`** for the full-screen vault manager. Each provider
+row keeps its configured owner, broker-reported account identity, and usage
+together, so mixed-owner pools remain explicit. **Space** enables or disables
+the highlighted vault, **Enter** selects it, and **`r`** refreshes all summaries.
+The first manifest entry is the non-disableable fallback. Selection and disabled
+state persist under the XDG state directory.
 
-The managed hosts declare three credential pools:
+Vault definitions are machine-local, not repository data. Put a mode-0600 JSON
+array at `$XDG_CONFIG_HOME/atyrode/code-auth-vaults.json`; each entry supplies
+the display id/label, provider owner labels, backing OMP profile, loopback broker
+URL, token file, and snapshot cache. The generic Home Manager service validates
+that file and starts one broker process per entry. Restart
+`atyrode-omp-auth-brokers` after changing it.
 
-- `mine`: Claude Alex + Codex Alex, backed by OMP profile `default`;
-- `mum`: Claude Mum + Codex Alex, backed by OMP profile `mum`;
-- `victor`: Claude Victor + Alex + Codex Alex, backed by OMP profile `victor`.
+Each backing OMP profile isolates provider credentials. Every trusted `code`
+launch still forces shared client profile `default`; sessions, resume history,
+settings, generated configuration, memory, and ordinary caches therefore do
+not split when the vault changes. The selected vault supplies only
+`OMP_AUTH_BROKER_*`. The `u` sandbox remains on its fixed,
+credential-sanitized `untrusted` profile.
 
-Each profile only backs a loopback OMP auth-broker service and its credentials.
-Every trusted `code` launch and usage request still forces the shared OMP client
-profile `default`; sessions, resume history, settings, generated configuration,
-memory, and ordinary caches therefore no longer split when the vault changes.
-The selected vault supplies only `OMP_AUTH_BROKER_*`. The `u` sandbox remains on
-its fixed, credential-sanitized `untrusted` profile.
+Broker bearer tokens stay in mutable mode-0600 files outside the Nix store.
+The manager reads the broker's redacted snapshot to show which accounts are
+actually authenticated; it never reads or mutates OMP's credential database.
+Press **`c`** or **`o`** to authenticate the highlighted vault's configured
+Claude or Codex owner. The footer names both the owner label and backing profile
+before the browser handoff starts. Cancelling a handoff is non-fatal, and a
+second handoff cannot be queued while one is active.
 
-Home Manager starts all three broker services and writes their bearer tokens as
-mutable mode-0600 files outside the Nix store. Existing credentials in the
-`default` and `mum` profile stores are immediately reusable after activation.
-To add Victor's first account, open **`v`**, highlight `victor`, press **`c`**,
-and finish the Anthropic flow. Repeat **`c`** to add another Anthropic identity
-to that vault, or press **`o`** to add its Codex identity. Runtime creation of a
-fourth vault is intentionally unsupported because each broker endpoint and
-service is declared by Home Manager.
+Managed vault usage comes directly from the broker's read-only aggregate usage
+endpoint, so an unrelated provider record cannot invalidate the display.
+Anthropic's Fable row is always reserved in the loading skeleton. If a refresh
+omits Fable, the last real value remains visible with its cache timestamp; when
+no value has ever been observed, the row shows `unavailable` in the same status
+column as `idle`, `tight`, and `maxed`.
 
 There are three ways to leave the TUI — every trusted launch goes through
 `omp-managed`; plain `omp` is reached by typing `omp` directly, never via

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -127,6 +127,9 @@ Usage panel shown by the generator, including provider-only headings,
 broker-reported account lists, and Codex-before-Claude ordering. Arrow keys
 retarget that detail without selecting the vault. The generator's **`s`** Usage
 visibility state transfers into the manager, where **`s`** toggles it too.
+If restoring Usage would make the current composition too small, **`s`** opens
+Usage full-screen immediately; closing it restores the exact prior Generator
+and Routing composition rather than exposing a different panel.
 Configured aliases are never presented as authenticated accounts. **Space**
 enables or disables the highlighted vault, **Enter** selects it, and **`r`**
 refreshes all summaries. The first manifest entry is the non-disableable
@@ -147,6 +150,13 @@ broker process per entry. It watches atomic content changes and automatically
 reconciles all children after a valid edit; an invalid replacement leaves the
 current brokers running. No Home Manager apply or manual service restart is
 needed.
+
+Usage and identity normally remain broker-sourced. OMP v17's broker aggregate
+can omit the Anthropic Fable limit even when that same vault profile returns it.
+Only when Fable is absent, `code` performs a provider-scoped, read-only usage
+query against that vault's backing profile with ambient broker routing removed,
+then appends only the missing Fable limit. Broker identities, Codex usage, and
+all other limits remain authoritative.
 
 Each backing OMP profile isolates provider credentials. Every trusted `code`
 launch still forces shared client profile `default`; sessions, resume history,

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -121,19 +121,32 @@ scaled by thinking level — above the `omp usage` panel (per-window `N% used`
 with green→red gradient bars, `free` on an idle bucket and `tight` at ≥80%).
 
 The usage widget names the active authentication vault. Press **`a`** to cycle
-enabled vaults. Press **`v`** for the full-screen vault manager. Each provider
-row keeps its configured owner, broker-reported account identity, and usage
-together, so mixed-owner pools remain explicit. **Space** enables or disables
-the highlighted vault, **Enter** selects it, and **`r`** refreshes all summaries.
-The first manifest entry is the non-disableable fallback. Selection and disabled
-state persist under the XDG state directory.
+enabled vaults. Press **`v`** for the full-screen vault manager. Its compact
+vault rows never duplicate quota data: the highlighted row drives the same full
+Usage panel shown by the generator, including provider-only headings,
+broker-reported account lists, and Codex-before-Claude ordering. Arrow keys
+retarget that detail without selecting the vault. The generator's **`s`** Usage
+visibility state transfers into the manager, where **`s`** toggles it too.
+Configured aliases are never presented as authenticated accounts. **Space**
+enables or disables the highlighted vault, **Enter** selects it, and **`r`**
+refreshes all summaries. The first manifest entry is the non-disableable
+fallback. Selection and disabled state persist under the XDG state directory.
 
 Vault definitions are machine-local, not repository data. Put a mode-0600 JSON
-array at `$XDG_CONFIG_HOME/atyrode/code-auth-vaults.json`; each entry supplies
-the display id/label, provider owner labels, backing OMP profile, loopback broker
-URL, token file, and snapshot cache. The generic Home Manager service validates
-that file and starts one broker process per entry. Restart
-`atyrode-omp-auth-brokers` after changing it.
+array at `$XDG_CONFIG_HOME/atyrode/code-auth-vaults.json`; each entry supplies a
+display label, stable id and backing OMP profile, loopback broker URL, token
+file, and snapshot cache. In the manager, **`n`** creates an empty vault and
+**`e`** changes only the highlighted vault's display label. Enter commits the
+text prompt and Escape cancels it. Creation derives a collision-safe id/profile,
+unused loopback port, and XDG state/cache paths; it never creates or reads
+credentials. A `CODE_AUTH_VAULTS` raw JSON override is intentionally read-only
+because it has no safe machine-local persistence target.
+
+The generic Home Manager supervisor validates the manifest and starts one
+broker process per entry. It watches atomic content changes and automatically
+reconciles all children after a valid edit; an invalid replacement leaves the
+current brokers running. No Home Manager apply or manual service restart is
+needed.
 
 Each backing OMP profile isolates provider credentials. Every trusted `code`
 launch still forces shared client profile `default`; sessions, resume history,
@@ -145,9 +158,9 @@ credential-sanitized `untrusted` profile.
 Broker bearer tokens stay in mutable mode-0600 files outside the Nix store.
 The manager reads the broker's redacted snapshot to show which accounts are
 actually authenticated; it never reads or mutates OMP's credential database.
-Press **`c`** or **`o`** to authenticate the highlighted vault's configured
-Claude or Codex owner. The footer names both the owner label and backing profile
-before the browser handoff starts. Cancelling a handoff is non-fatal, and a
+Press **`c`** or **`o`** to authenticate the highlighted vault with Claude or
+Codex. The footer names the provider and immutable backing profile before the
+browser handoff starts. Cancelling a handoff is non-fatal, and a
 second handoff cannot be queued while one is active.
 
 Managed vault usage comes directly from the broker's read-only aggregate usage

--- a/docs/omp/README.md
+++ b/docs/omp/README.md
@@ -17,7 +17,7 @@ repository launchers are not interchangeable:
 | Invoke | Authentication and state | Configuration and policy |
 | --- | --- | --- |
 | `omp` | The selected OMP `--profile`, or OMP's default state root | Plain, mutable upstream configuration under `~/.omp`; no repository-managed policy is injected |
-| `code` | The selected auth-broker vault (`mine`, `mum`, or `victor`) supplies credentials while every trusted launch shares client profile `default`; `a` cycles enabled vaults and `v` manages them | Always launches through the managed layers: Enter runs the generated routing profile (including its task-agent model overrides), `m` runs the managed defaults with no overlay. Plain `omp` is never launched via `code` |
+| `code` | The selected machine-local auth-broker vault supplies credentials while every trusted launch shares client profile `default`; `a` cycles enabled vaults and `v` manages them | Always launches through the managed layers: Enter runs the generated routing profile (including its task-agent model overrides), `m` runs the managed defaults with no overlay. Plain `omp` is never launched via `code` |
 | `omp-managed` | The explicit OMP `--profile`, or OMP's default state root | Injects the Nix-owned defaults, platform extensions, and enforced policy; maintenance subcommands bypass overlay injection but remain subject to repository intercepts/guards |
 | `ompu` | Always the fixed `untrusted` profile | Fixed credential-sanitized untrusted sandbox; it never inherits a personal vault selected in `code` |
 

--- a/docs/omp/cli.md
+++ b/docs/omp/cli.md
@@ -54,9 +54,9 @@ non-interactive execution.
 | `--no-title` | Disable session-title generation |
 
 An OMP profile isolates the **entire** state root, not just one provider's OAuth
-record. Authentication in `--profile mine` is independent of authentication in
-`--profile mum`. This is why `code` names complete Claude + Codex combinations
-rather than presenting provider credentials as independently swappable parts.
+record. Authentication in one profile is independent of authentication in
+another. `code` therefore reads machine-local vault definitions that name
+complete Claude + Codex combinations instead of swapping providers implicitly.
 
 ### Tools and extensibility
 
@@ -235,7 +235,7 @@ $ omp-managed --profile work --resume
 # Pick auth in the code TUI, then forward --resume to the chosen launch path
 $ code --resume
 
-# Fixed restricted sandbox; never inherits code's mine/mum selection
+# Fixed restricted sandbox; never inherits code's selected local vault
 $ ompu "inspect this untrusted repository"
 ```
 

--- a/modules/home/agent-tools.nix
+++ b/modules/home/agent-tools.nix
@@ -32,9 +32,9 @@ let
   policyConfig = ../../omp/policy.yml;
   untrustedConfig = ../../omp/untrusted.yml;
 
-  # Vault names, profile bindings, owner labels, ports, and token paths are
-  # machine-local data. The repository ships only a generic supervisor that
-  # validates and launches the entries from this local manifest.
+  # Vault definitions are machine-local. The repository ships only a generic
+  # supervisor that validates the local manifest and reconciles broker children
+  # whenever an atomic manifest replacement changes its content.
   vaultManifest = "${config.xdg.configHome}/atyrode/code-auth-vaults.json";
   rawOmpPackage = cfg.ompPackage.rawOmp or pkgs.omp;
   rawOmp = lib.getExe rawOmpPackage;
@@ -43,25 +43,51 @@ let
     umask 077
 
     manifest=${lib.escapeShellArg vaultManifest}
+    jq=${lib.getExe pkgs.jq}
+    sha256sum=${lib.getExe' pkgs.coreutils "sha256sum"}
+    dirname=${lib.getExe' pkgs.coreutils "dirname"}
+    mkdir=${lib.getExe' pkgs.coreutils "mkdir"}
+    mktemp=${lib.getExe' pkgs.coreutils "mktemp"}
+    chmod=${lib.getExe' pkgs.coreutils "chmod"}
+    mv=${lib.getExe' pkgs.coreutils "mv"}
+
+    validate_manifest() {
+      "$jq" -er '
+        if type != "array" or length == 0 then
+          error("vault manifest must be a non-empty array")
+        elif
+          length != ([.[].id] | unique | length) or
+          length != ([.[].profile] | unique | length) or
+          length != ([.[].brokerUrl] | unique | length) or
+          length != ([.[].tokenFile] | unique | length) or
+          length != ([.[].snapshotCache] | unique | length)
+        then
+          error("vault ids, profiles, broker URLs, and runtime paths must be unique")
+        elif all(.[];
+          (.id | type == "string" and test("^[a-z0-9][a-z0-9._-]{0,63}$") and (endswith(".") | not)) and
+          (.label | type == "string" and length > 0) and
+          (.profile | type == "string" and test("^[A-Za-z0-9._-]+$")) and
+          (.brokerUrl | type == "string" and
+            test("^http://127[.]0[.]0[.]1:[0-9]+$") and
+            (split(":")[-1] | tonumber) >= 1 and
+            (split(":")[-1] | tonumber) <= 65535) and
+          (.tokenFile | type == "string" and startswith("/")) and
+          (.snapshotCache | type == "string" and startswith("/"))
+        ) then
+          .[] | [.id, .profile, .brokerUrl, .tokenFile] | @tsv
+        else
+          error("vault entries contain unsafe or missing runtime fields")
+        end
+      ' "$manifest"
+    }
+
     if [[ ! -r "$manifest" ]]; then
       echo "OMP auth vault manifest not found: $manifest" >&2
       exit 1
     fi
-
-    entries="$(${lib.getExe pkgs.jq} -er '
-      if type != "array" or length == 0 then
-        error("vault manifest must be a non-empty array")
-      elif all(.[];
-        (.id | type == "string" and test("^[a-z0-9][a-z0-9._-]{0,63}$")) and
-        (.profile | type == "string" and test("^[A-Za-z0-9._-]+$")) and
-        (.brokerUrl | type == "string" and test("^http://127[.]0[.]0[.]1:[0-9]+$")) and
-        (.tokenFile | type == "string" and startswith("/"))
-      ) then
-        .[] | [.id, .profile, .brokerUrl, .tokenFile] | @tsv
-      else
-        error("vault entries contain unsafe or missing runtime fields")
-      end
-    ' "$manifest")"
+    entries="$(validate_manifest)"
+    observed_hash="$("$sha256sum" "$manifest")"
+    running_hash="$observed_hash"
 
     pids=()
     cleanup() {
@@ -69,34 +95,56 @@ let
         kill "$pid" 2>/dev/null || true
       done
       wait "''${pids[@]}" 2>/dev/null || true
+      pids=()
     }
-    trap cleanup EXIT INT TERM
+    trap cleanup EXIT
+    trap 'exit 0' INT TERM
 
-    while IFS=$'\t' read -r id profile broker_url token_file; do
-      bind="''${broker_url#http://}"
-      state_dir="$(${lib.getExe' pkgs.coreutils "dirname"} "$token_file")"
-      ${lib.getExe' pkgs.coreutils "mkdir"} -p "$state_dir"
-      token="$(${rawOmp} --profile "$profile" auth-broker token)"
-      if [[ -z "$token" ]]; then
-        echo "omp auth-broker returned an empty token for vault $id" >&2
-        exit 1
-      fi
-      token_tmp="$(${lib.getExe' pkgs.coreutils "mktemp"} "$state_dir/.token.XXXXXX")"
-      printf '%s\n' "$token" > "$token_tmp"
-      ${lib.getExe' pkgs.coreutils "chmod"} 0600 "$token_tmp"
-      ${lib.getExe' pkgs.coreutils "mv"} -f "$token_tmp" "$token_file"
-      ${rawOmp} --profile "$profile" auth-broker serve --bind="$bind" &
-      pids+=("$!")
-    done <<< "$entries"
+    launch_entries() {
+      local next_entries="$1"
+      while IFS=$'\t' read -r id profile broker_url token_file; do
+        bind="''${broker_url#http://}"
+        state_dir="$("$dirname" "$token_file")"
+        "$mkdir" -p -m 0700 "$state_dir"
+        token="$(${rawOmp} --profile "$profile" auth-broker token)"
+        if [[ -z "$token" ]]; then
+          echo "omp auth-broker returned an empty token for vault $id" >&2
+          return 1
+        fi
+        token_tmp="$("$mktemp" "$state_dir/.token.XXXXXX")"
+        printf '%s\n' "$token" > "$token_tmp"
+        "$chmod" 0600 "$token_tmp"
+        "$mv" -f "$token_tmp" "$token_file"
+        ${rawOmp} --profile "$profile" auth-broker serve --bind="$bind" &
+        pids+=("$!")
+      done <<< "$next_entries"
+    }
 
+    launch_entries "$entries"
     while true; do
+      sleep 2
+      if [[ -r "$manifest" ]]; then
+        next_hash="$("$sha256sum" "$manifest")"
+        if [[ "$next_hash" != "$observed_hash" ]]; then
+          observed_hash="$next_hash"
+          if next_entries="$(validate_manifest)"; then
+            if [[ "$next_hash" != "$running_hash" ]]; then
+              cleanup
+              entries="$next_entries"
+              launch_entries "$entries"
+              running_hash="$next_hash"
+            fi
+          else
+            echo "warning: invalid OMP auth vault manifest; keeping current brokers" >&2
+          fi
+        fi
+      fi
       for pid in "''${pids[@]}"; do
         if ! kill -0 "$pid" 2>/dev/null; then
           wait "$pid"
           exit $?
         fi
       done
-      sleep 2
     done
   '';
 

--- a/modules/home/agent-tools.nix
+++ b/modules/home/agent-tools.nix
@@ -32,79 +32,73 @@ let
   policyConfig = ../../omp/policy.yml;
   untrustedConfig = ../../omp/untrusted.yml;
 
-  # Authentication vaults isolate only provider credentials. Trusted clients
-  # continue to use the default OMP profile for sessions, settings, and caches.
-  codeAuthVaultDefinitions = [
-    {
-      id = "mine";
-      label = "mine";
-      profile = "default";
-      claude = "Alex";
-      codex = "Alex";
-      port = 46171;
-    }
-    {
-      id = "mum";
-      label = "mum";
-      profile = "mum";
-      claude = "Mum";
-      codex = "Alex";
-      port = 46172;
-    }
-    {
-      id = "victor";
-      label = "victor";
-      profile = "victor";
-      claude = "Victor + Alex";
-      codex = "Alex";
-      port = 46173;
-    }
-  ];
-  vaultStateRoot = "${config.xdg.stateHome}/atyrode/code-auth-vaults";
-  vaultCacheRoot = "${config.xdg.cacheHome}/atyrode/code-auth-vaults";
+  # Vault names, profile bindings, owner labels, ports, and token paths are
+  # machine-local data. The repository ships only a generic supervisor that
+  # validates and launches the entries from this local manifest.
+  vaultManifest = "${config.xdg.configHome}/atyrode/code-auth-vaults.json";
   rawOmpPackage = cfg.ompPackage.rawOmp or pkgs.omp;
   rawOmp = lib.getExe rawOmpPackage;
-  codeAuthVaults = map (vault: {
-    inherit (vault)
-      id
-      label
-      profile
-      claude
-      codex
-      ;
-    brokerUrl = "http://127.0.0.1:${toString vault.port}";
-    tokenFile = "${vaultStateRoot}/${vault.id}/token";
-    snapshotCache = "${vaultCacheRoot}/${vault.id}/snapshot.json";
-  }) codeAuthVaultDefinitions;
-  brokerScripts = builtins.listToAttrs (
-    map (
-      vault:
-      let
-        stateDir = "${vaultStateRoot}/${vault.id}";
-        tokenFile = "${stateDir}/token";
-      in
-      {
-        name = vault.id;
-        value = pkgs.writeShellScript "omp-auth-broker-${vault.id}" ''
-          set -euo pipefail
-          umask 077
-          ${lib.getExe' pkgs.coreutils "mkdir"} -p ${lib.escapeShellArg stateDir}
-          token="$(${rawOmp} --profile ${lib.escapeShellArg vault.profile} auth-broker token)"
-          if [[ -z "$token" ]]; then
-            echo "omp auth-broker returned an empty token for ${vault.id}" >&2
-            exit 1
-          fi
-          token_tmp="$(${lib.getExe' pkgs.coreutils "mktemp"} ${lib.escapeShellArg "${stateDir}/.token.XXXXXX"})"
-          trap '${lib.getExe' pkgs.coreutils "rm"} -f "$token_tmp"' EXIT
-          printf '%s\n' "$token" > "$token_tmp"
-          ${lib.getExe' pkgs.coreutils "chmod"} 0600 "$token_tmp"
-          ${lib.getExe' pkgs.coreutils "mv"} -f "$token_tmp" ${lib.escapeShellArg tokenFile}
-          trap - EXIT
-          exec ${rawOmp} --profile ${lib.escapeShellArg vault.profile} auth-broker serve --bind=127.0.0.1:${toString vault.port}
-        '';
-      }
-    ) codeAuthVaultDefinitions
-  );
+  brokerSupervisor = pkgs.writeShellScript "omp-auth-brokers" ''
+    set -euo pipefail
+    umask 077
+
+    manifest=${lib.escapeShellArg vaultManifest}
+    if [[ ! -r "$manifest" ]]; then
+      echo "OMP auth vault manifest not found: $manifest" >&2
+      exit 1
+    fi
+
+    entries="$(${lib.getExe pkgs.jq} -er '
+      if type != "array" or length == 0 then
+        error("vault manifest must be a non-empty array")
+      elif all(.[];
+        (.id | type == "string" and test("^[a-z0-9][a-z0-9._-]{0,63}$")) and
+        (.profile | type == "string" and test("^[A-Za-z0-9._-]+$")) and
+        (.brokerUrl | type == "string" and test("^http://127[.]0[.]0[.]1:[0-9]+$")) and
+        (.tokenFile | type == "string" and startswith("/"))
+      ) then
+        .[] | [.id, .profile, .brokerUrl, .tokenFile] | @tsv
+      else
+        error("vault entries contain unsafe or missing runtime fields")
+      end
+    ' "$manifest")"
+
+    pids=()
+    cleanup() {
+      for pid in "''${pids[@]}"; do
+        kill "$pid" 2>/dev/null || true
+      done
+      wait "''${pids[@]}" 2>/dev/null || true
+    }
+    trap cleanup EXIT INT TERM
+
+    while IFS=$'\t' read -r id profile broker_url token_file; do
+      bind="''${broker_url#http://}"
+      state_dir="$(${lib.getExe' pkgs.coreutils "dirname"} "$token_file")"
+      ${lib.getExe' pkgs.coreutils "mkdir"} -p "$state_dir"
+      token="$(${rawOmp} --profile "$profile" auth-broker token)"
+      if [[ -z "$token" ]]; then
+        echo "omp auth-broker returned an empty token for vault $id" >&2
+        exit 1
+      fi
+      token_tmp="$(${lib.getExe' pkgs.coreutils "mktemp"} "$state_dir/.token.XXXXXX")"
+      printf '%s\n' "$token" > "$token_tmp"
+      ${lib.getExe' pkgs.coreutils "chmod"} 0600 "$token_tmp"
+      ${lib.getExe' pkgs.coreutils "mv"} -f "$token_tmp" "$token_file"
+      ${rawOmp} --profile "$profile" auth-broker serve --bind="$bind" &
+      pids+=("$!")
+    done <<< "$entries"
+
+    while true; do
+      for pid in "''${pids[@]}"; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+          wait "$pid"
+          exit $?
+        fi
+      done
+      sleep 2
+    done
+  '';
 
 in
 {
@@ -190,7 +184,6 @@ in
           "omp/defaults.yml".source = defaultsConfig;
           "omp/policy.yml".source = policyConfig;
           "omp/untrusted.yml".source = untrustedConfig;
-          "atyrode/code-auth-vaults.json".text = builtins.toJSON codeAuthVaults;
         };
 
         home.file = {
@@ -243,42 +236,32 @@ in
       }
 
       {
-        systemd.user.services = lib.mkIf pkgs.stdenv.isLinux (
-          builtins.listToAttrs (
-            map (vault: {
-              name = "atyrode-omp-auth-broker-${vault.id}";
-              value = {
-                Unit = {
-                  Description = "OMP authentication broker (${vault.label})";
-                  After = [ "network.target" ];
-                };
-                Service = {
-                  Type = "simple";
-                  ExecStart = "${brokerScripts.${vault.id}}";
-                  Restart = "on-failure";
-                };
-                Install.WantedBy = [ "default.target" ];
-              };
-            }) codeAuthVaultDefinitions
-          )
-        );
+        systemd.user.services = lib.mkIf pkgs.stdenv.isLinux {
+          atyrode-omp-auth-brokers = {
+            Unit = {
+              Description = "Machine-local OMP authentication brokers";
+              After = [ "network.target" ];
+            };
+            Service = {
+              Type = "simple";
+              ExecStart = "${brokerSupervisor}";
+              Restart = "on-failure";
+            };
+            Install.WantedBy = [ "default.target" ];
+          };
+        };
 
-        launchd.agents = lib.mkIf pkgs.stdenv.isDarwin (
-          builtins.listToAttrs (
-            map (vault: {
-              name = "atyrode-omp-auth-broker-${vault.id}";
-              value = {
-                enable = true;
-                config = {
-                  ProgramArguments = [ "${brokerScripts.${vault.id}}" ];
-                  RunAtLoad = true;
-                  KeepAlive = true;
-                  ProcessType = "Background";
-                };
-              };
-            }) codeAuthVaultDefinitions
-          )
-        );
+        launchd.agents = lib.mkIf pkgs.stdenv.isDarwin {
+          atyrode-omp-auth-brokers = {
+            enable = true;
+            config = {
+              ProgramArguments = [ "${brokerSupervisor}" ];
+              RunAtLoad = true;
+              KeepAlive = true;
+              ProcessType = "Background";
+            };
+          };
+        };
       }
 
       (lib.mkIf lcfg.enable {

--- a/pkgs/cli-kit/README.md
+++ b/pkgs/cli-kit/README.md
@@ -9,8 +9,14 @@ Consumed as a local Go module via `replace cli-kit => ../cli-kit`.
 - **Palette & styles** (`palette.go`) — colour tokens (`CAcc`, `CBord`, …), the
   `MeterRamp`, text-presentation glyphs (`GWarn`/`GBroken`/`GReset`), and shared
   lipgloss styles (`StDim`, `StHead`, …).
-- **Layout helpers** (`layout.go`, `meter.go`) — `PadLeft`/`Pad`, `WindowList`
-  (a clipped, scrollbar'd column), `Scrollbar`, meters.
+- **Layout and section helpers** (`layout.go`, `meter.go`) —
+  `PadLeft`/`Pad`, `WindowList` (a clipped, scrollbar'd column), `Scrollbar`,
+  meters, and full-width `Rule`/`SeparatedSections` boundaries. Widths are
+  terminal cells; empty sections produce no orphan rule.
+- **Footer conventions** (`palette.go`, `layout.go`) — `NewHelp` applies the
+  shared key/description/separator palette to Bubble Help, while `WrapHelp`
+  wraps complete required cues without dropping them. Both remain ANSI-aware
+  through lipgloss width measurement.
 - **The smart PromptBox** (`promptbox.go`) + the **consumer contract**
   (`contract.go`, `run.go`) + an **omp backend** (`ompasker.go`).
 

--- a/pkgs/cli-kit/layout.go
+++ b/pkgs/cli-kit/layout.go
@@ -3,6 +3,7 @@ package clikit
 import (
 	"strings"
 
+	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -23,6 +24,66 @@ func Pad(s string, n int) string {
 		s += " "
 	}
 	return s
+}
+
+// Rule renders a full-width section boundary using the shared visual palette.
+func Rule(width int) string {
+	if width < 0 {
+		width = 0
+	}
+	return StDim.Render(strings.Repeat("─", width))
+}
+
+// SeparatedSections stacks every non-empty section behind a full-width Rule.
+// The result always begins with a boundary, so callers can attach it below any
+// independently laid-out body without allowing adjacent sections to run
+// together. Empty sections are omitted along with their boundary.
+func SeparatedSections(width int, sections ...string) string {
+	parts := make([]string, 0, len(sections)*2)
+	for _, section := range sections {
+		if section == "" {
+			continue
+		}
+		parts = append(parts, Rule(width), section)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// HelpItem is one reusable key/description pair in a TUI control footer.
+type HelpItem struct {
+	Key         string
+	Description string
+}
+
+// WrapHelp renders every control using the supplied shared help model and wraps
+// whole cues across rows without dropping any. This complements Bubble Help's
+// intentionally truncating single-line renderer for screens whose controls are
+// all required, such as modal managers.
+func WrapHelp(h help.Model, width int, items []HelpItem) string {
+	cue := func(item HelpItem) string {
+		return h.Styles.ShortKey.Inline(true).Render(item.Key) + " " +
+			h.Styles.ShortDesc.Inline(true).Render(item.Description)
+	}
+	separator := h.Styles.ShortSeparator.Inline(true).Render(h.ShortSeparator)
+	rows := make([]string, 0, len(items))
+	row := ""
+	for _, item := range items {
+		rendered := cue(item)
+		next := rendered
+		if row != "" {
+			next = row + separator + rendered
+		}
+		if row != "" && lipgloss.Width(next) > width {
+			rows = append(rows, row)
+			row = rendered
+		} else {
+			row = next
+		}
+	}
+	if row != "" {
+		rows = append(rows, row)
+	}
+	return strings.Join(rows, "\n")
 }
 
 // WindowList clips a list to h lines, scrolled to keep the cursor visible, fixes

--- a/pkgs/cli-kit/layout_test.go
+++ b/pkgs/cli-kit/layout_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // TestWindowListNeverWraps locks the height contract: a row wider than the
@@ -40,5 +41,52 @@ func TestWindowListStableGeometry(t *testing.T) {
 		if rw := lipgloss.Width(r); rw != 20 {
 			t.Errorf("row %d width = %d, want 20", i, rw)
 		}
+	}
+}
+
+func TestSeparatedSectionsAlwaysBoundsContent(t *testing.T) {
+	out := SeparatedSections(8, "", "usage", "", "controls")
+	rows := strings.Split(out, "\n")
+	if len(rows) != 4 {
+		t.Fatalf("got %d rows, want two boundaries and two sections: %q", len(rows), out)
+	}
+	for _, i := range []int{0, 2} {
+		if lipgloss.Width(rows[i]) != 8 || strings.Trim(ansi.Strip(rows[i]), "─") != "" {
+			t.Errorf("row %d is not an 8-cell section boundary: %q", i, rows[i])
+		}
+	}
+	if rows[1] != "usage" || rows[3] != "controls" {
+		t.Fatalf("section order changed: %q", out)
+	}
+	if got := SeparatedSections(8, "", ""); got != "" {
+		t.Fatalf("empty sections must produce no orphan boundary: %q", got)
+	}
+}
+
+func TestWrapHelpUsesSharedStyleAndWrapsWholeCues(t *testing.T) {
+	h := NewHelp()
+	if h.Styles.ShortKey.GetForeground() != StHead.GetForeground() ||
+		h.Styles.ShortDesc.GetForeground() != StDim.GetForeground() ||
+		h.Styles.ShortSeparator.GetForeground() != StDim.GetForeground() {
+		t.Fatal("shared Help styles diverged from the cli-kit palette")
+	}
+	items := []HelpItem{
+		{Key: "a", Description: "alpha"},
+		{Key: "b", Description: "beta"},
+		{Key: "c", Description: "gamma"},
+	}
+	out := WrapHelp(h, 16, items)
+	for _, row := range strings.Split(out, "\n") {
+		if lipgloss.Width(row) > 16 {
+			t.Errorf("wrapped Help row exceeds 16 cells: %q", row)
+		}
+	}
+	for _, want := range []string{"a alpha", "b beta", "c gamma"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("wrapped Help dropped %q: %q", want, out)
+		}
+	}
+	if got := WrapHelp(h, 16, nil); got != "" {
+		t.Fatalf("empty Help items rendered content: %q", got)
 	}
 }

--- a/pkgs/cli-kit/palette.go
+++ b/pkgs/cli-kit/palette.go
@@ -4,7 +4,10 @@
 // code-tui (its first proven consumer) and grown as new CLIs need more.
 package clikit
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/lipgloss"
+)
 
 // Palette — colour tokens and semantic roles shared across the CLIs.
 const (
@@ -52,3 +55,18 @@ var (
 	StOk     = lipgloss.NewStyle().Foreground(lipgloss.Color(CGreen))
 	StStruck = lipgloss.NewStyle().Strikethrough(true).Faint(true).Foreground(lipgloss.Color(CDim))
 )
+
+// NewHelp returns Bubble Tea's help model with the shared CLI palette applied.
+// Consumers keep their own key maps and layout policies while keys,
+// descriptions, separators, and truncation use one visual language.
+func NewHelp() help.Model {
+	h := help.New()
+	h.Styles.ShortKey = StHead
+	h.Styles.ShortDesc = StDim
+	h.Styles.ShortSeparator = StDim
+	h.Styles.Ellipsis = StDim
+	h.Styles.FullKey = StHead
+	h.Styles.FullDesc = StDim
+	h.Styles.FullSeparator = StDim
+	return h
+}

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -1212,14 +1212,14 @@ func (m model) routingColW() int {
 // ── trackpad / mouse wheel ───────────────────────────────────────────────────
 // The wheel drives the generator directly: vertical scroll moves the facet
 // selection, horizontal scroll changes the selected facet's value. Terminal
-// mouse protocols expose direction-only press events — no magnitude, release,
-// or gesture identity — and different terminals emit different event counts
-// for the same physical motion. Coalesce one leading-edge step per Bubble Tea
-// render quantum: the first event acts immediately, same-direction momentum
-// and diagonal jitter are dropped before Update/View, and an explicit reversal
-// acts immediately. No raw event can extend the window, so scrolling never
-// inherits the old trailing-debounce lockout. Routing remains continuous.
-const wheelQuantum = time.Second / 60
+// mouse protocols expose direction-only press events rather than trackpad
+// distance, so require a small burst before committing one generator step.
+// This gives fine Mac trackpad motion room to settle without making every raw
+// event select a new row or option. Routing remains continuous and ungated.
+const (
+	wheelStepEvents = 5
+	wheelGestureGap = 200 * time.Millisecond
+)
 
 const (
 	wheelAxisNone = iota
@@ -1227,23 +1227,9 @@ const (
 	wheelAxisH
 )
 
-// admittedWheelMsg marks a generator wheel event admitted before Bubble Tea's
-// Update/render cycle and carries the generation of its bounded coalescing
-// window.
-type admittedWheelMsg struct {
-	tea.MouseMsg
-	generation uint64
-}
-
-// wheelWindowDoneMsg closes one render-quantum input window. It is consumed by
-// the pre-dispatch filter, so it does not trigger an otherwise-useless redraw.
-type wheelWindowDoneMsg struct{ generation uint64 }
-
-func wheelWindowCmd(generation uint64) tea.Cmd {
-	return tea.Tick(wheelQuantum, func(time.Time) tea.Msg {
-		return wheelWindowDoneMsg{generation: generation}
-	})
-}
+// admittedWheelMsg marks a generator wheel event whose same-direction burst
+// crossed the step threshold before Bubble Tea's Update/render cycle.
+type admittedWheelMsg struct{ tea.MouseMsg }
 
 // wheelTarget is the layout state the pre-dispatch filter needs. Keeping this
 // interface narrow also lets the raw-input regression test wrap model while
@@ -1254,25 +1240,18 @@ type wheelTarget interface {
 }
 
 // wheelInputFilter removes mouse traffic before Bubble Tea's unconditional
-// redraw-after-Update. Generator momentum is coalesced to one leading-edge step
-// per render quantum; motion, non-wheel presses, routing horizontal wheel, and
-// clamped routing scroll are dropped because none can change the view.
+// redraw-after-Update. Generator motion accumulates by axis and direction;
+// only each complete threshold reaches Update. Motion, non-wheel presses,
+// routing horizontal wheel, and clamped routing scroll are dropped because
+// none can change the view.
 type wheelInputFilter struct {
-	open       bool
-	axis       int
-	button     tea.MouseButton
-	generation uint64
+	axis   int
+	button tea.MouseButton
+	count  int
+	last   time.Time
 }
 
 func (f *wheelInputFilter) Filter(app tea.Model, msg tea.Msg) tea.Msg {
-	if done, ok := msg.(wheelWindowDoneMsg); ok {
-		if done.generation == f.generation {
-			f.open = false
-			f.axis = wheelAxisNone
-			f.button = tea.MouseButtonNone
-		}
-		return nil
-	}
 
 	mouse, ok := msg.(tea.MouseMsg)
 	if !ok {
@@ -1304,18 +1283,24 @@ func (f *wheelInputFilter) Filter(app tea.Model, msg tea.Msg) tea.Msg {
 	default:
 		return nil
 	}
-	if f.open {
-		// A same-axis reversal is new intent, not momentum. Orthogonal input is
-		// diagonal jitter for no longer than this one render quantum.
-		if axis != f.axis || mouse.Button == f.button {
-			return nil
-		}
+	now := time.Now()
+	if f.count > 0 && now.Sub(f.last) <= wheelGestureGap && axis != f.axis {
+		// Ignore brief orthogonal trackpad jitter without discarding progress
+		// along the operator's dominant gesture axis.
+		return nil
 	}
-	f.open = true
-	f.axis = axis
-	f.button = mouse.Button
-	f.generation++
-	return admittedWheelMsg{MouseMsg: mouse, generation: f.generation}
+	if axis != f.axis || mouse.Button != f.button || now.Sub(f.last) > wheelGestureGap {
+		f.axis = axis
+		f.button = mouse.Button
+		f.count = 0
+	}
+	f.last = now
+	f.count++
+	if f.count < wheelStepEvents {
+		return nil
+	}
+	f.count = 0
+	return admittedWheelMsg{MouseMsg: mouse}
 }
 
 type model struct {
@@ -1329,6 +1314,7 @@ type model struct {
 	collapse   bool // p: hide the Routing section
 	showResult bool // in collapsed mode: show the preview full-width
 	hideUsage  bool // s: hide the Usage section (#198); fetch state keeps running unseen
+	showUsage  bool // narrow mode: show Usage full-screen instead of silently shedding it
 
 	facets         []facet
 	fcur           int
@@ -1347,6 +1333,9 @@ type model struct {
 	disabled     map[string]bool         // disabled vault ids (never includes the fallback)
 	vaultState   string                  // CODE_AUTH_STATE path
 	vaultErr     string                  // last vault switch/persist/login error
+	vaultManifest string                  // resolved writable manifest path; empty for raw JSON/read-only
+	managerInput  string                  // "create" or "rename" while manager text entry is active
+	managerText   string                  // pending manager text-entry value
 	vaultUsage   map[string]availability // per-vault usage snapshots for the manager
 	manager      bool                    // v: the full-screen vault manager is open
 	mgrCursor    int                     // manager row cursor
@@ -1542,44 +1531,99 @@ func (m *model) usageCtrlLine() string {
 	return line
 }
 
-// providerHeading names a provider usage group by its effective identity —
-// "Codex (account)" / "Claude (account)", derived from the active auth
-// profile — so mixed profiles (Claude (Collaborator) + Codex (Operator)) read
-// with no prose equation, in text rather than color alone. The parenthesized
-// owner is dimmed so the provider name stays the heading's anchor.
-func providerHeading(prov string, p vault) string {
-	col, name, acct := "#62a7ff", "Codex", p.Codex
+// providerHeading names a provider usage group without deriving identity from
+// configured vault owner labels. Account identity is rendered separately from
+// the broker's redacted snapshot.
+func providerHeading(prov string) string {
+	col, name := "#62a7ff", "Codex"
 	if prov == "anthropic" {
-		col, name, acct = "#ff9f52", "Claude", p.Claude
+		col, name = "#ff9f52", "Claude"
 	}
-	out := lipgloss.NewStyle().Foreground(lipgloss.Color(col)).Bold(true).Render(name)
-	if acct != "" {
-		out += " " + stDim.Render("("+acct+")")
-	}
-	return out
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(col)).Bold(true).Render(name)
 }
 
-// identityLines renders the effective provider/account headings on their own —
-// the loading and error states keep the active identity visible even before
-// any usage rows exist.
+// providerAccountRows renders only identities reported by the broker's
+// redacted snapshot. Email is preferred; the snapshot identity key is used
+// when a connected account has no email. Sorting the copied display values
+// keeps injected, cached, and fetched account sets deterministic without
+// deriving identity from configured owner labels.
+func providerAccountRows(a availability, prov string, checking bool) []string {
+	if checking {
+		return []string{stDim.Render("  checking account…")}
+	}
+	if !a.accountsOK {
+		return []string{stWarn.Render("  account status unavailable")}
+	}
+	accounts := a.accounts[prov]
+	if len(accounts) == 0 {
+		return []string{stBrk.Render("  not authenticated")}
+	}
+	identities := make([]string, 0, len(accounts))
+	unknown := 0
+	for _, account := range accounts {
+		identity := account.Email
+		if identity == "" {
+			identity = account.IdentityKey
+		}
+		if identity == "" {
+			unknown++
+			continue
+		}
+		identities = append(identities, identity)
+	}
+	sort.Strings(identities)
+	rows := make([]string, 0, len(identities)+unknown+1)
+	for _, identity := range identities {
+		rows = append(rows, stDim.Render("  "+identity))
+	}
+	for range unknown {
+		rows = append(rows, stDim.Render("  authenticated · identity unavailable"))
+	}
+	if a.accountsStale {
+		rows = append(rows, stWarn.Render("  identity cached"))
+	}
+	return rows
+}
+
+func providerIdentityBlock(a availability, prov string, checking bool) []string {
+	rows := []string{padLeft(providerHeading(prov), gut)}
+	rows = append(rows, providerAccountRows(a, prov, checking)...)
+	return rows
+}
+
+// identityLines keeps provider and broker-reported account state visible even
+// when no usage rows exist.
 func (m *model) identityLines() string {
-	p := m.activeVault()
-	return padLeft(providerHeading("openai-codex", p), gut) + "\n" +
-		padLeft(providerHeading("anthropic", p), gut)
+	var lines []string
+	for i, prov := range []string{"openai-codex", "anthropic"} {
+		if i > 0 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, providerIdentityBlock(m.avail, prov, false)...)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // usagePanel is the composition-agnostic Usage band sized for the current
 // terminal width — the wide layout's full-width footer form.
 func (m *model) usagePanel() string { return m.usagePanelFor(m.w) }
 
-// usagePanelFor renders the first-class Usage section: the pilled title with
-// its local hide cue, the per-provider usage groups headed by the effective
-// provider/account identity, and the refresh/switch control row at the
-// section's bottom edge — below the content it governs. Provider groups sit
-// side by side only when w seats every column; w <= 0 forces the vertical
-// stack (the medium layout's narrow usage column).
+// usagePanelFor renders the first-class Usage section: the pilled title names
+// the active vault and carries its local hide cue, followed by per-provider
+// account lists and usage groups, then the refresh/switch control row at the
+// section's bottom edge. Provider groups sit side by side only when w seats
+// every column; w <= 0 forces the vertical stack used by medium layouts.
 func (m *model) usagePanelFor(w int) string {
-	title := m.pill("usage") + "  " + stCueKey.Render("s") + stCue.Render(" · hide")
+	v := m.activeVault()
+	vaultName := v.Label
+	if vaultName == "" {
+		vaultName = v.ID
+	}
+	title := m.pill("usage")
+	if vaultName != "" {
+		title += stCue.Render(" · " + vaultName)
+	}
+	title += "  " + stCueKey.Render("s") + stCue.Render(" · hide")
 	if len(m.vaults) > 1 {
 		title += "  " + stCueKey.Render("v") + stCue.Render(" · vaults")
 	}
@@ -1595,10 +1639,9 @@ func (m *model) usagePanelFor(w int) string {
 // and the bottom control row: the identity-headed usage groups, or the
 // loading/unavailable identity block.
 func (m *model) usageBodyFor(w int) string {
-	p := m.activeVault()
 	if !m.avail.ok {
 		if m.usageLoading() {
-			return m.skeletonBody(w, p)
+			return m.skeletonBody(w)
 		}
 		out := m.identityLines()
 		if m.usageCmd != "" && !m.fetching && !m.nextRefresh.IsZero() {
@@ -1640,7 +1683,7 @@ func (m *model) usageBodyFor(w int) string {
 	for _, win := range wins {
 		if _, ok := blocks[win.prov]; !ok {
 			order = append(order, win.prov)
-			blocks[win.prov] = []string{padLeft(providerHeading(win.prov, p), gut)}
+			blocks[win.prov] = providerIdentityBlock(m.avail, win.prov, false)
 		}
 		blocks[win.prov] = append(blocks[win.prov], m.usageRow(win))
 	}
@@ -1657,12 +1700,14 @@ func (m *model) usageBodyFor(w int) string {
 // shared by the real usage body and the loading skeleton so the two agree on
 // geometry and the first fetch never pops the layout. colW must fit the
 // widest row (label · bar · pct · ↻reset · note) without wrapping the note;
-// a long account name widens the column instead of truncating the identity.
+// a long broker-reported email widens the column instead of truncating it.
 func layoutGroups(w int, order []string, blocks map[string][]string) string {
 	colW := 49
 	for _, prov := range order {
-		if hw := lipgloss.Width(blocks[prov][0]) + 2; hw > colW {
-			colW = hw
+		for _, row := range blocks[prov] {
+			if rowW := lipgloss.Width(row) + 2; rowW > colW {
+				colW = rowW
+			}
 		}
 	}
 	if w > 0 && len(order) > 1 && w >= colW*len(order) {
@@ -1704,14 +1749,14 @@ func skeletonRow(label string) string {
 		stDim.Render(" ··%"), stDim.Render(gReset+" ····"))
 }
 
-// skeletonBody is the pre-first-fetch Usage content: the provider/account
-// headings with generic placeholder window rows, laid out by the same group
-// logic as real data so the first result lands without a layout pop.
-func (m *model) skeletonBody(w int, p vault) string {
+// skeletonBody is the pre-first-fetch Usage content: provider headings,
+// explicit checking state, and generic placeholder window rows, laid out by
+// the same group logic as real data so the first result lands predictably.
+func (m *model) skeletonBody(w int) string {
 	order := []string{"openai-codex", "anthropic"}
 	blocks := map[string][]string{}
 	for _, prov := range order {
-		rows := []string{padLeft(providerHeading(prov, p), gut)}
+		rows := providerIdentityBlock(m.avail, prov, true)
 		for _, label := range skeletonWinsByProvider[prov] {
 			rows = append(rows, skeletonRow(label))
 		}
@@ -1937,6 +1982,9 @@ func (m *model) usageInFooter() bool {
 // routingShown reports whether the Routing section (and so its title-local
 // p · hide cue) is on screen in the current composition.
 func (m model) routingShown() bool {
+	if m.showUsage && m.sizeMode() == sizeNarrow {
+		return false
+	}
 	if m.collapse {
 		return false
 	}
@@ -1947,27 +1995,36 @@ func (m model) routingShown() bool {
 }
 
 // usageShown reports whether the Usage panel is rendered anywhere — the
-// wide/collapsed footer band or medium's secondary column. Narrow sheds it
-// regardless of the s toggle.
+// wide/collapsed footer band, medium's secondary column, or narrow's dedicated
+// full-screen view.
 func (m model) usageShown() bool {
 	if m.hideUsage {
 		return false
 	}
+	if m.sizeMode() == sizeNarrow {
+		return m.showUsage
+	}
 	return m.usageInFooter() || m.mode() == modeMedium
 }
 
-// usageCanShow reports whether restoring Usage would actually render it — the
-// compact footer must never advertise a recovery action the narrow layout
-// would immediately shed anyway.
+// usageCanShow reports whether restoring Usage would actually render it.
+// Narrow terminals use a dedicated full-width view when they can seat the
+// stacked Usage column; extremely small terminals still suppress a dead cue.
 func (m model) usageCanShow() bool {
+	if m.sizeMode() == sizeNarrow {
+		return m.w >= m.usageColW()
+	}
 	t := m
 	t.hideUsage = false
 	return t.usageShown()
 }
 
 // generatorShown: the Generator (and its launch footer advertising ⏎/m/u) is
-// visible in every composition except the narrow routing-full-screen swap.
+// visible in every composition except a narrow full-screen secondary view.
 func (m model) generatorShown() bool {
+	if m.sizeMode() == sizeNarrow && m.showUsage {
+		return false
+	}
 	return !(m.mode() == modeCollapsed && !m.collapse && m.showResult)
 }
 
@@ -2003,7 +2060,7 @@ func (m model) contextHelp() helpKeys {
 	if !m.routingShown() {
 		short = append(short, key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "show routing")))
 	}
-	if m.hideUsage && m.usageCanShow() {
+	if !m.usageShown() && m.usageCanShow() {
 		short = append(short, key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "show usage")))
 	}
 	// Keep full-help discovery and quit ahead of optional contextual actions:
@@ -2118,7 +2175,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case admittedWheelMsg:
 		m.applyWheelStep(msg.Button)
-		return m, wheelWindowCmd(msg.generation)
+		return m, nil
 	case tea.MouseMsg:
 		// Wheel dispatch by pointer position: inside the visible Routing pane
 		// the viewport owns vertical scrolling — continuous, ungated, clamped
@@ -2146,6 +2203,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "p":
 			switch {
+			case m.showUsage && m.sizeMode() == sizeNarrow:
+				m.showUsage = false
+				m.showResult = true
+				m.collapse = false
 			case m.collapse:
 				m.collapse = false // restore the hidden preview
 			case m.mode() == modeCollapsed:
@@ -2155,10 +2216,23 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.relayout()
 		case "s":
-			// Usage collapse (#198): a pure display toggle. Fetch state and the
-			// refresh cadence keep running unseen; nothing is refetched on
-			// restore, and the freed rows reallocate to the active composition.
-			m.hideUsage = !m.hideUsage
+			// Narrow terminals give Usage a dedicated full-screen view instead
+			// of treating s as a hidden-state toggle that accidentally reveals
+			// Routing. Wider layouts keep the inline section collapse.
+			if m.sizeMode() == sizeNarrow {
+				if m.showUsage {
+					m.showUsage = false
+					m.hideUsage = true
+				} else {
+					m.showUsage = true
+					m.hideUsage = false
+					m.showResult = false
+					m.collapse = false
+				}
+			} else {
+				m.showUsage = false
+				m.hideUsage = !m.hideUsage
+			}
 			m.relayout()
 		case "?":
 			m.help.ShowAll = !m.help.ShowAll
@@ -2335,8 +2409,16 @@ func (m *model) cycleFacet(dir int) {
 			idx = i
 		}
 	}
-	idx = (idx + dir + len(f.values)) % len(f.values)
-	m.sel[f.key] = f.values[idx]
+	next := idx + dir
+	if next < 0 {
+		next = 0
+	} else if next >= len(f.values) {
+		next = len(f.values) - 1
+	}
+	if next == idx {
+		return
+	}
+	m.sel[f.key] = f.values[next]
 	// main is fable's sub-setting: whenever fable leaves "on" it must clear too,
 	// so a later fable re-enable never silently resurrects the (expensive)
 	// fable-as-main escalation — it is re-chosen deliberately every time.
@@ -2466,9 +2548,12 @@ func (m model) View() string {
 	var content string
 	switch m.mode() {
 	case modeCollapsed:
-		if m.showResult && !m.collapse {
+		switch {
+		case m.showUsage && m.sizeMode() == sizeNarrow:
+			content = padLeft(m.usagePanelFor(m.w-gut), gut)
+		case m.showResult && !m.collapse:
 			content = padLeft(m.previewColumn(), gut)
-		} else {
+		default:
 			content = m.leftColumn(m.w, ch)
 		}
 	case modeMedium:
@@ -2575,7 +2660,7 @@ func main() {
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
 	generated := loadBlocks(os.Getenv("CODE_GENERATED"))
-	vaults := loadVaults(os.Getenv("CODE_AUTH_VAULTS"), os.Getenv("CODE_AUTH_VAULTS_FILE"))
+	vaults, vaultManifest := resolveVaults(os.Getenv("CODE_AUTH_VAULTS"), os.Getenv("CODE_AUTH_VAULTS_FILE"))
 	vaultState := os.Getenv("CODE_AUTH_STATE")
 	selected, disabled := loadVaultState(vaults, vaultState)
 	facets := facetDefs(glyphs)
@@ -2590,6 +2675,7 @@ func main() {
 		selected:       selected,
 		disabled:       disabled,
 		vaultState:     vaultState,
+		vaultManifest:  vaultManifest,
 		vaultUsage:     map[string]availability{},
 		fetching:       os.Getenv("CODE_USAGE") != "",
 		spin:           sp,

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -5,7 +5,8 @@
 //	CODE_GENERATED     : generated.plain (facet-grid blocks, keyed by combo id)
 //	CODE_USAGE         : optional command (space-split) that prints `omp usage --json`
 //	CODE_SELECTION_STATE: optional persisted generator facet choices; empty disables it
-//	CODE_AUTH_VAULTS   : non-secret JSON manifest of selectable auth-broker vaults
+//	CODE_AUTH_VAULTS   : optional JSON override for the machine-local vault manifest
+//	CODE_AUTH_VAULTS_FILE: optional path override for the XDG-local vault manifest
 //	CODE_AUTH_STATE    : persisted {selected,disabled} vault state (0600, mutable)
 //	CODE_OMP           : the omp-managed executable — launches every trusted session
 //	                     on the shared `default` client profile with the selected
@@ -18,6 +19,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -236,14 +238,15 @@ func loadBlocks(path string) map[string][]string {
 
 // ── usage + availability ─────────────────────────────────────────────────────
 type usageWin struct {
-	label   string
-	pct     int
-	tier    string
-	secs    int64 // seconds until reset (relative)
-	dur     int64 // window length in seconds
-	prov    string
-	stale   bool // retained from the last successful fetch after a refresh omitted this window
-	missing bool // never observed: rendered as a deterministic placeholder row
+	label    string
+	pct      int
+	tier     string
+	secs     int64 // seconds until reset (relative)
+	dur      int64 // window length in seconds
+	prov     string
+	stale    bool  // retained from the last successful fetch after a refresh omitted this window
+	missing  bool  // never observed: rendered as a deterministic placeholder row
+	observed int64 // Unix timestamp of the last real value; retained across cache fallback
 }
 
 // resetCredits tracks OpenAI reset credits: how many are currently available
@@ -254,32 +257,48 @@ type resetCredits struct {
 }
 
 type availability struct {
-	bucket  map[string]string // bucket -> "ok" | "maxed" | "unauthed"
-	reset   map[string]int64
-	wins    []usageWin
-	credits resetCredits
-	ok      bool
+	bucket        map[string]string // bucket -> "ok" | "maxed" | "unauthed"
+	reset         map[string]int64
+	wins          []usageWin
+	credits       resetCredits
+	ok            bool
+	accounts      map[string][]vaultAccount
+	accountsOK    bool
+	accountsStale bool
 }
 
-// loadAvailability fetches usage for a vault. It always runs on the shared
-// `default` client profile (stripping any forwarded profile flag) and applies
-// the vault's broker env, loaded fresh from its token file — so the figures
-// reflect the vault's credentials while the client profile stays shared. A
-// missing/unreadable token or a failed command yields an unavailable result.
+// loadAvailability fetches identity and usage for one vault. Managed broker
+// vaults read the broker's redacted snapshot and aggregate usage endpoints
+// directly, avoiding client-side credential-schema failures in unrelated
+// providers. Standalone configurations retain the forwarded CLI fallback.
+// Every path is read-only.
 func loadAvailability(cmd string, v vault) availability {
-	a := availability{bucket: map[string]string{}, reset: map[string]int64{}}
+	a := availability{
+		bucket: map[string]string{}, reset: map[string]int64{},
+		accounts: map[string][]vaultAccount{},
+	}
+	if accounts, err := loadVaultAccounts(v); err == nil {
+		a.accounts, a.accountsOK = accounts, true
+	}
 	if cmd == "" {
 		return a
 	}
-	env, err := brokerEnv(v)
-	if err != nil {
-		return a
+
+	var out []byte
+	var err error
+	if v.BrokerURL != "" && v.TokenFile != "" {
+		out, err = fetchVaultEndpoint(v, "/v1/usage")
+	} else {
+		env, envErr := brokerEnv(v)
+		if envErr != nil {
+			return a
+		}
+		parts := strings.Fields(cmd)
+		args := withOMPProfile("default", parts[1:]...)
+		c := exec.Command(parts[0], args...)
+		c.Env = withBrokerEnv(os.Environ(), env)
+		out, err = c.Output()
 	}
-	parts := strings.Fields(cmd)
-	args := withOMPProfile("default", parts[1:]...)
-	c := exec.Command(parts[0], args...)
-	c.Env = withBrokerEnv(os.Environ(), env)
-	out, err := c.Output()
 	if err != nil || len(out) == 0 {
 		return a
 	}
@@ -319,7 +338,8 @@ func loadAvailability(cmd string, v vault) availability {
 		for _, l := range r.Limits {
 			pct := int(l.Amount.UsedFraction*100 + 0.5)
 			a.wins = append(a.wins, usageWin{label: l.Label, pct: pct, tier: l.Scope.Tier,
-				secs: l.Window.ResetsAt/1000 - now, dur: l.Window.DurationMs / 1000, prov: r.Provider})
+				secs: l.Window.ResetsAt/1000 - now, dur: l.Window.DurationMs / 1000,
+				prov: r.Provider, observed: now})
 			bkt := bucketForProviderTier(r.Provider, l.Scope.Tier)
 			if bkt == "" {
 				continue
@@ -400,8 +420,13 @@ func (a availability) down(bucket string) bool {
 // Fresh values always win; nothing is fabricated — retained rows are visibly
 // marked stale and placeholders carry no numbers.
 func reconcileUsage(prev, next availability) (availability, bool) {
+	if !next.accountsOK && prev.accountsOK {
+		next.accounts, next.accountsOK, next.accountsStale = prev.accounts, true, true
+	}
 	if !next.ok {
 		if prev.ok {
+			prev.accounts, prev.accountsOK, prev.accountsStale =
+				next.accounts, next.accountsOK, next.accountsStale
 			return prev, true
 		}
 		return next, false
@@ -1317,14 +1342,15 @@ type model struct {
 	rdy      bool
 	usageCmd string
 
-	vaults     []vault
-	selected   string                  // active vault id
-	disabled   map[string]bool         // disabled vault ids (never includes the fallback)
-	vaultState string                  // CODE_AUTH_STATE path
-	vaultErr   string                  // last vault switch/persist/login error
-	vaultUsage map[string]availability // per-vault usage snapshots for the manager
-	manager    bool                    // v: the full-screen vault manager is open
-	mgrCursor  int                     // manager row cursor
+	vaults       []vault
+	selected     string                  // active vault id
+	disabled     map[string]bool         // disabled vault ids (never includes the fallback)
+	vaultState   string                  // CODE_AUTH_STATE path
+	vaultErr     string                  // last vault switch/persist/login error
+	vaultUsage   map[string]availability // per-vault usage snapshots for the manager
+	manager      bool                    // v: the full-screen vault manager is open
+	mgrCursor    int                     // manager row cursor
+	loginRunning bool                    // one suspended provider login may run at a time
 
 	fetching    bool      // a usage fetch is in flight (manual or auto)
 	nextRefresh time.Time // when the next auto-refresh fires
@@ -1518,7 +1544,7 @@ func (m *model) usageCtrlLine() string {
 
 // providerHeading names a provider usage group by its effective identity —
 // "Codex (account)" / "Claude (account)", derived from the active auth
-// profile — so mixed profiles (Claude (Mum) + Codex (Alex)) read correctly
+// profile — so mixed profiles (Claude (Collaborator) + Codex (Operator)) read
 // with no prose equation, in text rather than color alone. The parenthesized
 // owner is dimmed so the provider name stays the heading's anchor.
 func providerHeading(prov string, p vault) string {
@@ -1664,17 +1690,18 @@ func (m *model) usageLoading() bool {
 	return m.usageCmd != "" && !m.avail.ok && (m.fetching || m.nextRefresh.IsZero())
 }
 
-// skeletonWins are the loading skeleton's placeholder windows: both supported
-// providers expose a 5-hour rolling window and a weekly window, so the
-// skeleton mirrors that standard shape — real labels, empty bars, dotted
-// placeholders — without fabricating numbers the fetch hasn't produced.
-var skeletonWins = [...]string{"5h", "7d"}
+// skeletonWinsByProvider mirrors each provider's stable usage shape. Anthropic
+// always reserves the Fable row, even before a first successful fetch.
+var skeletonWinsByProvider = map[string][]string{
+	"openai-codex": {"5h", "7d"},
+	"anthropic":    {"5h", "7d", "7d fable"},
+}
 
 // skeletonRow is a placeholder usage row: the real row's exact geometry with
 // an empty bar and ·· placeholders for the percentage and reset time.
 func skeletonRow(label string) string {
 	return fmt.Sprintf("  %-9s %s %s used  %s", label, barStr(0),
-		stDim.Render(" ··%"), stDim.Render(gReset+" ··"))
+		stDim.Render(" ··%"), stDim.Render(gReset+" ····"))
 }
 
 // skeletonBody is the pre-first-fetch Usage content: the provider/account
@@ -1685,7 +1712,7 @@ func (m *model) skeletonBody(w int, p vault) string {
 	blocks := map[string][]string{}
 	for _, prov := range order {
 		rows := []string{padLeft(providerHeading(prov, p), gut)}
-		for _, label := range skeletonWins {
+		for _, label := range skeletonWinsByProvider[prov] {
 			rows = append(rows, skeletonRow(label))
 		}
 		blocks[prov] = rows
@@ -1738,15 +1765,20 @@ func (m *model) usageRow(w usageWin) string {
 		note = "  " + lipgloss.NewStyle().Foreground(lipgloss.Color(cGreen)).Render("idle")
 	}
 	if w.stale {
-		// Retained from the last successful fetch after a refresh omitted
-		// this window — the value is old, and the row says so.
-		note += "  " + stWarn.Render("stale")
+		// Retained from the last successful fetch after a refresh omitted this
+		// window. Keep the value and expose the observation timestamp.
+		cached := "cached"
+		if w.observed > 0 {
+			cached += " " + time.Unix(w.observed, 0).Local().Format("15:04")
+		}
+		note += "  " + stWarn.Render(cached)
 	}
-	reset := stDim.Render(gReset + " " + fmtReset(w.secs))
+	resetText := gReset + " " + pad(fmtReset(w.secs), 4)
+	reset := stDim.Render(resetText)
 	if w.dur > 0 && w.secs*10 < w.dur {
-		reset = lipgloss.NewStyle().Foreground(lipgloss.Color("#c8d0dc")).Bold(true).Render(gReset + " " + fmtReset(w.secs))
+		reset = lipgloss.NewStyle().Foreground(lipgloss.Color("#c8d0dc")).Bold(true).Render(resetText)
 	} else if w.dur > 0 && w.secs*4 < w.dur {
-		reset = lipgloss.NewStyle().Foreground(lipgloss.Color("#c8d0dc")).Render(gReset + " " + fmtReset(w.secs))
+		reset = lipgloss.NewStyle().Foreground(lipgloss.Color("#c8d0dc")).Render(resetText)
 	}
 	// During the one-time first-load fill only the bar is scaled toward its
 	// target; the label, percentage, and reset text are real from frame one.
@@ -2021,12 +2053,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.vaultUsage == nil {
 			m.vaultUsage = map[string]availability{}
 		}
-		m.vaultUsage[msg.vault] = msg.avail // scoped snapshot for the manager
+		previous, known := m.vaultUsage[msg.vault]
+		if !known && msg.vault == m.activeVault().ID {
+			previous = m.avail
+		}
+		scoped, scopedStale := reconcileUsage(previous, msg.avail)
+		m.vaultUsage[msg.vault] = scoped
 		if msg.vault != m.activeVault().ID {
 			return m, nil // not the active vault: never touches the detailed panel or its fill
 		}
 		first := !m.hadUsage && msg.avail.ok
-		m.avail, m.usageStale = reconcileUsage(m.avail, msg.avail)
+		m.avail, m.usageStale = scoped, scopedStale
 		m.hadUsage = m.hadUsage || msg.avail.ok
 		m.fetching = false
 		m.nextRefresh = time.Now().Add(refreshEvery)
@@ -2038,8 +2075,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, barAnimCmd(2)
 		}
 	case loginDoneMsg:
+		m.loginRunning = false
 		m.vaultErr = ""
-		if msg.err != nil {
+		if msg.err != nil && !errors.Is(msg.err, errLoginCancelled) {
 			m.vaultErr = "login failed: " + msg.err.Error()
 		}
 		for _, v := range m.vaults {
@@ -2537,7 +2575,7 @@ func main() {
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
 	generated := loadBlocks(os.Getenv("CODE_GENERATED"))
-	vaults := parseVaults(os.Getenv("CODE_AUTH_VAULTS"))
+	vaults := loadVaults(os.Getenv("CODE_AUTH_VAULTS"), os.Getenv("CODE_AUTH_VAULTS_FILE"))
 	vaultState := os.Getenv("CODE_AUTH_STATE")
 	selected, disabled := loadVaultState(vaults, vaultState)
 	facets := facetDefs(glyphs)

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -267,6 +267,127 @@ type availability struct {
 	accountsStale bool
 }
 
+// withoutBrokerRouting removes inherited client-side broker variables before a
+// profile-local, read-only usage query. The selected vault's Profile is the
+// credential store used by that vault's broker service; clearing these values
+// prevents an ambient session from silently redirecting the query elsewhere.
+func withoutBrokerRouting(base []string) []string {
+	out := make([]string, 0, len(base))
+	for _, e := range base {
+		key := e
+		if i := strings.IndexByte(e, '='); i >= 0 {
+			key = e[:i]
+		}
+		switch key {
+		case "OMP_AUTH_BROKER_URL", "OMP_AUTH_BROKER_TOKEN", "OMP_AUTH_BROKER_SNAPSHOT_CACHE":
+			continue
+		default:
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// supplementFableUsage works around an OMP v17 auth-broker discrepancy: its
+// aggregate /v1/usage response can omit an Anthropic Fable limit that the same
+// vault profile returns from a provider-scoped `omp usage` query. Only that
+// missing limit is appended; broker-sourced identities and every other usage
+// datum remain authoritative. Any direct-query or shape failure is a no-op.
+func supplementFableUsage(cmd string, v vault, brokerOut []byte) []byte {
+	type envelope struct {
+		Reports []json.RawMessage `json:"reports"`
+	}
+	type report struct {
+		Provider string            `json:"provider"`
+		Limits   []json.RawMessage `json:"limits"`
+	}
+	type limitIdentity struct {
+		ID    string `json:"id"`
+		Label string `json:"label"`
+		Scope struct {
+			Tier string `json:"tier"`
+		} `json:"scope"`
+	}
+
+	fableLimit := func(raw json.RawMessage) bool {
+		var l limitIdentity
+		if json.Unmarshal(raw, &l) != nil {
+			return false
+		}
+		return l.Scope.Tier == "fable" || l.ID == "anthropic:7d:fable" ||
+			l.Label == "Claude 7 Day (Fable)"
+	}
+
+	var brokerDoc envelope
+	if json.Unmarshal(brokerOut, &brokerDoc) != nil {
+		return brokerOut
+	}
+	brokerReportIndex := -1
+	var brokerAnthropic report
+	for i, raw := range brokerDoc.Reports {
+		var r report
+		if json.Unmarshal(raw, &r) != nil || r.Provider != "anthropic" {
+			continue
+		}
+		for _, limit := range r.Limits {
+			if fableLimit(limit) {
+				return brokerOut
+			}
+		}
+		brokerReportIndex, brokerAnthropic = i, r
+		break
+	}
+	if brokerReportIndex < 0 {
+		return brokerOut
+	}
+
+	parts := strings.Fields(cmd)
+	if len(parts) == 0 || v.Profile == "" {
+		return brokerOut
+	}
+	args := withOMPProfile(v.Profile, parts[1:]...)
+	args = append(args, "--provider", "anthropic")
+	c := exec.Command(parts[0], args...)
+	c.Env = withoutBrokerRouting(os.Environ())
+	directOut, err := c.Output()
+	if err != nil || len(directOut) == 0 {
+		return brokerOut
+	}
+
+	var directDoc envelope
+	if json.Unmarshal(directOut, &directDoc) != nil {
+		return brokerOut
+	}
+	var directFable json.RawMessage
+	for _, raw := range directDoc.Reports {
+		var r report
+		if json.Unmarshal(raw, &r) != nil || r.Provider != "anthropic" {
+			continue
+		}
+		for _, limit := range r.Limits {
+			if fableLimit(limit) {
+				directFable = limit
+				break
+			}
+		}
+	}
+	if len(directFable) == 0 {
+		return brokerOut
+	}
+
+	brokerAnthropic.Limits = append(brokerAnthropic.Limits, directFable)
+	updated, err := json.Marshal(brokerAnthropic)
+	if err != nil {
+		return brokerOut
+	}
+	brokerDoc.Reports[brokerReportIndex] = updated
+	merged, err := json.Marshal(brokerDoc)
+	if err != nil {
+		return brokerOut
+	}
+	return merged
+}
+
 // loadAvailability fetches identity and usage for one vault. Managed broker
 // vaults read the broker's redacted snapshot and aggregate usage endpoints
 // directly, avoiding client-side credential-schema failures in unrelated
@@ -288,6 +409,9 @@ func loadAvailability(cmd string, v vault) availability {
 	var err error
 	if v.BrokerURL != "" && v.TokenFile != "" {
 		out, err = fetchVaultEndpoint(v, "/v1/usage")
+		if err == nil {
+			out = supplementFableUsage(cmd, v, out)
+		}
 	} else {
 		env, envErr := brokerEnv(v)
 		if envErr != nil {
@@ -2216,22 +2340,21 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.relayout()
 		case "s":
-			// Narrow terminals give Usage a dedicated full-screen view instead
-			// of treating s as a hidden-state toggle that accidentally reveals
-			// Routing. Wider layouts keep the inline section collapse.
-			if m.sizeMode() == sizeNarrow {
-				if m.showUsage {
-					m.showUsage = false
-					m.hideUsage = true
-				} else {
-					m.showUsage = true
-					m.hideUsage = false
-					m.showResult = false
-					m.collapse = false
-				}
-			} else {
+			// Toggle the rendered section, not the pre-toggle size class. Usage
+			// changes the responsive minima, so a layout that fits while it is
+			// hidden may become narrow when it returns. In that case open the
+			// dedicated view atomically. It overlays the existing generator /
+			// Routing state so closing it restores that exact composition.
+			switch {
+			case m.showUsage:
 				m.showUsage = false
-				m.hideUsage = !m.hideUsage
+				m.hideUsage = true
+			case !m.usageShown():
+				m.hideUsage = false
+				m.showUsage = m.sizeMode() == sizeNarrow
+			default:
+				m.showUsage = false
+				m.hideUsage = true
 			}
 			m.relayout()
 		case "?":

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -1452,18 +1452,21 @@ type model struct {
 	rdy      bool
 	usageCmd string
 
-	vaults        []vault
-	selected      string                  // active vault id
-	disabled      map[string]bool         // disabled vault ids (never includes the fallback)
-	vaultState    string                  // CODE_AUTH_STATE path
-	vaultErr      string                  // last vault switch/persist/login error
-	vaultManifest string                  // resolved writable manifest path; empty for raw JSON/read-only
-	managerInput  string                  // "create" or "rename" while manager text entry is active
-	managerText   string                  // pending manager text-entry value
-	vaultUsage    map[string]availability // per-vault usage snapshots for the manager
-	manager       bool                    // v: the full-screen vault manager is open
-	mgrCursor     int                     // manager row cursor
-	loginRunning  bool                    // one suspended provider login may run at a time
+	vaults          []vault
+	selected        string                  // active vault id
+	disabled        map[string]bool         // disabled vault ids (never includes the fallback)
+	vaultState      string                  // CODE_AUTH_STATE path
+	vaultErr        string                  // last vault switch/persist/login error
+	vaultManifest   string                  // resolved writable manifest path; empty for raw JSON/read-only
+	managerInput    string                  // "create" or "rename" while manager text entry is active
+	managerText     string                  // pending manager text-entry value
+	vaultUsage      map[string]availability // per-vault snapshots, hydrated in the background
+	vaultUsageNext  map[string]time.Time    // independent auto-refresh deadline for each cached vault
+	vaultUsageStale map[string]bool         // whole-fetch failure retained per vault
+	vaultFetching   map[string]bool         // in-flight usage request state, isolated per vault
+	manager         bool                    // v: the full-screen vault manager is open
+	mgrCursor       int                     // manager row cursor
+	loginRunning    bool                    // one suspended provider login may run at a time
 
 	fetching    bool      // a usage fetch is in flight (manual or auto)
 	nextRefresh time.Time // when the next auto-refresh fires
@@ -1504,12 +1507,28 @@ func fetchUsageCmd(cmd string, v vault) tea.Cmd {
 	return func() tea.Msg { return usageMsg{vault: v.ID, avail: loadAvailability(cmd, v)} }
 }
 
-// fetchAllCmd refreshes every vault at once — the manager's whole-list view.
-func fetchAllCmd(cmd string, vaults []vault) tea.Cmd {
-	var cmds []tea.Cmd
+// startUsageFetch records request state before returning the asynchronous
+// command. Cached data stays visible; only the matching vault shows the
+// refreshing indicator.
+func (m *model) startUsageFetch(v vault) tea.Cmd {
+	if m.usageCmd == "" {
+		return nil
+	}
+	if m.vaultFetching == nil {
+		m.vaultFetching = map[string]bool{}
+	}
+	m.vaultFetching[v.ID] = true
+	if v.ID == m.activeVault().ID {
+		m.fetching = true
+	}
+	return fetchUsageCmd(m.usageCmd, v)
+}
+
+func (m *model) startUsageFetchAll(vaults []vault) tea.Cmd {
+	cmds := make([]tea.Cmd, 0, len(vaults))
 	for _, v := range vaults {
-		if c := fetchUsageCmd(cmd, v); c != nil {
-			cmds = append(cmds, c)
+		if cmd := m.startUsageFetch(v); cmd != nil {
+			cmds = append(cmds, cmd)
 		}
 	}
 	if len(cmds) == 0 {
@@ -1541,7 +1560,7 @@ func (m model) Init() tea.Cmd {
 	if m.usageCmd == "" {
 		return nil
 	}
-	return tea.Batch(fetchUsageCmd(m.usageCmd, m.activeVault()), m.spin.Tick, tickCmd())
+	return tea.Batch(m.startUsageFetchAll(m.vaults), m.spin.Tick, tickCmd())
 }
 
 func (m model) listW() int {
@@ -1916,6 +1935,27 @@ func (m model) secondaryMinH() int {
 	return h
 }
 
+func formatCachedAge(observed int64, now time.Time) string {
+	seconds := now.Unix() - observed
+	if seconds < 0 {
+		seconds = 0
+	}
+	switch {
+	case seconds < 60:
+		return "<1m ago"
+	case seconds < 60*60:
+		return fmt.Sprintf("%dm ago", seconds/60)
+	case seconds < 24*60*60:
+		return fmt.Sprintf("%dh ago", seconds/(60*60))
+	case seconds < 7*24*60*60:
+		return fmt.Sprintf("%dd ago", seconds/(24*60*60))
+	case seconds < 365*24*60*60:
+		return fmt.Sprintf("%dw ago", seconds/(7*24*60*60))
+	default:
+		return fmt.Sprintf("%dy ago", seconds/(365*24*60*60))
+	}
+}
+
 func (m *model) usageRow(w usageWin) string {
 	if w.missing {
 		// Never-observed window (the upstream payload omits it): the real
@@ -1934,11 +1974,11 @@ func (m *model) usageRow(w usageWin) string {
 		note = "  " + lipgloss.NewStyle().Foreground(lipgloss.Color(cGreen)).Render("idle")
 	}
 	if w.stale {
-		// Retained from the last successful fetch after a refresh omitted this
-		// window. Keep the value and expose the observation timestamp.
+		// Retained after a refresh omitted this window. Keep the value and
+		// show its age, which is faster to interpret while switching vaults.
 		cached := "cached"
 		if w.observed > 0 {
-			cached += " " + time.Unix(w.observed, 0).Local().Format("15:04")
+			cached += " " + formatCachedAge(w.observed, time.Now())
 		}
 		note += "  " + stWarn.Render(cached)
 	}
@@ -2073,15 +2113,15 @@ func (m *model) syncPreviewAt(yoff int) {
 // keeps Usage in the footer) then the controls help, each under a rule. Built
 // once here so relayout and View stay in sync.
 func (m *model) footer() string {
-	rule := stDim.Render(strings.Repeat("─", m.w))
-	var parts []string
+	usage := ""
 	if m.usageInFooter() {
-		if p := m.usagePanel(); p != "" {
-			parts = append(parts, rule, p)
-		}
+		usage = m.usagePanel()
 	}
-	parts = append(parts, rule, padLeft(m.help.View(m.contextHelp()), gut))
-	return strings.Join(parts, "\n")
+	return clikit.SeparatedSections(
+		m.w,
+		usage,
+		padLeft(m.help.View(m.contextHelp()), gut),
+	)
 }
 
 // usageInFooter says where Usage lives: the wide layout keeps it as the
@@ -2234,12 +2274,25 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.vaultUsage == nil {
 			m.vaultUsage = map[string]availability{}
 		}
+		if m.vaultUsageNext == nil {
+			m.vaultUsageNext = map[string]time.Time{}
+		}
+		if m.vaultUsageStale == nil {
+			m.vaultUsageStale = map[string]bool{}
+		}
+		if m.vaultFetching == nil {
+			m.vaultFetching = map[string]bool{}
+		}
 		previous, known := m.vaultUsage[msg.vault]
 		if !known && msg.vault == m.activeVault().ID {
 			previous = m.avail
 		}
 		scoped, scopedStale := reconcileUsage(previous, msg.avail)
+		refreshAt := time.Now().Add(refreshEvery)
 		m.vaultUsage[msg.vault] = scoped
+		m.vaultUsageNext[msg.vault] = refreshAt
+		m.vaultUsageStale[msg.vault] = scopedStale
+		m.vaultFetching[msg.vault] = false
 		if msg.vault != m.activeVault().ID {
 			return m, nil // not the active vault: never touches the detailed panel or its fill
 		}
@@ -2247,7 +2300,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.avail, m.usageStale = scoped, scopedStale
 		m.hadUsage = m.hadUsage || msg.avail.ok
 		m.fetching = false
-		m.nextRefresh = time.Now().Add(refreshEvery)
+		m.nextRefresh = refreshAt
 		m.relayout()
 		if first {
 			// The first real data replaces the skeleton: run the one-time
@@ -2268,7 +2321,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if v.ID == m.activeVault().ID {
 				m.fetching = m.usageCmd != ""
 			}
-			return m, fetchUsageCmd(m.usageCmd, v)
+			return m, m.startUsageFetch(v)
 		}
 		return m, nil
 	case barAnimMsg:
@@ -2287,8 +2340,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// re-arm the 1s tick; auto-refresh once the interval elapses.
 		cmds := []tea.Cmd{tickCmd()}
 		if !m.fetching && !m.nextRefresh.IsZero() && !time.Now().Before(m.nextRefresh) {
-			m.fetching = true
-			cmds = append(cmds, fetchUsageCmd(m.usageCmd, m.activeVault()))
+			cmds = append(cmds, m.startUsageFetch(m.activeVault()))
 		}
 		return m, tea.Batch(cmds...)
 	case spinner.TickMsg:
@@ -2369,10 +2421,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.syncPreview()
 		case "r":
 			if m.usageCmd != "" && !m.fetching {
-				m.fetching = true
-				return m, fetchUsageCmd(m.usageCmd, m.activeVault())
+				return m, m.startUsageFetch(m.activeVault())
 			}
 		case "a":
+			prev := m.selected
 			changed, err := m.cycleVault()
 			if err != nil {
 				m.vaultErr = err.Error()
@@ -2381,20 +2433,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if changed {
 				m.vaultErr = ""
-				m.usageStale = false // the wiped avail belongs to the new vault; no stale carry-over
-				m.fetching = m.usageCmd != ""
+				cmd := m.afterSelectionChange(prev)
 				m.relayout()
-				if m.fetching {
-					return m, fetchUsageCmd(m.usageCmd, m.activeVault())
+				if cmd != nil {
+					return m, cmd
 				}
 			}
 		case "v":
 			if len(m.vaults) > 0 {
 				m.manager = true
 				m.mgrCursor = m.activeIndex()
-				m.fetching = m.usageCmd != ""
+				m.fetching = m.vaultFetching[m.activeVault().ID]
 				m.relayout()
-				return m, fetchAllCmd(m.usageCmd, m.vaults)
 			}
 		case "up", "k":
 			m.moveUp()
@@ -2789,24 +2839,32 @@ func main() {
 	facets := facetDefs(glyphs)
 	selectionState := os.Getenv("CODE_SELECTION_STATE")
 	m := model{
-		generated:      generated,
-		advisors:       parseAdvisors(generated["__advisors__"]),
-		facts:          parseFacts(generated["__models__"]),
-		avail:          availability{bucket: map[string]string{}, reset: map[string]int64{}},
-		usageCmd:       os.Getenv("CODE_USAGE"),
-		vaults:         vaults,
-		selected:       selected,
-		disabled:       disabled,
-		vaultState:     vaultState,
-		vaultManifest:  vaultManifest,
-		vaultUsage:     map[string]availability{},
-		fetching:       os.Getenv("CODE_USAGE") != "",
-		spin:           sp,
-		help:           help.New(),
-		glyphs:         glyphs,
-		facets:         facets,
-		sel:            loadSelectionState(selectionState, facets),
-		selectionState: selectionState,
+		generated:       generated,
+		advisors:        parseAdvisors(generated["__advisors__"]),
+		facts:           parseFacts(generated["__models__"]),
+		avail:           availability{bucket: map[string]string{}, reset: map[string]int64{}},
+		vaultFetching:   map[string]bool{},
+		usageCmd:        os.Getenv("CODE_USAGE"),
+		vaults:          vaults,
+		selected:        selected,
+		disabled:        disabled,
+		vaultState:      vaultState,
+		vaultManifest:   vaultManifest,
+		vaultUsage:      map[string]availability{},
+		vaultUsageNext:  map[string]time.Time{},
+		vaultUsageStale: map[string]bool{},
+		fetching:        os.Getenv("CODE_USAGE") != "",
+		spin:            sp,
+		help:            clikit.NewHelp(),
+		glyphs:          glyphs,
+		facets:          facets,
+		sel:             loadSelectionState(selectionState, facets),
+		selectionState:  selectionState,
+	}
+	if m.usageCmd != "" {
+		for _, v := range m.vaults {
+			m.vaultFetching[v.ID] = true
+		}
 	}
 	// Cell-motion mouse reporting carries wheel events. Filter rejected
 	// momentum and unused motion before Bubble Tea's redraw-after-Update loop.

--- a/pkgs/code-tui/main.go
+++ b/pkgs/code-tui/main.go
@@ -1328,18 +1328,18 @@ type model struct {
 	rdy      bool
 	usageCmd string
 
-	vaults       []vault
-	selected     string                  // active vault id
-	disabled     map[string]bool         // disabled vault ids (never includes the fallback)
-	vaultState   string                  // CODE_AUTH_STATE path
-	vaultErr     string                  // last vault switch/persist/login error
+	vaults        []vault
+	selected      string                  // active vault id
+	disabled      map[string]bool         // disabled vault ids (never includes the fallback)
+	vaultState    string                  // CODE_AUTH_STATE path
+	vaultErr      string                  // last vault switch/persist/login error
 	vaultManifest string                  // resolved writable manifest path; empty for raw JSON/read-only
 	managerInput  string                  // "create" or "rename" while manager text entry is active
 	managerText   string                  // pending manager text-entry value
-	vaultUsage   map[string]availability // per-vault usage snapshots for the manager
-	manager      bool                    // v: the full-screen vault manager is open
-	mgrCursor    int                     // manager row cursor
-	loginRunning bool                    // one suspended provider login may run at a time
+	vaultUsage    map[string]availability // per-vault usage snapshots for the manager
+	manager       bool                    // v: the full-screen vault manager is open
+	mgrCursor     int                     // manager row cursor
+	loginRunning  bool                    // one suspended provider login may run at a time
 
 	fetching    bool      // a usage fetch is in flight (manual or auto)
 	nextRefresh time.Time // when the next auto-refresh fires

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	clikit "cli-kit"
 	"fmt"
-	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -509,7 +508,7 @@ func layoutModel() model {
 		usageCmd:    "omp usage --json",
 		vaults:      []vault{{ID: "default", Label: "primary", Claude: "Operator", Codex: "Operator"}},
 		spin:        spinner.New(),
-		help:        help.New(),
+		help:        clikit.NewHelp(),
 		glyphs:      glyphs,
 		facets:      facetDefs(glyphs),
 		sel:         defaultSel(),
@@ -2290,12 +2289,37 @@ func TestReconcileUsageFableRetention(t *testing.T) {
 	}
 	m := layoutModel()
 	row := stripAnsi(m.usageRow(fable))
-	wantCached := "cached " + time.Unix(fable.observed, 0).Local().Format("15:04")
-	if !strings.Contains(row, "7d fable") || !strings.Contains(row, wantCached) {
-		t.Errorf("the retained row must carry its cache timestamp %q: %q", wantCached, row)
+	if !strings.Contains(row, "7d fable") ||
+		!strings.Contains(row, "cached ") ||
+		!strings.Contains(row, " ago") {
+		t.Errorf("the retained row must carry its relative cache age: %q", row)
 	}
 	if !strings.Contains(row, "100% used") {
 		t.Errorf("the retained row must show the last observed value: %q", row)
+	}
+}
+
+func TestFormatCachedAge(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	tests := []struct {
+		name     string
+		observed int64
+		want     string
+	}{
+		{name: "future clock skew", observed: now.Unix() + 30, want: "<1m ago"},
+		{name: "seconds", observed: now.Unix() - 59, want: "<1m ago"},
+		{name: "minutes", observed: now.Unix() - 5*60, want: "5m ago"},
+		{name: "hours", observed: now.Unix() - 3*60*60, want: "3h ago"},
+		{name: "days", observed: now.Unix() - 2*24*60*60, want: "2d ago"},
+		{name: "weeks", observed: now.Unix() - 21*24*60*60, want: "3w ago"},
+		{name: "years", observed: now.Unix() - 2*365*24*60*60, want: "2y ago"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatCachedAge(tt.observed, now); got != tt.want {
+				t.Fatalf("formatCachedAge() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -1642,6 +1642,48 @@ func TestCollapseReallocation(t *testing.T) {
 	}
 }
 
+// TestUsageRestoreFallsBackToFullscreen locks the state transition at the
+// responsive boundary where Routing fits only while Usage is hidden. Restoring
+// Usage must choose its dedicated view immediately, then return to the exact
+// generator-only composition instead of leaking Routing into view.
+func TestUsageRestoreFallsBackToFullscreen(t *testing.T) {
+	m := layoutModel()
+	m.hideUsage = true
+	m.collapse = true
+	m.showResult = false
+
+	withUsage := m
+	withUsage.hideUsage = false
+	w := withUsage.mediumMinW() - 1
+	if w < routingMinW {
+		t.Fatalf("fixture: fallback width %d is below Routing minimum %d", w, routingMinW)
+	}
+	m = resize(t, m, w, 40)
+	if m.sizeMode() != sizeMedium || m.mode() != modeCollapsed {
+		t.Fatalf("fixture: hidden Usage must leave a collapsed medium layout, size/mode = %d/%d", m.sizeMode(), m.mode())
+	}
+
+	m, _ = press(t, m, "s")
+	if m.hideUsage || !m.showUsage || !m.usageShown() {
+		t.Fatalf("first s must open Usage full-screen immediately: hidden=%v show=%v shown=%v", m.hideUsage, m.showUsage, m.usageShown())
+	}
+	full := strings.Split(stripAnsi(m.View()), "\n")
+	if lineIndex(full, "usage", "s · hide") < 0 ||
+		lineIndex(full, "generator") >= 0 ||
+		lineIndex(full, "routing", "p · hide") >= 0 {
+		t.Fatalf("fallback must render only Usage:\n%s", strings.Join(full, "\n"))
+	}
+
+	m, _ = press(t, m, "s")
+	if !m.hideUsage || m.showUsage || !m.collapse || m.showResult {
+		t.Fatalf("second s must restore prior generator state: hidden=%v show=%v collapse=%v result=%v", m.hideUsage, m.showUsage, m.collapse, m.showResult)
+	}
+	restored := strings.Split(stripAnsi(m.View()), "\n")
+	if lineIndex(restored, "generator") < 0 || lineIndex(restored, "routing", "p · hide") >= 0 {
+		t.Fatalf("return from Usage must restore generator without Routing:\n%s", strings.Join(restored, "\n"))
+	}
+}
+
 // ── bottom-pinned section chrome · secondary separator · defaults cue ────────
 
 // TestRoutingFallbackCuePinned locks the moved fallback-display cue: it is

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -237,6 +237,24 @@ func TestCycleFacetClearsMain(t *testing.T) {
 	}
 }
 
+func TestCycleFacetClampsAtEndpoints(t *testing.T) {
+	m := &model{facets: facetDefs(map[string]string{}), sel: defaultSel()}
+	m.fcur = 0 // lane
+
+	m.sel["lane"] = m.facets[0].values[0]
+	m.cycleFacet(-1)
+	if got := m.sel["lane"]; got != m.facets[0].values[0] {
+		t.Fatalf("left at first option wrapped to %q", got)
+	}
+
+	last := m.facets[0].values[len(m.facets[0].values)-1]
+	m.sel["lane"] = last
+	m.cycleFacet(1)
+	if got := m.sel["lane"]; got != last {
+		t.Fatalf("right at last option wrapped to %q", got)
+	}
+}
+
 // TestLaunchKeys locks the launch decision: Enter always launches the generated
 // profile for the current facets — even at defaults with no prompt — while m
 // requests omp-managed on the managed defaults with no generated overlay.
@@ -892,7 +910,7 @@ func TestWheelThroughUpdate(t *testing.T) {
 	}
 }
 
-func TestWheelInputFilterCoalescesOneRenderQuantum(t *testing.T) {
+func TestWheelInputFilterRequiresDeliberateBurst(t *testing.T) {
 	m := layoutModel()
 	wide, _, _, _ := layoutSizes(t, m)
 	m = resize(t, m, wide.w, wide.h)
@@ -900,65 +918,46 @@ func TestWheelInputFilterCoalescesOneRenderQuantum(t *testing.T) {
 	wheel := func(b tea.MouseButton) tea.MouseMsg {
 		return tea.MouseMsg{Action: tea.MouseActionPress, Button: b, X: 2, Y: topGap + 2}
 	}
-
-	first, ok := filter.Filter(m, wheel(tea.MouseButtonWheelUp)).(admittedWheelMsg)
-	if !ok {
-		t.Fatal("leading vertical event was not admitted")
+	admit := func(b tea.MouseButton) admittedWheelMsg {
+		t.Helper()
+		for i := 1; i < wheelStepEvents; i++ {
+			if got := filter.Filter(m, wheel(b)); got != nil {
+				t.Fatalf("event %d/%d admitted early as %T", i, wheelStepEvents, got)
+			}
+			if i == 2 && (b == tea.MouseButtonWheelUp || b == tea.MouseButtonWheelDown) {
+				if got := filter.Filter(m, wheel(tea.MouseButtonWheelRight)); got != nil {
+					t.Fatalf("orthogonal jitter reached Update as %T", got)
+				}
+			}
+		}
+		msg, ok := filter.Filter(m, wheel(b)).(admittedWheelMsg)
+		if !ok {
+			t.Fatalf("event %d/%d was not admitted", wheelStepEvents, wheelStepEvents)
+		}
+		return msg
 	}
+
+	first := admit(tea.MouseButtonWheelUp)
 	nm, cmd := m.Update(first)
 	m = nm.(model)
-	if cmd == nil || m.fcur != 1 {
-		t.Fatalf("leading event: cmd nil = %t, fcur = %d", cmd == nil, m.fcur)
-	}
-	for range 100 {
-		if got := filter.Filter(m, wheel(tea.MouseButtonWheelUp)); got != nil {
-			t.Fatalf("same-direction momentum reached Update as %T", got)
-		}
-		if got := filter.Filter(m, wheel(tea.MouseButtonWheelRight)); got != nil {
-			t.Fatalf("orthogonal jitter reached Update as %T", got)
-		}
+	if cmd != nil || m.fcur != 1 {
+		t.Fatalf("first deliberate burst: cmd nil = %t, fcur = %d", cmd == nil, m.fcur)
 	}
 
-	// A reversal is explicit intent and must act immediately rather than wait
-	// behind momentum from the old direction.
-	reverse, ok := filter.Filter(m, wheel(tea.MouseButtonWheelDown)).(admittedWheelMsg)
-	if !ok {
-		t.Fatal("same-axis reversal was not admitted immediately")
-	}
+	reverse := admit(tea.MouseButtonWheelDown)
 	nm, cmd = m.Update(reverse)
 	m = nm.(model)
-	if cmd == nil || m.fcur != 0 {
-		t.Fatalf("reversal: cmd nil = %t, fcur = %d", cmd == nil, m.fcur)
+	if cmd != nil || m.fcur != 0 {
+		t.Fatalf("reverse burst: cmd nil = %t, fcur = %d", cmd == nil, m.fcur)
 	}
 
-	// The stale close from the superseded window cannot re-arm the new one.
-	if got := filter.Filter(m, wheelWindowDoneMsg{generation: first.generation}); got != nil {
-		t.Fatalf("stale close reached Update as %T", got)
-	}
-	if got := filter.Filter(m, wheel(tea.MouseButtonWheelDown)); got != nil {
-		t.Fatalf("stale close re-armed current window: %T", got)
-	}
-	if got := filter.Filter(m, wheelWindowDoneMsg{generation: reverse.generation}); got != nil {
-		t.Fatalf("current close reached Update as %T", got)
-	}
-
-	left, ok := filter.Filter(m, wheel(tea.MouseButtonWheelLeft)).(admittedWheelMsg)
-	if !ok {
-		t.Fatal("horizontal event was not admitted after one render quantum")
-	}
+	// A later orthogonal gesture starts cleanly after the prior gesture gap.
+	filter.last = time.Now().Add(-wheelGestureGap - time.Millisecond)
+	left := admit(tea.MouseButtonWheelLeft)
 	nm, _ = m.Update(left)
 	m = nm.(model)
 	if m.sel["lane"] != "claude-led" {
-		t.Fatalf("horizontal wheel did not move lane: %q", m.sel["lane"])
-	}
-	right, ok := filter.Filter(m, wheel(tea.MouseButtonWheelRight)).(admittedWheelMsg)
-	if !ok {
-		t.Fatal("horizontal reversal was not admitted immediately")
-	}
-	nm, _ = m.Update(right)
-	m = nm.(model)
-	if m.sel["lane"] != "mixed" {
-		t.Fatalf("horizontal reversal did not restore lane: %q", m.sel["lane"])
+		t.Fatalf("horizontal burst did not move lane: %q", m.sel["lane"])
 	}
 }
 
@@ -970,23 +969,33 @@ func TestFilteredWheelPreservesSelectionPersistence(t *testing.T) {
 	filter := wheelInputFilter{}
 	left := tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelLeft, X: 2, Y: topGap + 2}
 
-	msg := filter.Filter(m, left)
-	nm, _ := m.Update(msg)
-	m = nm.(model)
-	for range 100 {
+	var msg tea.Msg
+	for range wheelStepEvents {
 		if got := filter.Filter(m, left); got != nil {
-			t.Fatalf("coalesced wheel event reached Update as %T", got)
+			msg = got
 		}
 	}
+	if msg == nil {
+		t.Fatal("deliberate wheel-left burst was not admitted")
+	}
+	nm, _ := m.Update(msg)
+	m = nm.(model)
 	if got := loadSelectionState(m.selectionState, m.facets)["lane"]; got != "claude-led" {
 		t.Fatalf("persisted lane after wheel-left = %q, want claude-led", got)
 	}
 
+	filter.last = time.Now().Add(-wheelGestureGap - time.Millisecond)
 	right := tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelRight, X: 2, Y: topGap + 2}
-	nm, _ = m.Update(filter.Filter(m, right))
+	msg = nil
+	for range wheelStepEvents {
+		if got := filter.Filter(m, right); got != nil {
+			msg = got
+		}
+	}
+	nm, _ = m.Update(msg)
 	m = nm.(model)
 	if got := loadSelectionState(m.selectionState, m.facets)["lane"]; got != "mixed" {
-		t.Fatalf("persisted lane after immediate reversal = %q, want mixed", got)
+		t.Fatalf("persisted lane after wheel-right burst = %q, want mixed", got)
 	}
 }
 
@@ -1055,9 +1064,9 @@ func (p burstProbe) View() string {
 }
 
 // TestRawMouseBurstRemainsResponsive drives the real Bubble Tea ANSI parser
-// with two dense trackpad-like wheel/jitter/motion bursts separated by one
-// render quantum. Coalesced events must never reach Update/View, and the second
-// burst must re-arm independently of the first burst's rejected tail.
+// with two dense trackpad-like wheel/jitter/motion bursts separated by a
+// gesture gap. Rejected sub-threshold events must never reach Update/View, and
+// each deliberate burst produces only one generator step.
 func TestRawMouseBurstRemainsResponsive(t *testing.T) {
 	m := layoutModel()
 	wide, _, _, _ := layoutSizes(t, m)
@@ -1082,7 +1091,7 @@ func TestRawMouseBurstRemainsResponsive(t *testing.T) {
 	started := time.Now()
 	var redrawsAtKey int64
 	var fcurAtKey int
-	for range 3 {
+	for range wheelStepEvents {
 		fmt.Fprint(inW, "\x1b[<64;3;4M") // vertical wheel
 		fmt.Fprint(inW, "\x1b[<67;3;4M") // horizontal axis jitter
 		fmt.Fprint(inW, "\x1b[<35;4;4M") // cell motion with no button
@@ -1098,13 +1107,13 @@ func TestRawMouseBurstRemainsResponsive(t *testing.T) {
 		t.Fatal("keyboard input was starved after the first trackpad burst")
 	}
 
-	time.Sleep(2 * wheelQuantum)
-	for range 3 {
-		fmt.Fprint(inW, "\x1b[<64;3;4M") // same direction, newly re-armed quantum
+	time.Sleep(wheelGestureGap + 10*time.Millisecond)
+	for range wheelStepEvents {
+		fmt.Fprint(inW, "\x1b[<64;3;4M") // same direction, new gesture
 		fmt.Fprint(inW, "\x1b[<66;3;4M") // horizontal axis jitter
 		fmt.Fprint(inW, "\x1b[<35;4;4M") // cell motion
 	}
-	time.Sleep(2 * wheelQuantum)
+	time.Sleep(20 * time.Millisecond)
 	fmt.Fprint(inW, "q")
 	inW.Close()
 
@@ -1124,8 +1133,8 @@ func TestRawMouseBurstRemainsResponsive(t *testing.T) {
 	if got := views.Load(); got > 10 {
 		t.Fatalf("raw bursts produced %d views, want bounded redraw count <= 10", got)
 	}
-	t.Logf("18 raw mouse messages + keyboard + second burst: %d views, key after %d views, %s total",
-		views.Load(), redrawsAtKey, time.Since(started))
+	t.Logf("%d raw mouse messages + keyboard: %d views, key after %d views, %s total",
+		2*wheelStepEvents*3, views.Load(), redrawsAtKey, time.Since(started))
 }
 
 // ── usage identity · collapsible sections · contextual help (#198) ──────────
@@ -1167,39 +1176,55 @@ func hasDesc(descs []string, want string) bool {
 	return false
 }
 
-// TestUsageHeadingsNameEffectiveProfile locks the identity move: provider
-// group headings carry the effective account ("Codex <account>",
-// "Claude <account>") for every supported profile combination — including
-// mixed profiles — and the standalone auth equation is gone.
-func TestUsageHeadingsNameEffectiveProfile(t *testing.T) {
-	cases := []struct {
-		name          string
-		claude, codex string
-	}{
-		{"same owner", "Operator", "Operator"},
-		{"mixed owners", "Collaborator", "Operator"},
-		{"same collaborator", "Collaborator", "Collaborator"},
+// TestUsageProviderAccountsComeFromSnapshot locks the identity boundary:
+// headings name only providers, while account emails come from the broker's
+// redacted snapshot in deterministic order. Configured owner labels are never
+// rendered as provider identity.
+func TestUsageProviderAccountsComeFromSnapshot(t *testing.T) {
+	m := layoutModel()
+	m.vaults = []vault{{
+		ID: "p", Label: "custom vault", Claude: "Mum", Codex: "Victor + Alex",
+	}}
+	m.avail.accountsOK = true
+	m.avail.accounts = map[string][]vaultAccount{
+		"openai-codex": {
+			{Provider: "openai-codex", IdentityKey: "opaque-z", Email: "z@example.test"},
+			{Provider: "openai-codex", IdentityKey: "opaque-a", Email: "a@example.test"},
+		},
+		"anthropic": {
+			{Provider: "anthropic", IdentityKey: "do-not-render", Email: "claude@example.test"},
+		},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			m := layoutModel()
-			m.vaults = []vault{{ID: "p", Label: "p", Claude: tc.claude, Codex: tc.codex}}
-			lines := strings.Split(stripAnsi(m.usagePanel()), "\n")
-			codexHead := lineIndex(lines, "Codex ("+tc.codex+")")
-			claudeHead := lineIndex(lines, "Claude ("+tc.claude+")")
-			if codexHead < 0 || claudeHead < 0 {
-				t.Fatalf("provider headings must name the effective accounts:\n%s", strings.Join(lines, "\n"))
-			}
-			if trimmed := strings.TrimSpace(lines[codexHead]); trimmed != "Codex ("+tc.codex+")" {
-				t.Errorf("Codex heading must be a standalone group title, got %q", trimmed)
-			}
-			if lineIndex(lines, "auth ·") >= 0 || lineIndex(lines, "Claude "+tc.claude+" + ") >= 0 {
-				t.Errorf("the standalone auth equation must be gone:\n%s", strings.Join(lines, "\n"))
-			}
-			if lines[0] == "" || !strings.Contains(lines[0], "usage") || !strings.Contains(lines[0], "s · hide") {
-				t.Errorf("usage must open with its first-class title and local hide cue, got %q", lines[0])
-			}
-		})
+
+	panel := stripAnsi(m.usagePanel())
+	lines := strings.Split(panel, "\n")
+	for _, provider := range []string{"Codex", "Claude"} {
+		idx := lineIndex(lines, provider)
+		if idx < 0 || strings.TrimSpace(lines[idx]) != provider {
+			t.Fatalf("%s must be a provider-only heading:\n%s", provider, panel)
+		}
+	}
+	for _, forbidden := range []string{"Mum", "Victor + Alex", "opaque-z", "opaque-a", "do-not-render"} {
+		if strings.Contains(panel, forbidden) {
+			t.Errorf("rendered configured or opaque identity %q:\n%s", forbidden, panel)
+		}
+	}
+	a, z := strings.Index(panel, "a@example.test"), strings.Index(panel, "z@example.test")
+	if a < 0 || z < 0 || a > z {
+		t.Errorf("multiple snapshot emails must render deterministically: a=%d z=%d\n%s", a, z, panel)
+	}
+	if claude := strings.Index(panel, "claude@example.test"); claude < 0 {
+		t.Errorf("single snapshot email missing:\n%s", panel)
+	}
+	if used := strings.Index(panel, "% used"); used < z {
+		t.Errorf("usage rows must follow the provider/account list:\n%s", panel)
+	}
+
+	m.avail.accounts["anthropic"] = []vaultAccount{{
+		Provider: "anthropic", IdentityKey: "email:snapshot-identity@example.test",
+	}}
+	if panel := stripAnsi(m.usagePanel()); !strings.Contains(panel, "email:snapshot-identity@example.test") {
+		t.Errorf("snapshot identity must identify an account without an email:\n%s", panel)
 	}
 }
 
@@ -1227,9 +1252,8 @@ func TestUsageSwitchCue(t *testing.T) {
 	}
 }
 
-// TestUsageLoadingErrorStates: the loading, refreshing, unavailable, and
-// switch-failure states each keep the effective identity visible and replace
-// only the status — errors stay attached to the Usage section.
+// TestUsageLoadingErrorStates: loading, refreshing, and unavailable states keep
+// provider-only headings and explicit broker account status visible.
 func TestUsageLoadingErrorStates(t *testing.T) {
 	m := layoutModel()
 
@@ -1237,7 +1261,7 @@ func TestUsageLoadingErrorStates(t *testing.T) {
 	loading.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
 	loading.fetching = true
 	panel := stripAnsi(loading.usagePanel())
-	for _, want := range []string{"fetching usage…", "Codex (Operator)", "Claude (Operator)"} {
+	for _, want := range []string{"fetching usage…", "Codex", "Claude", "checking account…"} {
 		if !strings.Contains(panel, want) {
 			t.Errorf("loading: panel missing %q:\n%s", want, panel)
 		}
@@ -1248,8 +1272,13 @@ func TestUsageLoadingErrorStates(t *testing.T) {
 
 	refreshing := m
 	refreshing.fetching = true
+	refreshing.avail.accountsOK = true
+	refreshing.avail.accounts = map[string][]vaultAccount{
+		"openai-codex": {{Provider: "openai-codex", Email: "operator.codex@example.test"}},
+		"anthropic":    {{Provider: "anthropic", Email: "operator.claude@example.test"}},
+	}
 	panel = stripAnsi(refreshing.usagePanel())
-	for _, want := range []string{"refreshing…", "Codex (Operator)", "Claude (Operator)", "% used"} {
+	for _, want := range []string{"refreshing…", "Codex", "Claude", "operator.codex@example.test", "operator.claude@example.test", "% used"} {
 		if !strings.Contains(panel, want) {
 			t.Errorf("refreshing: panel missing %q:\n%s", want, panel)
 		}
@@ -1261,7 +1290,7 @@ func TestUsageLoadingErrorStates(t *testing.T) {
 	failed := m
 	failed.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
 	panel = stripAnsi(failed.usagePanel())
-	for _, want := range []string{"usage unavailable · press v to manage vaults", "Codex (Operator)", "Claude (Operator)"} {
+	for _, want := range []string{"usage unavailable · press v to manage vaults", "Codex", "Claude", "account status unavailable"} {
 		if !strings.Contains(panel, want) {
 			t.Errorf("unavailable: panel missing %q:\n%s", want, panel)
 		}
@@ -1341,8 +1370,7 @@ func TestSectionToggleCombinations(t *testing.T) {
 // visible actions never repeat in the compact line, hidden sections add their
 // recovery cue, refresh hides while a fetch is in flight or unusable, the
 // launch trio surfaces only when the generator's launch footer is off screen,
-// and the usage recovery cue never advertises a restore the narrow layout
-// would immediately shed.
+// and narrow terminals advertise the dedicated full-screen Usage view.
 func TestCompactHelpDerivation(t *testing.T) {
 	m := multiProfileModel()
 	wide, _, narrow, _ := layoutSizes(t, m)
@@ -1362,13 +1390,10 @@ func TestCompactHelpDerivation(t *testing.T) {
 
 	m = resize(t, m, narrow.w, narrow.h)
 	descs = shortDescs(m)
-	for _, d := range []string{"show routing", "switch vault", "refresh usage"} {
+	for _, d := range []string{"show routing", "show usage", "switch vault", "refresh usage"} {
 		if !hasDesc(descs, d) {
 			t.Errorf("narrow compact help missing %q: %v", d, descs)
 		}
-	}
-	if hasDesc(descs, "show usage") {
-		t.Errorf("narrow sheds usage by size, not by state — no show-usage cue: %v", descs)
 	}
 	ordered := strings.Join(descs, "|")
 	for _, optional := range []string{"switch vault", "refresh usage"} {
@@ -1449,13 +1474,16 @@ func TestFullHelpComplete(t *testing.T) {
 	}
 }
 
-// TestLongAccountLabelsWidthInvariant: over-long account names widen the
-// measured usage column (shifting the breakpoints) instead of overflowing or
-// truncating the identity, at every representative terminal size.
-func TestLongAccountLabelsWidthInvariant(t *testing.T) {
-	const longName = "Alexander-Maximilian-Extremely-Long-Name"
+// TestLongAccountEmailsWidthInvariant: a long broker-reported email widens the
+// measured usage column instead of overflowing or truncating the identity.
+func TestLongAccountEmailsWidthInvariant(t *testing.T) {
+	const longEmail = "alexander-maximilian-extremely-long-name@example.test"
 	m := layoutModel()
-	m.vaults = []vault{{ID: "long", Label: "long", Claude: longName, Codex: longName}}
+	m.avail.accountsOK = true
+	m.avail.accounts = map[string][]vaultAccount{
+		"openai-codex": {{Provider: "openai-codex", Email: longEmail}},
+		"anthropic":    {{Provider: "anthropic", Email: "claude@example.test"}},
+	}
 	wideW := m.genRowWidth() + routingMinW
 	sizes := []termSize{
 		{wideW + 30, 40},
@@ -1466,11 +1494,11 @@ func TestLongAccountLabelsWidthInvariant(t *testing.T) {
 	}
 	for _, s := range sizes {
 		m = resize(t, m, s.w, s.h)
-		label := fmt.Sprintf("long labels %dx%d", s.w, s.h)
+		label := fmt.Sprintf("long email %dx%d", s.w, s.h)
 		assertLayoutInvariants(t, m, label)
 		view := stripAnsi(m.View())
-		if strings.Contains(view, "% used") && !strings.Contains(view, "Codex ("+longName+")") {
-			t.Errorf("%s: visible usage must keep the full account identity:\n%s", label, view)
+		if strings.Contains(view, "% used") && !strings.Contains(view, longEmail) {
+			t.Errorf("%s: visible usage must keep the full snapshot email:\n%s", label, view)
 		}
 	}
 }
@@ -1513,8 +1541,8 @@ func TestSectionStatePreservation(t *testing.T) {
 	}
 	m.fetching = false
 	m.avail = multiProfileModel().avail
-	if panel := stripAnsi(m.usagePanel()); !strings.Contains(panel, "Claude (Collaborator)") {
-		t.Errorf("usage headings must follow the switched profile:\n%s", panel)
+	if panel := stripAnsi(m.usagePanel()); strings.Contains(panel, "Collaborator") {
+		t.Errorf("switching vaults must not expose configured owner labels:\n%s", panel)
 	}
 
 	nm, _ = m.Update(clikit.ActionsProposedMsg{})
@@ -1601,14 +1629,17 @@ func TestCollapseReallocation(t *testing.T) {
 		t.Fatalf("fixture: %dx%d must start collapsed", narrow.w, narrow.h)
 	}
 	n, _ = press(t, n, "s")
-	if n.mode() != modeMedium {
-		t.Fatalf("narrow: freeing the usage column must let routing return, mode = %d", n.mode())
+	if !n.showUsage || !n.usageShown() {
+		t.Fatal("narrow s must open the dedicated Usage view")
 	}
 	lines := strings.Split(stripAnsi(n.View()), "\n")
-	if lineIndex(lines, "routing", "p · hide") < 0 {
-		t.Errorf("narrow with usage hidden: the routing section must reappear:\n%s", strings.Join(lines, "\n"))
+	if lineIndex(lines, "usage", "s · hide") < 0 || lineIndex(lines, "routing", "p · hide") >= 0 {
+		t.Errorf("narrow s must show Usage, not Routing:\n%s", strings.Join(lines, "\n"))
 	}
-	assertLayoutInvariants(t, n, "narrow usage hidden")
+	n, _ = press(t, n, "s")
+	if n.showUsage || !n.hideUsage || n.usageShown() {
+		t.Fatal("second narrow s must return to the generator with Usage hidden")
+	}
 }
 
 // ── bottom-pinned section chrome · secondary separator · defaults cue ────────
@@ -1670,7 +1701,7 @@ func TestUsageCtrlRowPinned(t *testing.T) {
 		if ctrl != len(lines)-1 {
 			t.Errorf("%s: control row on line %d of %d, want the panel's last row:\n%s", label, ctrl, len(lines)-1, panel)
 		}
-		for _, needle := range []string{"Codex (", "Claude (", "% used"} {
+		for _, needle := range []string{"Codex", "Claude", "% used"} {
 			if idx := lineIndex(lines, needle); idx < 0 || idx > ctrl {
 				t.Errorf("%s: %q (line %d) must sit above the control row (%d)", label, needle, idx, ctrl)
 			}
@@ -1882,12 +1913,9 @@ func TestCreditExpiryUrgency(t *testing.T) {
 
 // ── loading skeleton · first-load bar fill ───────────────────────────────────
 
-// TestUsageSkeleton locks the pre-first-fetch Usage shape: provider/account
-// headings over generic placeholder window rows (real labels, empty bars, no
-// fabricated numbers), the loading status pinned to the panel's last row, the
-// stacked skeleton exactly as tall as the loaded column (no layout pop), the
-// frame invariants at wide and medium, and standalone runs (no usage command)
-// staying neutral.
+// TestUsageSkeleton locks the pre-first-fetch Usage shape: provider-only
+// headings, explicit checking state, generic placeholder window rows, and the
+// loading status pinned to the panel's last row.
 func TestUsageSkeleton(t *testing.T) {
 	loading := layoutModel()
 	loading.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
@@ -1895,10 +1923,13 @@ func TestUsageSkeleton(t *testing.T) {
 
 	panel := stripAnsi(loading.usagePanel())
 	lines := strings.Split(panel, "\n")
-	for _, h := range []string{"Codex (Operator)", "Claude (Operator)"} {
+	for _, h := range []string{"Codex", "Claude"} {
 		if lineIndex(lines, h) < 0 {
-			t.Errorf("skeleton must keep the provider identity %q:\n%s", h, panel)
+			t.Errorf("skeleton must keep the provider heading %q:\n%s", h, panel)
 		}
+	}
+	if got := strings.Count(panel, "checking account…"); got != 2 {
+		t.Errorf("skeleton must show one checking state per provider, got %d:\n%s", got, panel)
 	}
 	if got := strings.Count(panel, "··% used"); got != 5 {
 		t.Errorf("want Codex's two rows plus Claude's three including Fable (5 total), got %d:\n%s", got, panel)
@@ -2305,7 +2336,7 @@ func TestReconcileUsageFablePlaceholder(t *testing.T) {
 
 func TestFableSkeletonAndUnavailableStatusStayStable(t *testing.T) {
 	m := layoutModel()
-	skeleton := stripAnsi(m.skeletonBody(0, vault{Claude: "Operator", Codex: "Operator"}))
+	skeleton := stripAnsi(m.skeletonBody(0))
 	if strings.Count(skeleton, "7d fable") != 1 {
 		t.Fatalf("the pre-fetch skeleton must always reserve one Fable row:\n%s", skeleton)
 	}

--- a/pkgs/code-tui/main_test.go
+++ b/pkgs/code-tui/main_test.go
@@ -489,7 +489,7 @@ func layoutModel() model {
 			},
 		},
 		usageCmd:    "omp usage --json",
-		vaults:      []vault{{ID: "default", Label: "mine", Claude: "Alex", Codex: "Alex"}},
+		vaults:      []vault{{ID: "default", Label: "primary", Claude: "Operator", Codex: "Operator"}},
 		spin:        spinner.New(),
 		help:        help.New(),
 		glyphs:      glyphs,
@@ -1142,8 +1142,8 @@ func press(t *testing.T, m model, k string) (model, tea.Cmd) {
 func multiProfileModel() model {
 	m := layoutModel()
 	m.vaults = []vault{
-		{ID: "default", Label: "mine", Claude: "Alex", Codex: "Alex"},
-		{ID: "mum", Label: "mum", Claude: "Mum", Codex: "Alex"},
+		{ID: "default", Label: "primary", Claude: "Operator", Codex: "Operator"},
+		{ID: "secondary", Label: "secondary", Claude: "Collaborator", Codex: "Operator"},
 	}
 	return m
 }
@@ -1176,9 +1176,9 @@ func TestUsageHeadingsNameEffectiveProfile(t *testing.T) {
 		name          string
 		claude, codex string
 	}{
-		{"alex/alex", "Alex", "Alex"},
-		{"mum/alex mixed", "Mum", "Alex"},
-		{"mum/mum", "Mum", "Mum"},
+		{"same owner", "Operator", "Operator"},
+		{"mixed owners", "Collaborator", "Operator"},
+		{"same collaborator", "Collaborator", "Collaborator"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1237,7 +1237,7 @@ func TestUsageLoadingErrorStates(t *testing.T) {
 	loading.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
 	loading.fetching = true
 	panel := stripAnsi(loading.usagePanel())
-	for _, want := range []string{"fetching usage…", "Codex (Alex)", "Claude (Alex)"} {
+	for _, want := range []string{"fetching usage…", "Codex (Operator)", "Claude (Operator)"} {
 		if !strings.Contains(panel, want) {
 			t.Errorf("loading: panel missing %q:\n%s", want, panel)
 		}
@@ -1249,7 +1249,7 @@ func TestUsageLoadingErrorStates(t *testing.T) {
 	refreshing := m
 	refreshing.fetching = true
 	panel = stripAnsi(refreshing.usagePanel())
-	for _, want := range []string{"refreshing…", "Codex (Alex)", "Claude (Alex)", "% used"} {
+	for _, want := range []string{"refreshing…", "Codex (Operator)", "Claude (Operator)", "% used"} {
 		if !strings.Contains(panel, want) {
 			t.Errorf("refreshing: panel missing %q:\n%s", want, panel)
 		}
@@ -1261,7 +1261,7 @@ func TestUsageLoadingErrorStates(t *testing.T) {
 	failed := m
 	failed.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
 	panel = stripAnsi(failed.usagePanel())
-	for _, want := range []string{"usage unavailable · press v to manage vaults", "Codex (Alex)", "Claude (Alex)"} {
+	for _, want := range []string{"usage unavailable · press v to manage vaults", "Codex (Operator)", "Claude (Operator)"} {
 		if !strings.Contains(panel, want) {
 			t.Errorf("unavailable: panel missing %q:\n%s", want, panel)
 		}
@@ -1508,12 +1508,12 @@ func TestSectionStatePreservation(t *testing.T) {
 	if !m.hideUsage || !m.collapse {
 		t.Fatal("an auth switch mutated section visibility")
 	}
-	if m.activeVault().ID != "mum" {
+	if m.activeVault().ID != "secondary" {
 		t.Fatalf("vault switch did not advance the selection: %q", m.activeVault().ID)
 	}
 	m.fetching = false
 	m.avail = multiProfileModel().avail
-	if panel := stripAnsi(m.usagePanel()); !strings.Contains(panel, "Claude (Mum)") {
+	if panel := stripAnsi(m.usagePanel()); !strings.Contains(panel, "Claude (Collaborator)") {
 		t.Errorf("usage headings must follow the switched profile:\n%s", panel)
 	}
 
@@ -1895,13 +1895,13 @@ func TestUsageSkeleton(t *testing.T) {
 
 	panel := stripAnsi(loading.usagePanel())
 	lines := strings.Split(panel, "\n")
-	for _, h := range []string{"Codex (Alex)", "Claude (Alex)"} {
+	for _, h := range []string{"Codex (Operator)", "Claude (Operator)"} {
 		if lineIndex(lines, h) < 0 {
 			t.Errorf("skeleton must keep the provider identity %q:\n%s", h, panel)
 		}
 	}
-	if got := strings.Count(panel, "··% used"); got != 4 {
-		t.Errorf("want two placeholder rows per provider (4 total), got %d:\n%s", got, panel)
+	if got := strings.Count(panel, "··% used"); got != 5 {
+		t.Errorf("want Codex's two rows plus Claude's three including Fable (5 total), got %d:\n%s", got, panel)
 	}
 	if regexp.MustCompile(`\d+% used`).MatchString(panel) {
 		t.Errorf("the skeleton must not fabricate numeric values:\n%s", panel)
@@ -1912,8 +1912,10 @@ func TestUsageSkeleton(t *testing.T) {
 	if status := lineIndex(lines, "fetching usage…"); status != len(lines)-1 {
 		t.Errorf("the loading status must stay pinned to the panel's last row (%d of %d):\n%s", status, len(lines)-1, panel)
 	}
-	if sh, lh := lipgloss.Height(loading.usageColumn()), lipgloss.Height(layoutModel().usageColumn()); sh != lh {
-		t.Errorf("skeleton column is %d rows, loaded column %d — the first fetch would pop the layout", sh, lh)
+	loaded := layoutModel()
+	loaded.avail, _ = reconcileUsage(availability{bucket: map[string]string{}, reset: map[string]int64{}}, loaded.avail)
+	if sh, lh := lipgloss.Height(loading.usageColumn()), lipgloss.Height(loaded.usageColumn()); sh != lh {
+		t.Errorf("skeleton column is %d rows, reconciled loaded column %d — the first fetch would pop the layout", sh, lh)
 	}
 
 	wide, medium, _, _ := layoutSizes(t, loading)
@@ -2174,7 +2176,7 @@ func TestReconcileUsageFableRetention(t *testing.T) {
 		reset:  map[string]int64{"claude-fable": 9000},
 		wins: []usageWin{
 			{label: "Claude 5 Hour", pct: 10, secs: 3600, dur: 5 * 3600, prov: "anthropic"},
-			{label: "Claude 7 Day (Fable)", pct: 100, tier: "fable", secs: 9000, dur: 7 * day, prov: "anthropic"},
+			{label: "Claude 7 Day (Fable)", pct: 100, tier: "fable", secs: 9000, dur: 7 * day, prov: "anthropic", observed: 1_752_665_040},
 		},
 	}
 	next := availability{
@@ -2215,8 +2217,9 @@ func TestReconcileUsageFableRetention(t *testing.T) {
 	}
 	m := layoutModel()
 	row := stripAnsi(m.usageRow(fable))
-	if !strings.Contains(row, "7d fable") || !strings.Contains(row, "stale") {
-		t.Errorf("the retained row must carry a visible stale warning: %q", row)
+	wantCached := "cached " + time.Unix(fable.observed, 0).Local().Format("15:04")
+	if !strings.Contains(row, "7d fable") || !strings.Contains(row, wantCached) {
+		t.Errorf("the retained row must carry its cache timestamp %q: %q", wantCached, row)
 	}
 	if !strings.Contains(row, "100% used") {
 		t.Errorf("the retained row must show the last observed value: %q", row)
@@ -2297,6 +2300,31 @@ func TestReconcileUsageFablePlaceholder(t *testing.T) {
 	got2, _ := reconcileUsage(got, withFable)
 	if len(got2.wins) != 2 || got2.wins[1].stale || got2.wins[1].missing || got2.wins[1].pct != 7 {
 		t.Errorf("a present fable window must pass through fresh: %+v", got2.wins)
+	}
+}
+
+func TestFableSkeletonAndUnavailableStatusStayStable(t *testing.T) {
+	m := layoutModel()
+	skeleton := stripAnsi(m.skeletonBody(0, vault{Claude: "Operator", Codex: "Operator"}))
+	if strings.Count(skeleton, "7d fable") != 1 {
+		t.Fatalf("the pre-fetch skeleton must always reserve one Fable row:\n%s", skeleton)
+	}
+
+	missing := stripAnsi(m.usageRow(usageWin{
+		label: "Claude 7 Day (Fable)", tier: "fable", missing: true,
+	}))
+	tight := stripAnsi(m.usageRow(usageWin{
+		label: "Claude 7 Day (Fable)", tier: "fable", pct: 85,
+		secs: 2 * day, dur: 7 * day,
+	}))
+	missingAt := strings.Index(missing, "unavailable")
+	tightAt := strings.Index(tight, "tight")
+	if missingAt < 0 || tightAt < 0 {
+		t.Fatalf("status labels missing: unavailable=%q tight=%q", missing, tight)
+	}
+	if got, want := lipgloss.Width(missing[:missingAt]), lipgloss.Width(tight[:tightAt]); got != want {
+		t.Fatalf("Fable unavailable status column = %d, want the normal status column %d\nmissing: %s\ntight:   %s",
+			got, want, missing, tight)
 	}
 }
 

--- a/pkgs/code-tui/manager.go
+++ b/pkgs/code-tui/manager.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,6 +17,36 @@ import (
 type loginDoneMsg struct {
 	vault string
 	err   error
+}
+
+var errLoginCancelled = errors.New("login cancelled")
+
+// loginProcess keeps upstream stderr buffered until the handoff finishes. OMP
+// v17 can close readline while cancelling browser authentication, then print an
+// ERR_USE_AFTER_CLOSE stack trace and exit non-zero. Treat that exact failure
+// as cancellation; preserve every other diagnostic verbatim.
+type loginProcess struct {
+	cmd            *exec.Cmd
+	stderr         bytes.Buffer
+	terminalStderr io.Writer
+}
+
+func (p *loginProcess) SetStdin(r io.Reader)  { p.cmd.Stdin = r }
+func (p *loginProcess) SetStdout(w io.Writer) { p.cmd.Stdout = w }
+func (p *loginProcess) SetStderr(w io.Writer) { p.terminalStderr = w }
+
+func (p *loginProcess) Run() error {
+	p.cmd.Stderr = &p.stderr
+	err := p.cmd.Run()
+	diagnostic := p.stderr.String()
+	if strings.Contains(diagnostic, "ERR_USE_AFTER_CLOSE") &&
+		strings.Contains(diagnostic, "readline was closed") {
+		return errLoginCancelled
+	}
+	if p.terminalStderr != nil && diagnostic != "" {
+		_, _ = io.WriteString(p.terminalStderr, diagnostic)
+	}
+	return err
 }
 
 // loginCmd suspends Bubble Tea and runs the plain-OMP login handoff for the
@@ -30,7 +63,8 @@ func (m model) loginCmd(i int, provider string) tea.Cmd {
 		raw = "omp"
 	}
 	c := exec.Command(raw, loginArgv(v.Profile, provider)...)
-	return tea.ExecProcess(c, func(err error) tea.Msg {
+	p := &loginProcess{cmd: c}
+	return tea.Exec(p, func(err error) tea.Msg {
 		return loginDoneMsg{vault: v.ID, err: err}
 	})
 }
@@ -38,6 +72,9 @@ func (m model) loginCmd(i int, provider string) tea.Cmd {
 // updateManager handles keys while the vault manager is open. Every action is
 // scoped to the manager; the generator keys stay inert until it closes.
 func (m model) updateManager(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.loginRunning {
+		return m, nil
+	}
 	switch msg.String() {
 	case "ctrl+c":
 		return m, tea.Quit
@@ -75,9 +112,13 @@ func (m model) updateManager(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.fetching = m.usageCmd != ""
 		return m, fetchAllCmd(m.usageCmd, m.vaults)
 	case "c":
-		return m, m.loginCmd(m.mgrCursor, "anthropic")
+		cmd := m.loginCmd(m.mgrCursor, "anthropic")
+		m.loginRunning = cmd != nil
+		return m, cmd
 	case "o":
-		return m, m.loginCmd(m.mgrCursor, "openai-codex")
+		cmd := m.loginCmd(m.mgrCursor, "openai-codex")
+		m.loginRunning = cmd != nil
+		return m, cmd
 	}
 	return m, nil
 }
@@ -154,56 +195,75 @@ func (m model) managerRow(i, w int) string {
 		labelCol = stHead.Render(labelPlain)
 	}
 
-	usage := m.vaultUsageSummary(i)
-	left := cursor + mark + labelCol
-	// cursor(2)+mark(2)+label(10)=14; identity column is a fixed 26 cells.
-	const identW = 26
-	ident := stDim.Render(pad("Claude "+v.Claude+" · Codex "+v.Codex, identW))
-	if 14+2+identW+2+lipgloss.Width(usage) <= w {
-		return left + "  " + ident + "  " + usage
+	head := cursor + mark + labelCol
+	if w < 38 {
+		return head
 	}
-	return left + "  " + usage
+	indent := strings.Repeat(" ", 4)
+	return strings.Join([]string{
+		head,
+		indent + m.vaultProviderLine(i, "anthropic"),
+		indent + m.vaultProviderLine(i, "openai-codex"),
+	}, "\n")
 }
 
 // vaultUsageSummary is the manager's compact per-provider usage cell: the
 // highest-used window per provider, or a state word (disabled/loading/offline)
 // when there is no usable data.
-func (m model) vaultUsageSummary(i int) string {
+func (m model) vaultProviderLine(i int, provider string) string {
+	v := m.vaults[i]
+	line := providerHeading(provider, v)
 	if !m.isEnabled(i) {
-		return stDim.Render("disabled")
+		return line + stDim.Render(" · disabled")
 	}
-	a, ok := m.vaultUsage[m.vaults[i].ID]
-	if !ok {
-		return stDim.Render("loading…")
+	a, loaded := m.vaultUsage[v.ID]
+	if !loaded {
+		return line + stDim.Render(" · checking account…")
 	}
-	if !a.ok {
-		return stWarn.Render("offline")
+	if !a.accountsOK {
+		line += stWarn.Render(" · account status unavailable")
+	} else if accounts := a.accounts[provider]; len(accounts) == 0 {
+		line += stBrk.Render(" · not authenticated")
+	} else {
+		identities := make([]string, 0, len(accounts))
+		for _, account := range accounts {
+			identity := account.Email
+			if identity == "" {
+				identity = account.IdentityKey
+			}
+			if identity != "" {
+				identities = append(identities, identity)
+			}
+		}
+		switch {
+		case len(identities) == 0:
+			line += stDim.Render(" · authenticated")
+		case len(identities) == 1:
+			line += stDim.Render(" · " + identities[0])
+		default:
+			line += stDim.Render(" · " + strings.Join(identities, ", "))
+		}
+		if a.accountsStale {
+			line += stWarn.Render(" · identity cached")
+		}
 	}
-	var parts []string
-	if pct, has := maxPct(a, "openai-codex"); has {
-		parts = append(parts, provCell("Codex", pct))
-	}
-	if pct, has := maxPct(a, "anthropic"); has {
-		parts = append(parts, provCell("Claude", pct))
-	}
-	if len(parts) == 0 {
-		return stDim.Render("no usage")
-	}
-	return strings.Join(parts, stDim.Render(" · "))
-}
 
-// provCell renders one provider's compact "<name> NN%" figure, tinted to warn
-// as the window fills so a hot vault is legible at a glance.
-func provCell(name string, pct int) string {
-	fig := fmt.Sprintf("%s %d%%", name, pct)
-	switch {
-	case pct >= 100:
-		return stBrk.Render(fig)
-	case pct >= 80:
-		return stWarn.Render(fig)
-	default:
-		return stDim.Render(fig)
+	if pct, ok := maxPct(a, provider); ok {
+		usage := fmt.Sprintf(" · %d%% used", pct)
+		switch {
+		case pct >= 100:
+			line += stBrk.Render(usage + " · maxed")
+		case pct >= 80:
+			line += stWarn.Render(usage + " · tight")
+		default:
+			line += stDim.Render(usage)
+		}
+	} else if !a.ok {
+		line += stWarn.Render(" · usage unavailable")
+	} else {
+		line += stDim.Render(" · usage unavailable")
 	}
+	return line
 }
 
 // maxPct returns the highest used percentage across a provider's windows, and
@@ -226,13 +286,20 @@ func maxPct(a availability, prov string) (int, bool) {
 // the labelled form would not fit the width, keeping the footer within bounds.
 func (m model) managerControls(w int) string {
 	cue := func(k, label string) string { return stKey.Render(k) + stDim.Render(" "+label) }
-	full := strings.Join([]string{
-		cue("↑↓", "move"), cue("⏎", "activate"), cue("space", "enable"),
-		cue("r", "refresh"), cue("c", "claude login"), cue("o", "codex login"),
-		cue("v", "close"),
+	v := m.activeVault()
+	if m.mgrCursor >= 0 && m.mgrCursor < len(m.vaults) {
+		v = m.vaults[m.mgrCursor]
+	}
+	navigation := strings.Join([]string{
+		cue("↑↓", "move"), cue("⏎", "select"), cue("space", "enable"),
+		cue("r", "refresh"), cue("v", "close"),
 	}, stDim.Render("  ·  "))
-	if lipgloss.Width(full) <= w {
-		return full
+	login := strings.Join([]string{
+		cue("c", "login Claude for "+v.Claude+" in profile "+v.Profile),
+		cue("o", "login Codex for "+v.Codex+" in profile "+v.Profile),
+	}, stDim.Render("  ·  "))
+	if lipgloss.Width(navigation) <= w && lipgloss.Width(login) <= w {
+		return navigation + "\n" + login
 	}
 	return strings.Join([]string{
 		stKey.Render("↑↓"), stKey.Render("⏎"), stKey.Render("spc"),

--- a/pkgs/code-tui/manager.go
+++ b/pkgs/code-tui/manager.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	clikit "cli-kit"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -229,8 +230,7 @@ func (m model) updateManager(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.managerInput, m.managerText, m.vaultErr = "rename", m.vaults[m.mgrCursor].Label, ""
 		return m, nil
 	case "r":
-		m.fetching = m.usageCmd != ""
-		return m, fetchAllCmd(m.usageCmd, m.vaults)
+		return m, m.startUsageFetchAll(m.vaults)
 	case "c":
 		cmd := m.loginCmd(m.mgrCursor, "anthropic")
 		m.loginRunning = cmd != nil
@@ -243,14 +243,19 @@ func (m model) updateManager(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// afterSelectionChange re-fetches the detailed panel's usage when the active
-// vault moved, so closing the manager lands on the right identity's data.
+// afterSelectionChange restores cached usage without fetching. An uncached
+// vault joins an existing startup prefetch when present, otherwise it starts
+// one request and keeps its own loading state.
 func (m *model) afterSelectionChange(prev string) tea.Cmd {
 	if m.selected == prev || m.usageCmd == "" {
 		return nil
 	}
-	m.fetching = true
-	return fetchUsageCmd(m.usageCmd, m.activeVault())
+	id := m.activeVault().ID
+	if _, cached := m.vaultUsage[id]; cached || m.vaultFetching[id] {
+		m.fetching = m.vaultFetching[id]
+		return nil
+	}
+	return m.startUsageFetch(m.activeVault())
 }
 
 // managerUsageModel scopes the existing full Usage layout to the highlighted
@@ -263,10 +268,12 @@ func (m model) managerUsageModel() model {
 	}
 	v := m.vaults[m.mgrCursor]
 	scoped.selected = v.ID
+	scoped.fetching = m.vaultFetching[v.ID]
+	scoped.nextRefresh = m.vaultUsageNext[v.ID]
+	scoped.usageStale = m.vaultUsageStale[v.ID]
 	if a, ok := m.vaultUsage[v.ID]; ok {
 		scoped.avail = a
 		scoped.hadUsage = a.ok
-		scoped.fetching = false
 	} else if v.ID != m.selected {
 		scoped.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
 		scoped.hadUsage = false
@@ -301,31 +308,27 @@ func (m model) managerView() string {
 	body := strings.Join(lines, "\n")
 
 	controls := padLeft(m.managerControls(m.w-gut), gut)
-	rule := stDim.Render(strings.Repeat("─", m.w))
 	usage := ""
 	if !m.hideUsage {
 		usage = m.managerUsagePanel()
 	}
-	maxUsageH := m.h - lipgloss.Height(controls) - lipgloss.Height(rule) - topGap - 2
+	controlsFooterH := lipgloss.Height(clikit.SeparatedSections(m.w, controls))
+	maxUsageH := m.h - controlsFooterH - 1 - topGap - 2 // one Usage boundary plus a usable body
 	if maxUsageH < 0 {
 		maxUsageH = 0
 	}
 	if lipgloss.Height(usage) > maxUsageH {
 		usage = lipgloss.NewStyle().MaxHeight(maxUsageH).Render(usage)
 	}
-	ch := m.h - lipgloss.Height(usage) - lipgloss.Height(controls) - lipgloss.Height(rule)
+	footer := clikit.SeparatedSections(m.w, usage, controls)
+	ch := m.h - lipgloss.Height(footer)
 	if ch < 1 {
 		ch = 1
 	}
 	placed := lipgloss.Place(m.w, ch, lipgloss.Left, lipgloss.Top,
 		strings.Repeat("\n", topGap)+body)
-	parts := []string{placed}
-	if usage != "" {
-		parts = append(parts, usage)
-	}
-	parts = append(parts, rule, controls)
 	return lipgloss.NewStyle().MaxWidth(m.w).MaxHeight(m.h).Render(
-		lipgloss.JoinVertical(lipgloss.Left, parts...))
+		lipgloss.JoinVertical(lipgloss.Left, placed, footer))
 }
 
 // managerRow renders only list state and immutable profile context. Provider
@@ -376,58 +379,48 @@ func (m model) managerRow(i, w int) string {
 // managerControls wraps labelled actions without dropping create, rename, Usage
 // visibility, or provider/profile login context.
 func (m model) managerControls(w int) string {
-	cue := func(k, label string) string { return stKey.Render(k) + stDim.Render(" "+label) }
 	v := m.activeVault()
 	if m.mgrCursor >= 0 && m.mgrCursor < len(m.vaults) {
 		v = m.vaults[m.mgrCursor]
 	}
 	if m.managerInput != "" {
-		return cue("⏎", "save") + stDim.Render("  ·  ") + cue("esc", "cancel")
+		return clikit.WrapHelp(m.help, w, []clikit.HelpItem{
+			{Key: "⏎", Description: "save"},
+			{Key: "esc", Description: "cancel"},
+		})
 	}
 	usageAction := "hide usage"
 	if m.hideUsage {
 		usageAction = "show usage"
 	}
-	items := []string{
-		cue("↑↓", "move"),
-		cue("⏎", "select"),
-		cue("space", "enable"),
-		cue("n", "new vault"),
-		cue("e", "rename"),
-		cue("s", usageAction),
-		cue("r", "refresh"),
-		cue("v", "close"),
-		cue("o", "login Codex in profile "+v.Profile),
-		cue("c", "login Claude in profile "+v.Profile),
+	items := []clikit.HelpItem{
+		{Key: "↑↓", Description: "move"},
+		{Key: "⏎", Description: "select"},
+		{Key: "space", Description: "enable"},
+		{Key: "n", Description: "new vault"},
+		{Key: "e", Description: "rename"},
+		{Key: "s", Description: usageAction},
+		{Key: "r", Description: "refresh"},
+		{Key: "v", Description: "close"},
+		{Key: "o", Description: "login Codex in profile " + v.Profile},
+		{Key: "c", Description: "login Claude in profile " + v.Profile},
 	}
 	for _, item := range items {
-		if lipgloss.Width(item) > w {
-			items = []string{
-				cue("↑↓", "move"), cue("⏎", "select"), cue("spc", "enable"),
-				cue("n", "new"), cue("e", "rename"), cue("r", "refresh"), cue("v", "close"),
-				cue("o", "Codex login"), cue("c", "Claude login"),
+		if lipgloss.Width(clikit.WrapHelp(m.help, 0, []clikit.HelpItem{item})) > w {
+			items = []clikit.HelpItem{
+				{Key: "↑↓", Description: "move"},
+				{Key: "⏎", Description: "select"},
+				{Key: "spc", Description: "enable"},
+				{Key: "n", Description: "new"},
+				{Key: "e", Description: "rename"},
+				{Key: "s", Description: usageAction},
+				{Key: "r", Description: "refresh"},
+				{Key: "v", Description: "close"},
+				{Key: "o", Description: "Codex login"},
+				{Key: "c", Description: "Claude login"},
 			}
 			break
 		}
 	}
-
-	sep := stDim.Render("  ·  ")
-	rows := []string{}
-	row := ""
-	for _, item := range items {
-		next := item
-		if row != "" {
-			next = row + sep + item
-		}
-		if row != "" && lipgloss.Width(next) > w {
-			rows = append(rows, row)
-			row = item
-		} else {
-			row = next
-		}
-	}
-	if row != "" {
-		rows = append(rows, row)
-	}
-	return strings.Join(rows, "\n")
+	return clikit.WrapHelp(m.help, w, items)
 }

--- a/pkgs/code-tui/manager.go
+++ b/pkgs/code-tui/manager.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -69,11 +68,97 @@ func (m model) loginCmd(i int, provider string) tea.Cmd {
 	})
 }
 
+const managerEditDisabled = "vault editing is disabled: no writable machine-local manifest (CODE_AUTH_VAULTS JSON overrides are read-only)"
+
+func syntheticFallback(vaults []vault) bool {
+	return len(vaults) == 1 && vaults[0].ID == "default" &&
+		vaults[0].BrokerURL == "" && vaults[0].TokenFile == "" && vaults[0].SnapshotCache == ""
+}
+
+// commitManagerInput writes the complete validated manifest before changing
+// model state. Create derives metadata only; rename changes only Label.
+func (m *model) commitManagerInput() error {
+	switch m.managerInput {
+	case "create":
+		existing := m.vaults
+		replacingFallback := syntheticFallback(existing)
+		if replacingFallback {
+			existing = nil
+		}
+		v, err := newVault(m.managerText, existing)
+		if err != nil {
+			return err
+		}
+		next := append(append([]vault(nil), existing...), v)
+		if err := writeVaultManifest(m.vaultManifest, next); err != nil {
+			return err
+		}
+		m.vaults = next
+		m.mgrCursor = len(next) - 1
+		if replacingFallback {
+			m.selected = v.ID
+			m.disabled = map[string]bool{}
+		}
+		if m.vaultUsage == nil {
+			m.vaultUsage = map[string]availability{}
+		}
+	case "rename":
+		if m.mgrCursor < 0 || m.mgrCursor >= len(m.vaults) {
+			return errors.New("no vault is selected")
+		}
+		label := strings.TrimSpace(m.managerText)
+		if label == "" {
+			return errors.New("vault name cannot be empty")
+		}
+		next := append([]vault(nil), m.vaults...)
+		next[m.mgrCursor].Label = label
+		if err := writeVaultManifest(m.vaultManifest, next); err != nil {
+			return err
+		}
+		m.vaults = next
+	default:
+		return errors.New("no vault edit is active")
+	}
+	m.managerInput = ""
+	m.managerText = ""
+	return nil
+}
+
+func (m model) updateManagerInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		m.managerInput, m.managerText, m.vaultErr = "", "", ""
+	case "enter":
+		if err := m.commitManagerInput(); err != nil {
+			m.vaultErr = err.Error()
+		} else {
+			m.vaultErr = ""
+		}
+	case " ":
+		m.managerText += " "
+	case "backspace", "ctrl+h":
+		runes := []rune(m.managerText)
+		if len(runes) > 0 {
+			m.managerText = string(runes[:len(runes)-1])
+		}
+	default:
+		if msg.Type == tea.KeyRunes {
+			m.managerText += string(msg.Runes)
+		}
+	}
+	return m, nil
+}
+
 // updateManager handles keys while the vault manager is open. Every action is
 // scoped to the manager; the generator keys stay inert until it closes.
 func (m model) updateManager(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.loginRunning {
 		return m, nil
+	}
+	if m.managerInput != "" {
+		return m.updateManagerInput(msg)
 	}
 	switch msg.String() {
 	case "ctrl+c":
@@ -92,6 +177,23 @@ func (m model) updateManager(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.mgrCursor++
 		}
 		return m, nil
+	case "s":
+		m.hideUsage = !m.hideUsage
+		m.showUsage = false
+		m.relayout()
+		return m, nil
+	case "a":
+		prev := m.selected
+		changed, err := m.cycleVault()
+		if err != nil {
+			m.vaultErr = err.Error()
+			return m, nil
+		}
+		if changed {
+			m.mgrCursor = m.activeIndex()
+			m.vaultErr = ""
+		}
+		return m, m.afterSelectionChange(prev)
 	case "enter":
 		prev := m.selected
 		if _, err := m.activateVault(m.mgrCursor); err != nil {
@@ -108,6 +210,24 @@ func (m model) updateManager(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.vaultErr = ""
 		return m, m.afterSelectionChange(prev)
+	case "n":
+		if m.vaultManifest == "" {
+			m.vaultErr = managerEditDisabled
+			return m, nil
+		}
+		m.managerInput, m.managerText, m.vaultErr = "create", "", ""
+		return m, nil
+	case "e":
+		if m.vaultManifest == "" {
+			m.vaultErr = managerEditDisabled
+			return m, nil
+		}
+		if m.mgrCursor < 0 || m.mgrCursor >= len(m.vaults) {
+			m.vaultErr = "no vault is selected"
+			return m, nil
+		}
+		m.managerInput, m.managerText, m.vaultErr = "rename", m.vaults[m.mgrCursor].Label, ""
+		return m, nil
 	case "r":
 		m.fetching = m.usageCmd != ""
 		return m, fetchAllCmd(m.usageCmd, m.vaults)
@@ -133,15 +253,47 @@ func (m *model) afterSelectionChange(prev string) tea.Cmd {
 	return fetchUsageCmd(m.usageCmd, m.activeVault())
 }
 
-// managerView renders the collapsed-by-default full-screen vault manager: a
-// row per vault with its enabled/selected/offline state and compact
-// per-provider usage, over a pinned control rule. Overflow is clipped to the
-// terminal bounds, so the footer can never be pushed off-screen.
+// managerUsageModel scopes the existing full Usage layout to the highlighted
+// vault without selecting it. Cached snapshots stay per-vault; an uncached row
+// uses the same loading shape as the generator's Usage panel.
+func (m model) managerUsageModel() model {
+	scoped := m
+	if m.mgrCursor < 0 || m.mgrCursor >= len(m.vaults) {
+		return scoped
+	}
+	v := m.vaults[m.mgrCursor]
+	scoped.selected = v.ID
+	if a, ok := m.vaultUsage[v.ID]; ok {
+		scoped.avail = a
+		scoped.hadUsage = a.ok
+		scoped.fetching = false
+	} else if v.ID != m.selected {
+		scoped.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
+		scoped.hadUsage = false
+	}
+	return scoped
+}
+
+func (m model) managerUsagePanel() string {
+	scoped := m.managerUsageModel()
+	return scoped.usagePanel()
+}
+
+// managerView renders a compact vault list above the same full Usage footer
+// used by the generator. The highlighted row owns that detailed panel; inline
+// account and aggregate usage duplication is deliberately absent.
 func (m model) managerView() string {
 	title := padLeft(m.pill("vaults")+"  "+stCue.Render("isolated auth vaults · the trusted profile stays shared"), gut)
 	lines := []string{title, ""}
 	for i := range m.vaults {
 		lines = append(lines, padLeft(m.managerRow(i, m.w-gut), gut))
+	}
+	if m.managerInput != "" {
+		label := "New vault name"
+		if m.managerInput == "rename" {
+			label = "Rename vault"
+		}
+		lines = append(lines, "", padLeft(stKey.Render(label+": ")+m.managerText+"█", gut))
 	}
 	if m.vaultErr != "" {
 		lines = append(lines, "", padLeft(stBrk.Render(m.vaultErr), gut))
@@ -150,18 +302,34 @@ func (m model) managerView() string {
 
 	controls := padLeft(m.managerControls(m.w-gut), gut)
 	rule := stDim.Render(strings.Repeat("─", m.w))
-	ch := m.h - lipgloss.Height(controls) - lipgloss.Height(rule) - topGap
+	usage := ""
+	if !m.hideUsage {
+		usage = m.managerUsagePanel()
+	}
+	maxUsageH := m.h - lipgloss.Height(controls) - lipgloss.Height(rule) - topGap - 2
+	if maxUsageH < 0 {
+		maxUsageH = 0
+	}
+	if lipgloss.Height(usage) > maxUsageH {
+		usage = lipgloss.NewStyle().MaxHeight(maxUsageH).Render(usage)
+	}
+	ch := m.h - lipgloss.Height(usage) - lipgloss.Height(controls) - lipgloss.Height(rule)
 	if ch < 1 {
 		ch = 1
 	}
 	placed := lipgloss.Place(m.w, ch, lipgloss.Left, lipgloss.Top,
 		strings.Repeat("\n", topGap)+body)
+	parts := []string{placed}
+	if usage != "" {
+		parts = append(parts, usage)
+	}
+	parts = append(parts, rule, controls)
 	return lipgloss.NewStyle().MaxWidth(m.w).MaxHeight(m.h).Render(
-		lipgloss.JoinVertical(lipgloss.Left, placed, rule, controls))
+		lipgloss.JoinVertical(lipgloss.Left, parts...))
 }
 
-// managerRow renders one vault: cursor + state mark + label, then (when the
-// width seats it) the backing accounts, then the compact usage summary.
+// managerRow renders only list state and immutable profile context. Provider
+// accounts and usage live once in the highlighted row's full Usage panel.
 func (m model) managerRow(i, w int) string {
 	v := m.vaults[i]
 	acc := m.accent()
@@ -179,7 +347,6 @@ func (m model) managerRow(i, w int) string {
 	default:
 		mark = stDim.Render("○ ")
 	}
-
 	label := v.Label
 	if label == "" {
 		label = v.ID
@@ -194,115 +361,73 @@ func (m model) managerRow(i, w int) string {
 	default:
 		labelCol = stHead.Render(labelPlain)
 	}
-
-	head := cursor + mark + labelCol
-	if w < 38 {
-		return head
+	row := cursor + mark + labelCol
+	profile := stDim.Render("  profile " + v.Profile)
+	if lipgloss.Width(row)+lipgloss.Width(profile) <= w {
+		row += profile
 	}
-	indent := strings.Repeat(" ", 4)
-	return strings.Join([]string{
-		head,
-		indent + m.vaultProviderLine(i, "anthropic"),
-		indent + m.vaultProviderLine(i, "openai-codex"),
-	}, "\n")
+	if disabled := stDim.Render("  disabled"); !m.isEnabled(i) &&
+		lipgloss.Width(row)+lipgloss.Width(disabled) <= w {
+		row += disabled
+	}
+	return row
 }
 
-// vaultUsageSummary is the manager's compact per-provider usage cell: the
-// highest-used window per provider, or a state word (disabled/loading/offline)
-// when there is no usable data.
-func (m model) vaultProviderLine(i int, provider string) string {
-	v := m.vaults[i]
-	line := providerHeading(provider, v)
-	if !m.isEnabled(i) {
-		return line + stDim.Render(" · disabled")
-	}
-	a, loaded := m.vaultUsage[v.ID]
-	if !loaded {
-		return line + stDim.Render(" · checking account…")
-	}
-	if !a.accountsOK {
-		line += stWarn.Render(" · account status unavailable")
-	} else if accounts := a.accounts[provider]; len(accounts) == 0 {
-		line += stBrk.Render(" · not authenticated")
-	} else {
-		identities := make([]string, 0, len(accounts))
-		for _, account := range accounts {
-			identity := account.Email
-			if identity == "" {
-				identity = account.IdentityKey
-			}
-			if identity != "" {
-				identities = append(identities, identity)
-			}
-		}
-		switch {
-		case len(identities) == 0:
-			line += stDim.Render(" · authenticated")
-		case len(identities) == 1:
-			line += stDim.Render(" · " + identities[0])
-		default:
-			line += stDim.Render(" · " + strings.Join(identities, ", "))
-		}
-		if a.accountsStale {
-			line += stWarn.Render(" · identity cached")
-		}
-	}
-
-	if pct, ok := maxPct(a, provider); ok {
-		usage := fmt.Sprintf(" · %d%% used", pct)
-		switch {
-		case pct >= 100:
-			line += stBrk.Render(usage + " · maxed")
-		case pct >= 80:
-			line += stWarn.Render(usage + " · tight")
-		default:
-			line += stDim.Render(usage)
-		}
-	} else if !a.ok {
-		line += stWarn.Render(" · usage unavailable")
-	} else {
-		line += stDim.Render(" · usage unavailable")
-	}
-	return line
-}
-
-// maxPct returns the highest used percentage across a provider's windows, and
-// whether the provider was present in the payload at all.
-func maxPct(a availability, prov string) (int, bool) {
-	max, has := 0, false
-	for _, w := range a.wins {
-		if w.prov != prov {
-			continue
-		}
-		has = true
-		if w.pct > max {
-			max = w.pct
-		}
-	}
-	return max, has
-}
-
-// managerControls is the manager's bottom cue row. It drops to keys-only when
-// the labelled form would not fit the width, keeping the footer within bounds.
+// managerControls wraps labelled actions without dropping create, rename, Usage
+// visibility, or provider/profile login context.
 func (m model) managerControls(w int) string {
 	cue := func(k, label string) string { return stKey.Render(k) + stDim.Render(" "+label) }
 	v := m.activeVault()
 	if m.mgrCursor >= 0 && m.mgrCursor < len(m.vaults) {
 		v = m.vaults[m.mgrCursor]
 	}
-	navigation := strings.Join([]string{
-		cue("↑↓", "move"), cue("⏎", "select"), cue("space", "enable"),
-		cue("r", "refresh"), cue("v", "close"),
-	}, stDim.Render("  ·  "))
-	login := strings.Join([]string{
-		cue("c", "login Claude for "+v.Claude+" in profile "+v.Profile),
-		cue("o", "login Codex for "+v.Codex+" in profile "+v.Profile),
-	}, stDim.Render("  ·  "))
-	if lipgloss.Width(navigation) <= w && lipgloss.Width(login) <= w {
-		return navigation + "\n" + login
+	if m.managerInput != "" {
+		return cue("⏎", "save") + stDim.Render("  ·  ") + cue("esc", "cancel")
 	}
-	return strings.Join([]string{
-		stKey.Render("↑↓"), stKey.Render("⏎"), stKey.Render("spc"),
-		stKey.Render("r"), stKey.Render("c"), stKey.Render("o"), stKey.Render("v"),
-	}, stDim.Render(" "))
+	usageAction := "hide usage"
+	if m.hideUsage {
+		usageAction = "show usage"
+	}
+	items := []string{
+		cue("↑↓", "move"),
+		cue("⏎", "select"),
+		cue("space", "enable"),
+		cue("n", "new vault"),
+		cue("e", "rename"),
+		cue("s", usageAction),
+		cue("r", "refresh"),
+		cue("v", "close"),
+		cue("o", "login Codex in profile "+v.Profile),
+		cue("c", "login Claude in profile "+v.Profile),
+	}
+	for _, item := range items {
+		if lipgloss.Width(item) > w {
+			items = []string{
+				cue("↑↓", "move"), cue("⏎", "select"), cue("spc", "enable"),
+				cue("n", "new"), cue("e", "rename"), cue("r", "refresh"), cue("v", "close"),
+				cue("o", "Codex login"), cue("c", "Claude login"),
+			}
+			break
+		}
+	}
+
+	sep := stDim.Render("  ·  ")
+	rows := []string{}
+	row := ""
+	for _, item := range items {
+		next := item
+		if row != "" {
+			next = row + sep + item
+		}
+		if row != "" && lipgloss.Width(next) > w {
+			rows = append(rows, row)
+			row = item
+		} else {
+			row = next
+		}
+	}
+	if row != "" {
+		rows = append(rows, row)
+	}
+	return strings.Join(rows, "\n")
 }

--- a/pkgs/code-tui/manager_test.go
+++ b/pkgs/code-tui/manager_test.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -8,23 +13,30 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// managerModel is a three-vault model with the manager open and a
-// representative spread of per-vault usage states: mine has data, mum is
-// offline (a fetch returned unavailable), victor has never been fetched.
+// managerModel is a three-vault model with representative loaded, unavailable,
+// and never-fetched states.
 func managerModel() model {
 	m := layoutModel()
 	m.vaults = []vault{
-		{ID: "mine", Label: "mine", Profile: "default", Claude: "Alex", Codex: "Alex"},
-		{ID: "mum", Label: "mum", Profile: "mum", Claude: "Mum", Codex: "Alex"},
-		{ID: "victor", Label: "victor", Profile: "victor", Claude: "Victor", Codex: "Alex"},
+		{ID: "primary", Label: "primary", Profile: "default", Claude: "Operator", Codex: "Operator"},
+		{ID: "secondary", Label: "secondary", Profile: "secondary", Claude: "Collaborator", Codex: "Operator"},
+		{ID: "tertiary", Label: "tertiary", Profile: "tertiary", Claude: "Reviewer", Codex: "Operator"},
 	}
-	m.selected = "mine"
+	m.selected = "primary"
 	m.disabled = map[string]bool{}
 	m.vaultUsage = map[string]availability{
-		"mine": {ok: true, bucket: map[string]string{}, reset: map[string]int64{}, wins: []usageWin{
-			{prov: "openai-codex", pct: 12}, {prov: "anthropic", pct: 55},
-		}},
-		"mum": {ok: false, bucket: map[string]string{}, reset: map[string]int64{}},
+		"primary": {
+			ok: true, bucket: map[string]string{}, reset: map[string]int64{},
+			accountsOK: true, accounts: map[string][]vaultAccount{
+				"anthropic":    {{Provider: "anthropic", Email: "operator.claude@example.test"}},
+				"openai-codex": {{Provider: "openai-codex", Email: "operator.codex@example.test"}},
+			},
+			wins: []usageWin{{prov: "openai-codex", pct: 12}, {prov: "anthropic", pct: 55}},
+		},
+		"secondary": {
+			ok: false, bucket: map[string]string{}, reset: map[string]int64{},
+			accountsOK: true, accounts: map[string][]vaultAccount{},
+		},
 	}
 	m.manager = true
 	return m
@@ -102,9 +114,9 @@ func TestManagerCursorNavigation(t *testing.T) {
 
 func TestManagerActivateSelectsCursoredVault(t *testing.T) {
 	m := managerModel()
-	m.mgrCursor = 1 // mum
+	m.mgrCursor = 1 // secondary
 	m, cmd := sendKey(t, m, "enter")
-	if m.selected != "mum" {
+	if m.selected != "secondary" {
 		t.Fatalf("enter must activate the cursored vault, selected=%q", m.selected)
 	}
 	if cmd == nil {
@@ -113,32 +125,32 @@ func TestManagerActivateSelectsCursoredVault(t *testing.T) {
 }
 func TestManagerActivateEnablesDisabledVault(t *testing.T) {
 	m := managerModel()
-	m.disabled = map[string]bool{"victor": true}
-	m.mgrCursor = 2 // victor (disabled)
+	m.disabled = map[string]bool{"tertiary": true}
+	m.mgrCursor = 2 // tertiary (disabled)
 	m, _ = sendKey(t, m, "enter")
-	if m.disabled["victor"] {
+	if m.disabled["tertiary"] {
 		t.Fatal("activating a disabled vault must enable it")
 	}
-	if m.selected != "victor" {
-		t.Fatalf("enter must select victor, selected=%q", m.selected)
+	if m.selected != "tertiary" {
+		t.Fatalf("enter must select tertiary, selected=%q", m.selected)
 	}
 }
 
-func TestManagerSpaceTogglesEnabledAndProtectsMine(t *testing.T) {
+func TestManagerSpaceTogglesEnabledAndProtectsFallback(t *testing.T) {
 	m := managerModel()
-	m.mgrCursor = 1 // mum
+	m.mgrCursor = 1 // secondary
 	m, _ = sendKey(t, m, "space")
-	if !m.disabled["mum"] {
+	if !m.disabled["secondary"] {
 		t.Fatal("space must disable an enabled vault")
 	}
 	m, _ = sendKey(t, m, "space")
-	if m.disabled["mum"] {
+	if m.disabled["secondary"] {
 		t.Fatal("space must re-enable a disabled vault")
 	}
 
-	m.mgrCursor = 0 // mine — the protected fallback
+	m.mgrCursor = 0 // protected fallback
 	m, _ = sendKey(t, m, "space")
-	if m.disabled["mine"] || !m.isEnabled(0) {
+	if m.disabled["primary"] || !m.isEnabled(0) {
 		t.Fatal("the fallback vault must never be disabled from the manager")
 	}
 }
@@ -165,9 +177,84 @@ func TestManagerLoginKeysReturnCommands(t *testing.T) {
 	}
 }
 
+func TestManagerDoesNotQueueLoginHandoffs(t *testing.T) {
+	m := managerModel()
+	m.mgrCursor = 1
+	m, first := sendKey(t, m, "c")
+	if first == nil || !m.loginRunning {
+		t.Fatal("the first login must start and mark the handoff active")
+	}
+	m, second := sendKey(t, m, "o")
+	if second != nil {
+		t.Fatal("a second login key must be ignored while a handoff is active")
+	}
+
+	nm, _ := m.Update(loginDoneMsg{vault: "secondary", err: errLoginCancelled})
+	m = nm.(model)
+	if m.loginRunning {
+		t.Fatal("login completion must release the handoff guard")
+	}
+	if m.vaultErr != "" {
+		t.Fatalf("cancellation must not render as a failure: %q", m.vaultErr)
+	}
+
+	m.loginRunning = true
+	nm, _ = m.Update(loginDoneMsg{vault: "secondary", err: errors.New("provider failed")})
+	m = nm.(model)
+	if m.vaultErr != "login failed: provider failed" {
+		t.Fatalf("real login error was not preserved: %q", m.vaultErr)
+	}
+}
+
+func TestLoginProcessSuppressesReadlineCancellation(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestLoginProcessHelper$")
+	cmd.Env = append(os.Environ(), "CODE_LOGIN_HELPER=cancel")
+	p := &loginProcess{cmd: cmd}
+	p.SetStdin(strings.NewReader(""))
+	p.SetStdout(io.Discard)
+	var visible bytes.Buffer
+	p.SetStderr(&visible)
+
+	if err := p.Run(); !errors.Is(err, errLoginCancelled) {
+		t.Fatalf("cancel error = %v, want errLoginCancelled", err)
+	}
+	if visible.Len() != 0 {
+		t.Fatalf("readline cancellation leaked to terminal: %q", visible.String())
+	}
+}
+
+func TestLoginProcessPreservesRealDiagnostics(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestLoginProcessHelper$")
+	cmd.Env = append(os.Environ(), "CODE_LOGIN_HELPER=error")
+	p := &loginProcess{cmd: cmd}
+	p.SetStdin(strings.NewReader(""))
+	p.SetStdout(io.Discard)
+	var visible bytes.Buffer
+	p.SetStderr(&visible)
+
+	err := p.Run()
+	if err == nil || errors.Is(err, errLoginCancelled) {
+		t.Fatalf("real process error was misclassified: %v", err)
+	}
+	if visible.String() != "provider login failed\n" {
+		t.Fatalf("real diagnostic = %q", visible.String())
+	}
+}
+
+func TestLoginProcessHelper(t *testing.T) {
+	switch os.Getenv("CODE_LOGIN_HELPER") {
+	case "cancel":
+		_, _ = os.Stderr.WriteString("error: readline was closed\n code: \"ERR_USE_AFTER_CLOSE\"\n")
+		os.Exit(1)
+	case "error":
+		_, _ = os.Stderr.WriteString("provider login failed\n")
+		os.Exit(1)
+	}
+}
+
 func TestManagerStaleUsageScopedByVault(t *testing.T) {
 	m := managerModel()
-	m.selected = "mine"
+	m.selected = "primary"
 	m.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}
 	m.hadUsage = false
 
@@ -175,7 +262,7 @@ func TestManagerStaleUsageScopedByVault(t *testing.T) {
 
 	// A reply for a non-active vault is stored under that vault and never
 	// touches the detailed panel or produces a command.
-	nm, cmd := m.Update(usageMsg{vault: "mum", avail: ok})
+	nm, cmd := m.Update(usageMsg{vault: "secondary", avail: ok})
 	m = nm.(model)
 	if cmd != nil {
 		t.Fatal("a non-active vault reply must not drive the detailed panel's fill")
@@ -183,23 +270,55 @@ func TestManagerStaleUsageScopedByVault(t *testing.T) {
 	if m.avail.ok {
 		t.Fatal("a non-active vault reply must not populate the detailed panel")
 	}
-	if !m.vaultUsage["mum"].ok {
+	if !m.vaultUsage["secondary"].ok {
 		t.Fatal("a reply must be stored under its own vault for the manager")
 	}
 
 	// A reply for the active vault does update the detailed panel.
-	nm, _ = m.Update(usageMsg{vault: "mine", avail: ok})
+	nm, _ = m.Update(usageMsg{vault: "primary", avail: ok})
 	m = nm.(model)
 	if !m.avail.ok {
 		t.Fatal("the active vault's reply must populate the detailed panel")
 	}
 }
 
+func TestManagerRetainsCachedFablePerVault(t *testing.T) {
+	m := managerModel()
+	m.selected = "primary"
+	first := availability{
+		ok: true, bucket: map[string]string{"claude-fable": "ok"}, reset: map[string]int64{},
+		wins: []usageWin{
+			{label: "Claude 5 Hour", prov: "anthropic", pct: 20},
+			{label: "Claude 7 Day (Fable)", prov: "anthropic", tier: "fable", pct: 45, observed: 1_752_665_040},
+		},
+	}
+	nm, _ := m.Update(usageMsg{vault: "secondary", avail: first})
+	m = nm.(model)
+	second := availability{
+		ok: true, bucket: map[string]string{"claude-fable": "ok"}, reset: map[string]int64{},
+		wins: []usageWin{{label: "Claude 5 Hour", prov: "anthropic", pct: 30}},
+	}
+	nm, _ = m.Update(usageMsg{vault: "secondary", avail: second})
+	m = nm.(model)
+
+	found := false
+	for _, w := range m.vaultUsage["secondary"].wins {
+		if w.tier == "fable" {
+			found = true
+			if !w.stale || w.pct != 45 || w.observed != 1_752_665_040 {
+				t.Fatalf("per-vault Fable cache was not retained: %+v", w)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("per-vault Fable cache disappeared after an omitted refresh")
+	}
+}
+
 func TestManagerRenderingWithinBounds(t *testing.T) {
 	base := managerModel()
-	// A fourth, disabled vault so one row exercises every state at once:
-	// mine has usage, mum is offline, victor is loading, guest is disabled.
-	base.vaults = append(base.vaults, vault{ID: "guest", Label: "guest", Profile: "guest", Claude: "Guest", Codex: "Alex"})
+	// A fourth, disabled vault so one row exercises every state at once.
+	base.vaults = append(base.vaults, vault{ID: "guest", Label: "guest", Profile: "guest", Claude: "Guest", Codex: "Operator"})
 	base.disabled = map[string]bool{"guest": true}
 	wideW := base.genRowWidth() + routingMinW
 	for _, s := range []termSize{{wideW + 20, 40}, {72, 30}, {50, 20}} {
@@ -211,14 +330,20 @@ func TestManagerRenderingWithinBounds(t *testing.T) {
 			}
 		}
 		plain := stripAnsi(view)
-		for _, want := range []string{"vaults", "mine", "mum", "victor", "guest", "offline", "loading", "disabled"} {
+		for _, want := range []string{
+			"vaults", "primary", "secondary", "tertiary", "guest",
+			"not authenticated", "checking account", "disabled",
+		} {
 			if !strings.Contains(plain, want) {
 				t.Errorf("width %d: manager view missing %q:\n%s", s.w, want, plain)
 			}
 		}
-		// The active vault's compact per-provider usage renders.
-		if !strings.Contains(plain, "Codex 12%") || !strings.Contains(plain, "Claude 55%") {
-			t.Errorf("width %d: manager missing active vault usage:\n%s", s.w, plain)
+		// Wide layouts keep verified identity and usage on the same owner row;
+		// narrow layouts deliberately clip detail without overflowing.
+		if s.w >= 100 &&
+			(!strings.Contains(plain, "Claude (Operator) · operator.claude@example.test · 55% used") ||
+				!strings.Contains(plain, "Codex (Operator) · operator.codex@example.test · 12% used")) {
+			t.Errorf("width %d: manager did not bind usage to an account owner:\n%s", s.w, plain)
 		}
 		// A control cue row is always present.
 		if !strings.Contains(plain, "v") {
@@ -230,11 +355,12 @@ func TestManagerRenderingWithinBounds(t *testing.T) {
 func TestManagerControlsCompactWhenNarrow(t *testing.T) {
 	m := managerModel()
 	wide := m.managerControls(200)
-	if !strings.Contains(stripAnsi(wide), "activate") {
-		t.Fatalf("wide controls must be labelled: %q", stripAnsi(wide))
+	if !strings.Contains(stripAnsi(wide), "select") ||
+		!strings.Contains(stripAnsi(wide), "login Claude for Operator in profile default") {
+		t.Fatalf("wide controls must name the target account and profile: %q", stripAnsi(wide))
 	}
 	narrow := m.managerControls(20)
-	if strings.Contains(stripAnsi(narrow), "activate") {
+	if strings.Contains(stripAnsi(narrow), "login") {
 		t.Fatalf("narrow controls must drop to keys only: %q", stripAnsi(narrow))
 	}
 	if lipgloss.Width(narrow) > 20 {

--- a/pkgs/code-tui/manager_test.go
+++ b/pkgs/code-tui/manager_test.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -531,7 +531,6 @@ func TestManagerEditCancelAndRawJSONDisabled(t *testing.T) {
 		t.Fatalf("raw JSON editing error is unclear: %q", m.vaultErr)
 	}
 }
-
 
 func TestManagerControlsWrapLabelsWhenNarrow(t *testing.T) {
 	m := managerModel()

--- a/pkgs/code-tui/manager_test.go
+++ b/pkgs/code-tui/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -41,6 +42,12 @@ func managerModel() model {
 			accountsOK: true, accounts: map[string][]vaultAccount{},
 		},
 	}
+	m.vaultUsageNext = map[string]time.Time{
+		"primary":   time.Now().Add(refreshEvery),
+		"secondary": time.Now().Add(refreshEvery),
+	}
+	m.vaultUsageStale = map[string]bool{}
+	m.vaultFetching = map[string]bool{"tertiary": true}
 	m.manager = true
 	return m
 }
@@ -93,8 +100,8 @@ func TestManagerOpenAndClose(t *testing.T) {
 	if !opened.manager {
 		t.Fatal("v must open the manager")
 	}
-	if cmd == nil {
-		t.Fatal("opening the manager must kick off a whole-list refresh")
+	if cmd != nil {
+		t.Fatal("opening the manager must reuse the startup cache without refreshing")
 	}
 	if opened.mgrCursor != opened.activeIndex() {
 		t.Fatalf("manager must open on the active vault, cursor=%d active=%d", opened.mgrCursor, opened.activeIndex())
@@ -163,8 +170,11 @@ func TestManagerActivateSelectsCursoredVault(t *testing.T) {
 	if m.selected != "secondary" {
 		t.Fatalf("enter must activate the cursored vault, selected=%q", m.selected)
 	}
-	if cmd == nil {
-		t.Fatal("activating a different vault must refresh the detailed panel")
+	if cmd != nil {
+		t.Fatal("activating a cached vault must not refetch its usage")
+	}
+	if got := m.avail.accountsOK; !got {
+		t.Fatal("activating a cached vault must restore its detailed Usage immediately")
 	}
 }
 func TestManagerActivateEnablesDisabledVault(t *testing.T) {
@@ -207,6 +217,11 @@ func TestManagerRefreshAllRefetches(t *testing.T) {
 	}
 	if !m.fetching {
 		t.Fatal("r must mark the active fetch in flight")
+	}
+	for _, v := range m.vaults {
+		if !m.vaultFetching[v.ID] {
+			t.Errorf("r did not mark %q usage fetch in flight", v.ID)
+		}
 	}
 }
 
@@ -408,9 +423,9 @@ func TestManagerProviderAccountsAndOrdering(t *testing.T) {
 	if panel := stripAnsi(m.managerUsagePanel()); strings.Count(panel, "not authenticated") != 2 {
 		t.Errorf("zero-account providers must remain explicit:\n%s", panel)
 	}
-	m.mgrCursor, m.fetching = 2, true
+	m.mgrCursor = 2
 	if panel := stripAnsi(m.managerUsagePanel()); strings.Count(panel, "checking account…") != 2 {
-		t.Errorf("unloaded providers must remain explicit:\n%s", panel)
+		t.Errorf("an in-flight unloaded vault must remain explicit:\n%s", panel)
 	}
 }
 
@@ -453,6 +468,45 @@ func TestManagerRenderingWithinBounds(t *testing.T) {
 		if !strings.Contains(plain, "v") {
 			t.Errorf("width %d: manager missing control cues:\n%s", s.w, plain)
 		}
+	}
+}
+
+func TestManagerSectionsAndFooterShareVisualContract(t *testing.T) {
+	m := resize(t, managerModel(), 100, 40)
+	lines := strings.Split(stripAnsi(m.View()), "\n")
+	rule := strings.Repeat("─", m.w)
+	usage := lineIndex(lines, "usage", "primary")
+	controls := lineIndex(lines, "↑↓", "move")
+	if usage <= 0 || lines[usage-1] != rule {
+		t.Fatalf("visible Usage must have a full-width top boundary:\n%s", strings.Join(lines, "\n"))
+	}
+	if controls <= 0 || lines[controls-1] != rule {
+		t.Fatalf("manager controls must have a full-width top boundary:\n%s", strings.Join(lines, "\n"))
+	}
+	if got := strings.Count(strings.Join(lines, "\n"), rule); got != 2 {
+		t.Fatalf("visible Usage + controls must render exactly two boundaries, got %d", got)
+	}
+
+	styledCue := m.help.Styles.ShortKey.Inline(true).Render("↑↓") + " " +
+		m.help.Styles.ShortDesc.Inline(true).Render("move")
+	if !strings.Contains(m.managerControls(100), styledCue) {
+		t.Fatal("manager controls do not use the shared Help key/description styles")
+	}
+
+	m.hideUsage = true
+	hidden := strings.Split(stripAnsi(m.View()), "\n")
+	if lineIndex(hidden, "usage", "primary") >= 0 {
+		t.Fatalf("hidden Usage remained visible:\n%s", strings.Join(hidden, "\n"))
+	}
+	hiddenControls := lineIndex(hidden, "↑↓", "move")
+	if hiddenControls <= 0 || hidden[hiddenControls-1] != rule {
+		t.Fatalf("hidden Usage left controls without their boundary:\n%s", strings.Join(hidden, "\n"))
+	}
+	if got := strings.Count(strings.Join(hidden, "\n"), rule); got != 1 {
+		t.Fatalf("hidden Usage must remove its boundary, got %d total boundaries", got)
+	}
+	if controls := stripAnsi(m.managerControls(20)); !strings.Contains(controls, "show usage") {
+		t.Fatalf("compact manager controls lost dynamic Usage state: %q", controls)
 	}
 }
 func TestManagerCreatePromptCommitAndExistingEntryInvariant(t *testing.T) {

--- a/pkgs/code-tui/manager_test.go
+++ b/pkgs/code-tui/manager_test.go
@@ -3,8 +3,11 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"reflect"
 	"os/exec"
 	"strings"
 	"testing"
@@ -65,6 +68,22 @@ func sendKey(t *testing.T, m model, k string) (model, tea.Cmd) {
 	return nm.(model), cmd
 }
 
+func editableManagerModel(t *testing.T) model {
+	t.Helper()
+	m := managerModel()
+	root := t.TempDir()
+	m.vaultManifest = filepath.Join(root, "config", "vaults.json")
+	m.vaultState = filepath.Join(root, "state", "selection.json")
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "xdg-state"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "xdg-cache"))
+	for i := range m.vaults {
+		m.vaults[i].BrokerURL = fmt.Sprintf("http://127.0.0.1:%d", 43000+i)
+		m.vaults[i].TokenFile = filepath.Join(root, "tokens", m.vaults[i].ID)
+		m.vaults[i].SnapshotCache = filepath.Join(root, "cache", m.vaults[i].ID)
+	}
+	return m
+}
+
 func TestManagerOpenAndClose(t *testing.T) {
 	m := multiProfileModel()
 	wide, _, _, _ := layoutSizes(t, m)
@@ -109,6 +128,31 @@ func TestManagerCursorNavigation(t *testing.T) {
 	}
 	if m.mgrCursor != 0 {
 		t.Fatalf("up must clamp at the first vault, got %d", m.mgrCursor)
+	}
+}
+
+func TestManagerHighlightScopesUsageAndSharesVisibility(t *testing.T) {
+	m := managerModel()
+	m.hideUsage = false
+	if panel := stripAnsi(m.managerUsagePanel()); !strings.Contains(panel, "usage") || !strings.Contains(panel, "primary") ||
+		!strings.Contains(panel, "operator.codex@example.test") {
+		t.Fatalf("initial manager Usage is not scoped to highlighted primary:\n%s", panel)
+	}
+	m, _ = sendKey(t, m, "down")
+	if m.selected != "primary" {
+		t.Fatalf("arrow navigation must not select the highlighted vault, selected=%q", m.selected)
+	}
+	if panel := stripAnsi(m.managerUsagePanel()); !strings.Contains(panel, "usage") || !strings.Contains(panel, "secondary") ||
+		strings.Contains(panel, "operator.codex@example.test") {
+		t.Fatalf("arrow navigation did not retarget detailed Usage:\n%s", panel)
+	}
+	m, _ = sendKey(t, m, "s")
+	if !m.hideUsage {
+		t.Fatal("manager s must hide the shared Usage state")
+	}
+	m, _ = sendKey(t, m, "s")
+	if m.hideUsage {
+		t.Fatal("manager s must restore the shared Usage state")
 	}
 }
 
@@ -315,6 +359,61 @@ func TestManagerRetainsCachedFablePerVault(t *testing.T) {
 	}
 }
 
+func TestManagerProviderAccountsAndOrdering(t *testing.T) {
+	m := managerModel()
+	m.vaults[0].Claude = "Mum"
+	m.vaults[0].Codex = "Victor + Alex"
+	m.vaultUsage["primary"] = availability{
+		ok: true, accountsOK: true,
+		bucket: map[string]string{}, reset: map[string]int64{},
+		accounts: map[string][]vaultAccount{
+			"openai-codex": {
+				{Provider: "openai-codex", IdentityKey: "opaque-z", Email: "z@example.test"},
+				{Provider: "openai-codex", IdentityKey: "opaque-a", Email: "a@example.test"},
+			},
+			"anthropic": {
+				{Provider: "anthropic", IdentityKey: "opaque-claude", Email: "claude@example.test"},
+			},
+		},
+		wins: []usageWin{{prov: "openai-codex", pct: 12}, {prov: "anthropic", pct: 55}},
+	}
+
+	panel := stripAnsi(m.managerUsagePanel())
+	codex := strings.Index(panel, "Codex")
+	a := strings.Index(panel, "a@example.test")
+	z := strings.Index(panel, "z@example.test")
+	codexUsage := strings.Index(panel, "12% used")
+	claude := strings.Index(panel, "Claude")
+	claudeEmail := strings.Index(panel, "claude@example.test")
+	claudeUsage := strings.Index(panel, "55% used")
+	if !(codex >= 0 && codex < a && a < z && z < codexUsage &&
+		codexUsage < claude && claude < claudeEmail && claudeEmail < claudeUsage) {
+		t.Fatalf("manager detail must reuse full Usage with Codex first and sorted accounts:\n%s", panel)
+	}
+	for _, forbidden := range []string{"Mum", "Victor + Alex", "opaque-z", "opaque-a", "opaque-claude"} {
+		if strings.Contains(panel, forbidden) {
+			t.Errorf("manager rendered configured or opaque identity %q:\n%s", forbidden, panel)
+		}
+	}
+	if row := stripAnsi(m.managerRow(0, 200)); strings.Contains(row, "% used") ||
+		strings.Contains(row, "@example.test") || strings.Contains(row, "Codex") || strings.Contains(row, "Claude") {
+		t.Fatalf("vault row duplicated provider/account/usage detail: %q", row)
+	}
+	// Rendering sorts a copied email list and must not mutate the snapshot.
+	if got := m.vaultUsage["primary"].accounts["openai-codex"][0].Email; got != "z@example.test" {
+		t.Errorf("rendering mutated account snapshot order: first email = %q", got)
+	}
+
+	m.mgrCursor = 1
+	if panel := stripAnsi(m.managerUsagePanel()); strings.Count(panel, "not authenticated") != 2 {
+		t.Errorf("zero-account providers must remain explicit:\n%s", panel)
+	}
+	m.mgrCursor, m.fetching = 2, true
+	if panel := stripAnsi(m.managerUsagePanel()); strings.Count(panel, "checking account…") != 2 {
+		t.Errorf("unloaded providers must remain explicit:\n%s", panel)
+	}
+}
+
 func TestManagerRenderingWithinBounds(t *testing.T) {
 	base := managerModel()
 	// A fourth, disabled vault so one row exercises every state at once.
@@ -331,19 +430,24 @@ func TestManagerRenderingWithinBounds(t *testing.T) {
 		}
 		plain := stripAnsi(view)
 		for _, want := range []string{
-			"vaults", "primary", "secondary", "tertiary", "guest",
-			"not authenticated", "checking account", "disabled",
+			"vaults", "primary", "secondary", "tertiary", "usage",
 		} {
 			if !strings.Contains(plain, want) {
 				t.Errorf("width %d: manager view missing %q:\n%s", s.w, want, plain)
 			}
 		}
-		// Wide layouts keep verified identity and usage on the same owner row;
-		// narrow layouts deliberately clip detail without overflowing.
+
+		if s.h >= 30 && (!strings.Contains(plain, "guest") || !strings.Contains(plain, "disabled")) {
+			t.Errorf("width %d: manager view must show the disabled vault when height seats it:\n%s", s.w, plain)
+		}
+		// The highlighted vault's full Usage footer owns provider identity and
+		// aggregate usage; list rows never duplicate it.
 		if s.w >= 100 &&
-			(!strings.Contains(plain, "Claude (Operator) · operator.claude@example.test · 55% used") ||
-				!strings.Contains(plain, "Codex (Operator) · operator.codex@example.test · 12% used")) {
-			t.Errorf("width %d: manager did not bind usage to an account owner:\n%s", s.w, plain)
+			(!strings.Contains(plain, "operator.claude@example.test") ||
+				!strings.Contains(plain, "55% used") ||
+				!strings.Contains(plain, "operator.codex@example.test") ||
+				!strings.Contains(plain, "12% used")) {
+			t.Errorf("width %d: manager did not render provider accounts and usage:\n%s", s.w, plain)
 		}
 		// A control cue row is always present.
 		if !strings.Contains(plain, "v") {
@@ -351,19 +455,106 @@ func TestManagerRenderingWithinBounds(t *testing.T) {
 		}
 	}
 }
+func TestManagerCreatePromptCommitAndExistingEntryInvariant(t *testing.T) {
+	m := editableManagerModel(t)
+	before := append([]vault(nil), m.vaults...)
+	credential := filepath.Join(t.TempDir(), "auth.db")
+	if err := os.WriteFile(credential, []byte("credential sentinel"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
-func TestManagerControlsCompactWhenNarrow(t *testing.T) {
+	m, _ = sendKey(t, m, "n")
+	if m.managerInput != "create" || !strings.Contains(stripAnsi(m.managerView()), "New vault name:") {
+		t.Fatalf("n must open an explicit create prompt:\n%s", stripAnsi(m.managerView()))
+	}
+	m, _ = sendKey(t, m, "Team")
+	m, _ = sendKey(t, m, "space")
+	m, _ = sendKey(t, m, "Vault")
+	m, _ = sendKey(t, m, "enter")
+	if m.managerInput != "" || len(m.vaults) != len(before)+1 {
+		t.Fatalf("create did not commit: mode=%q vaults=%#v", m.managerInput, m.vaults)
+	}
+	if !reflect.DeepEqual(m.vaults[:len(before)], before) {
+		t.Fatalf("create changed an existing entry:\nbefore=%#v\nafter=%#v", before, m.vaults[:len(before)])
+	}
+	created := m.vaults[len(before)]
+	if created.ID != "team-vault" || created.Profile != "team-vault" || created.Label != "Team Vault" {
+		t.Fatalf("created vault identity = %+v", created)
+	}
+	if data, err := os.ReadFile(credential); err != nil || string(data) != "credential sentinel" {
+		t.Fatalf("create touched credential sentinel: data=%q err=%v", data, err)
+	}
+}
+
+func TestManagerRenameChangesOnlyLabel(t *testing.T) {
+	m := editableManagerModel(t)
+	m.mgrCursor = 1
+	before := m.vaults[1]
+	selected, disabled := m.selected, map[string]bool{"tertiary": true}
+	m.disabled = disabled
+	m, _ = sendKey(t, m, "e")
+	if m.managerInput != "rename" || m.managerText != before.Label ||
+		!strings.Contains(stripAnsi(m.managerView()), "Rename vault:") {
+		t.Fatalf("e must open a prefilled rename prompt: mode=%q text=%q", m.managerInput, m.managerText)
+	}
+	for range len([]rune(before.Label)) {
+		m, _ = sendKey(t, m, "backspace")
+	}
+	m, _ = sendKey(t, m, "Display")
+	m, _ = sendKey(t, m, "space")
+	m, _ = sendKey(t, m, "Only")
+	m, _ = sendKey(t, m, "enter")
+	after := m.vaults[1]
+	want := before
+	want.Label = "Display Only"
+	if !reflect.DeepEqual(after, want) {
+		t.Fatalf("rename changed immutable fields:\nwant=%+v\ngot=%+v", want, after)
+	}
+	if m.selected != selected || !reflect.DeepEqual(m.disabled, disabled) {
+		t.Fatalf("rename changed selection state: selected=%q disabled=%v", m.selected, m.disabled)
+	}
+}
+
+func TestManagerEditCancelAndRawJSONDisabled(t *testing.T) {
+	m := editableManagerModel(t)
+	m, _ = sendKey(t, m, "n")
+	m, _ = sendKey(t, m, "discard me")
+	m, _ = sendKey(t, m, "esc")
+	if m.managerInput != "" || len(m.vaults) != 3 {
+		t.Fatalf("Esc must cancel edit without changing vaults: mode=%q count=%d", m.managerInput, len(m.vaults))
+	}
+
+	m.vaultManifest = ""
+	m, _ = sendKey(t, m, "n")
+	if m.managerInput != "" || !strings.Contains(m.vaultErr, "editing is disabled") ||
+		!strings.Contains(m.vaultErr, "CODE_AUTH_VAULTS") {
+		t.Fatalf("raw JSON editing error is unclear: %q", m.vaultErr)
+	}
+}
+
+
+func TestManagerControlsWrapLabelsWhenNarrow(t *testing.T) {
 	m := managerModel()
 	wide := m.managerControls(200)
 	if !strings.Contains(stripAnsi(wide), "select") ||
-		!strings.Contains(stripAnsi(wide), "login Claude for Operator in profile default") {
-		t.Fatalf("wide controls must name the target account and profile: %q", stripAnsi(wide))
+		!strings.Contains(stripAnsi(wide), "login Claude in profile default") {
+		t.Fatalf("wide controls must name only the provider and immutable profile: %q", stripAnsi(wide))
+	}
+	for _, forbidden := range []string{"Operator", "Collaborator", "Reviewer"} {
+		if strings.Contains(stripAnsi(wide), forbidden) {
+			t.Fatalf("login cue leaked configured owner alias %q: %q", forbidden, stripAnsi(wide))
+		}
 	}
 	narrow := m.managerControls(20)
-	if strings.Contains(stripAnsi(narrow), "login") {
-		t.Fatalf("narrow controls must drop to keys only: %q", stripAnsi(narrow))
+	plain := stripAnsi(narrow)
+	for _, label := range []string{"move", "select", "enable", "new", "rename", "refresh", "close", "Claude login", "Codex login"} {
+		if !strings.Contains(plain, label) {
+			t.Fatalf("narrow controls dropped %q: %q", label, plain)
+		}
 	}
-	if lipgloss.Width(narrow) > 20 {
-		t.Fatalf("narrow controls must fit the width, got %d", lipgloss.Width(narrow))
+	for _, line := range strings.Split(narrow, "\n") {
+		if lipgloss.Width(line) > 20 {
+			t.Fatalf("narrow control line must fit the width, got %d: %q", lipgloss.Width(line), stripAnsi(line))
+		}
 	}
 }

--- a/pkgs/code-tui/vault.go
+++ b/pkgs/code-tui/vault.go
@@ -3,12 +3,16 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -102,15 +106,34 @@ func loadVaultAccounts(v vault) (map[string][]vaultAccount, error) {
 	return accounts, nil
 }
 
-var validVaultID = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+var (
+	validVaultID      = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+	validVaultProfile = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	unsafeVaultSlug   = regexp.MustCompile(`[^a-z0-9]+`)
+	repeatedVaultDash = regexp.MustCompile(`-+`)
+)
 
-// loadVaults resolves the machine-local manifest. CODE_AUTH_VAULTS remains an
-// explicit JSON override for tests and one-shot runs; otherwise the file path
-// override or the XDG config default is read. Missing files retain the neutral
-// single-vault fallback.
-func loadVaults(raw, path string) []vault {
+func machineLocalPath(path string) bool {
+	path = filepath.Clean(path)
+	if !filepath.IsAbs(path) || path == "/nix/store" || strings.HasPrefix(path, "/nix/store/") {
+		return false
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		if rel, err := filepath.Rel(cwd, path); err == nil &&
+			rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return false
+		}
+	}
+	return true
+}
+
+// resolveVaults retains the resolved manifest path alongside its entries.
+// Raw JSON is deliberately read-only: it has no safe machine-local persistence
+// target. A missing file at a resolved XDG path remains editable and starts
+// with the neutral fallback until the first manifest write.
+func resolveVaults(raw, path string) ([]vault, string) {
 	if raw != "" {
-		return parseVaults(raw)
+		return parseVaults(raw), ""
 	}
 	if path == "" {
 		configHome := os.Getenv("XDG_CONFIG_HOME")
@@ -128,7 +151,15 @@ func loadVaults(raw, path string) []vault {
 			raw = string(data)
 		}
 	}
-	return parseVaults(raw)
+	if !machineLocalPath(path) {
+		path = ""
+	}
+	return parseVaults(raw), path
+}
+
+func loadVaults(raw, path string) []vault {
+	vaults, _ := resolveVaults(raw, path)
+	return vaults
 }
 
 // parseVaults decodes the non-secret CODE_AUTH_VAULTS JSON manifest, dropping
@@ -170,6 +201,181 @@ func parseVaults(raw string) []vault {
 		return []vault{{ID: "default", Label: "default", Profile: "default", Claude: "current", Codex: "current"}}
 	}
 	return valid
+}
+
+// vaultSlug converts a display name into the safe stable base used for both
+// the manifest id and backing OMP profile. Uniquification is deterministic
+// against the current manifest and never renames an existing entry.
+func vaultSlug(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = unsafeVaultSlug.ReplaceAllString(s, "-")
+	s = repeatedVaultDash.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-.")
+	if s == "" {
+		s = "vault"
+	}
+	if len(s) > 64 {
+		s = strings.TrimRight(s[:64], "-.")
+	}
+	return s
+}
+
+func uniqueVaultName(base string, used map[string]bool) string {
+	if !used[base] {
+		return base
+	}
+	for n := 2; ; n++ {
+		suffix := "-" + strconv.Itoa(n)
+		stem := strings.TrimRight(base, "-.")
+		if len(stem)+len(suffix) > 64 {
+			stem = strings.TrimRight(stem[:64-len(suffix)], "-.")
+		}
+		candidate := stem + suffix
+		if !used[candidate] {
+			return candidate
+		}
+	}
+}
+
+func xdgLocalHome(env, fallback string) (string, error) {
+	path := os.Getenv(env)
+	if path == "" {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			return "", fmt.Errorf("%s is unavailable", env)
+		}
+		path = filepath.Join(home, fallback)
+	}
+	path = filepath.Clean(path)
+	if !machineLocalPath(path) {
+		return "", fmt.Errorf("%s must be an absolute mutable path outside the repository and Nix store", env)
+	}
+	return path, nil
+}
+
+// newVault derives only machine-local metadata. It never opens an OMP profile,
+// auth database, token file, or snapshot. Asking the kernel for an ephemeral
+// loopback port avoids both manifest collisions and ports already in use.
+func newVault(name string, existing []vault) (vault, error) {
+	label := strings.TrimSpace(name)
+	if label == "" {
+		return vault{}, errors.New("vault name cannot be empty")
+	}
+	ids, profiles, ports := map[string]bool{}, map[string]bool{}, map[int]bool{}
+	for _, v := range existing {
+		ids[v.ID], profiles[v.Profile] = true, true
+		if u, err := url.Parse(v.BrokerURL); err == nil {
+			if port, err := strconv.Atoi(u.Port()); err == nil {
+				ports[port] = true
+			}
+		}
+	}
+	base := vaultSlug(label)
+	id := uniqueVaultName(base, ids)
+	profile := uniqueVaultName(base, profiles)
+
+	port := 0
+	for port == 0 {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return vault{}, fmt.Errorf("allocate broker port: %w", err)
+		}
+		candidate := listener.Addr().(*net.TCPAddr).Port
+		if err := listener.Close(); err != nil {
+			return vault{}, fmt.Errorf("release broker port: %w", err)
+		}
+		if !ports[candidate] {
+			port = candidate
+		}
+	}
+	stateHome, err := xdgLocalHome("XDG_STATE_HOME", filepath.Join(".local", "state"))
+	if err != nil {
+		return vault{}, err
+	}
+	cacheHome, err := xdgLocalHome("XDG_CACHE_HOME", ".cache")
+	if err != nil {
+		return vault{}, err
+	}
+	return vault{
+		ID:            id,
+		Label:         label,
+		Profile:       profile,
+		BrokerURL:     fmt.Sprintf("http://127.0.0.1:%d", port),
+		TokenFile:     filepath.Join(stateHome, "atyrode", "code-auth-vaults", id, "broker.token"),
+		SnapshotCache: filepath.Join(cacheHome, "atyrode", "code-auth-vaults", id, "snapshot.json"),
+	}, nil
+}
+
+// writeVaultManifest validates and atomically replaces the complete
+// machine-local manifest. Parent directories are private and the final file is
+// always 0600. No credential path is read or written.
+func writeVaultManifest(path string, vaults []vault) error {
+	if path == "" {
+		return errors.New("vault editing is disabled: no writable machine-local manifest path")
+	}
+	if len(vaults) == 0 {
+		return errors.New("vault manifest cannot be empty")
+	}
+	seenIDs, seenProfiles, seenURLs := map[string]bool{}, map[string]bool{}, map[string]bool{}
+	for _, v := range vaults {
+		if !validVaultID.MatchString(v.ID) || strings.HasSuffix(v.ID, ".") || seenIDs[v.ID] {
+			return fmt.Errorf("invalid or duplicate vault id %q", v.ID)
+		}
+		if strings.TrimSpace(v.Label) == "" {
+			return fmt.Errorf("vault %q has an empty label", v.ID)
+		}
+		if !validVaultProfile.MatchString(v.Profile) || seenProfiles[v.Profile] {
+			return fmt.Errorf("vault %q has an invalid or duplicate profile", v.ID)
+		}
+		if !filepath.IsAbs(v.TokenFile) || !filepath.IsAbs(v.SnapshotCache) {
+			return fmt.Errorf("vault %q must use absolute XDG-local runtime paths", v.ID)
+		}
+		u, err := url.Parse(v.BrokerURL)
+		port, portErr := strconv.Atoi(u.Port())
+		if err != nil || portErr != nil || u.Scheme != "http" || u.Hostname() != "127.0.0.1" ||
+			u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" ||
+			port < 1 || port > 65535 || seenURLs[v.BrokerURL] {
+			return fmt.Errorf("vault %q has an unsafe or duplicate broker URL", v.ID)
+		}
+		seenIDs[v.ID], seenProfiles[v.Profile], seenURLs[v.BrokerURL] = true, true, true
+	}
+	data, err := json.MarshalIndent(vaults, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return err
+	}
+	if err := os.Chmod(parent, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(parent, ".code-auth-vaults.*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
 }
 
 // vaultStateFile is the persisted CODE_AUTH_STATE payload: the selected vault id

--- a/pkgs/code-tui/vault.go
+++ b/pkgs/code-tui/vault.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -27,7 +30,106 @@ type vault struct {
 	SnapshotCache string `json:"snapshotCache"`
 }
 
+// vaultAccount is the non-secret identity metadata exposed by the broker's
+// redacted snapshot. Access and refresh material are deliberately not decoded.
+type vaultAccount struct {
+	Provider    string
+	IdentityKey string
+	Email       string
+}
+
+// fetchVaultEndpoint performs one read-only broker request with the vault's
+// mutable token. It is the sole path used for identity and usage discovery.
+func fetchVaultEndpoint(v vault, endpoint string) ([]byte, error) {
+	if v.BrokerURL == "" || v.TokenFile == "" {
+		return nil, errors.New("vault broker discovery is not configured")
+	}
+	token, err := os.ReadFile(v.TokenFile)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodGet, strings.TrimRight(v.BrokerURL, "/")+endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(string(token)))
+	client := http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("vault broker endpoint unavailable")
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+}
+
+// loadVaultAccounts reads only redacted identity metadata from a vault. It
+// never opens or mutates OMP's credential database and never decodes token
+// fields from the response.
+func loadVaultAccounts(v vault) (map[string][]vaultAccount, error) {
+	body, err := fetchVaultEndpoint(v, "/v1/snapshot")
+	if err != nil {
+		return nil, err
+	}
+	var snapshot struct {
+		Credentials []struct {
+			Provider    string `json:"provider"`
+			IdentityKey string `json:"identityKey"`
+			Credential  struct {
+				Email string `json:"email"`
+			} `json:"credential"`
+		} `json:"credentials"`
+	}
+	if err := json.Unmarshal(body, &snapshot); err != nil {
+		return nil, err
+	}
+	accounts := map[string][]vaultAccount{}
+	for _, c := range snapshot.Credentials {
+		if c.Provider != "anthropic" && c.Provider != "openai-codex" {
+			continue
+		}
+		accounts[c.Provider] = append(accounts[c.Provider], vaultAccount{
+			Provider: c.Provider, IdentityKey: c.IdentityKey, Email: c.Credential.Email,
+		})
+	}
+	for provider := range accounts {
+		sort.Slice(accounts[provider], func(i, j int) bool {
+			return accounts[provider][i].IdentityKey < accounts[provider][j].IdentityKey
+		})
+	}
+	return accounts, nil
+}
+
 var validVaultID = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+
+// loadVaults resolves the machine-local manifest. CODE_AUTH_VAULTS remains an
+// explicit JSON override for tests and one-shot runs; otherwise the file path
+// override or the XDG config default is read. Missing files retain the neutral
+// single-vault fallback.
+func loadVaults(raw, path string) []vault {
+	if raw != "" {
+		return parseVaults(raw)
+	}
+	if path == "" {
+		configHome := os.Getenv("XDG_CONFIG_HOME")
+		if configHome == "" {
+			if home, err := os.UserHomeDir(); err == nil {
+				configHome = filepath.Join(home, ".config")
+			}
+		}
+		if configHome != "" {
+			path = filepath.Join(configHome, "atyrode", "code-auth-vaults.json")
+		}
+	}
+	if path != "" {
+		if data, err := os.ReadFile(path); err == nil {
+			raw = string(data)
+		}
+	}
+	return parseVaults(raw)
+}
 
 // parseVaults decodes the non-secret CODE_AUTH_VAULTS JSON manifest, dropping
 // entries with an unsafe or duplicate id and filling the display defaults. An

--- a/pkgs/code-tui/vault.go
+++ b/pkgs/code-tui/vault.go
@@ -590,10 +590,26 @@ func (m model) enabledCount() int {
 	return c
 }
 
-// selectVault points the active selection at index i and re-arms the detailed
-// usage panel (a fresh first-load fill for the new vault's context). It reports
-// whether the selection actually moved; re-selecting the active vault is a
-// no-op that preserves its usage on screen.
+// restoreCachedUsage swaps the detailed panel to an already-fetched vault
+// snapshot without network work. Each vault carries its own deadline and stale
+// state, so switching cannot inherit another account's countdown or warning.
+func (m *model) restoreCachedUsage(id string) bool {
+	cached, ok := m.vaultUsage[id]
+	if !ok {
+		return false
+	}
+	m.avail = cached
+	m.hadUsage = cached.ok
+	m.usageStale = m.vaultUsageStale[id]
+	m.nextRefresh = m.vaultUsageNext[id]
+	m.fetching = m.vaultFetching[id]
+	m.barAnim = 0
+	return true
+}
+
+// selectVault points the active selection at index i and immediately restores
+// its cached detailed Usage state when available. It reports whether selection
+// moved; re-selecting the active vault preserves the current panel.
 func (m *model) selectVault(i int) bool {
 	if i < 0 || i >= len(m.vaults) {
 		return false
@@ -603,6 +619,9 @@ func (m *model) selectVault(i int) bool {
 		return false
 	}
 	m.selected = id
+	if m.restoreCachedUsage(id) {
+		return true
+	}
 	m.hadUsage = false
 	m.barAnim = 0
 	m.avail = availability{bucket: map[string]string{}, reset: map[string]int64{}}

--- a/pkgs/code-tui/vault_test.go
+++ b/pkgs/code-tui/vault_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 const day = int64(86400)
@@ -375,6 +376,36 @@ func TestCycleVaultSkipsDisabled(t *testing.T) {
 	changed, _ = m.cycleVault()
 	if !changed || m.activeVault().ID != "primary" {
 		t.Fatalf("cycle from tertiary must wrap past disabled secondary to primary, got %q", m.activeVault().ID)
+	}
+}
+
+func TestSelectVaultRestoresIndependentUsageCache(t *testing.T) {
+	deadline := time.Now().Add(2 * time.Minute)
+	cached := availability{
+		ok:         true,
+		accountsOK: true,
+		bucket:     map[string]string{"claude-main": "ok"},
+		reset:      map[string]int64{"claude-main": 120},
+		wins:       []usageWin{{label: "Claude 5 Hour", pct: 37}},
+	}
+	m := model{
+		vaults:          []vault{{ID: "primary"}, {ID: "secondary"}},
+		selected:        "primary",
+		vaultUsage:      map[string]availability{"secondary": cached},
+		vaultUsageNext:  map[string]time.Time{"secondary": deadline},
+		vaultUsageStale: map[string]bool{"secondary": true},
+		vaultFetching:   map[string]bool{"secondary": true},
+	}
+
+	if !m.selectVault(1) {
+		t.Fatal("selectVault must move to secondary")
+	}
+	if !reflect.DeepEqual(m.avail, cached) {
+		t.Fatalf("cached Usage was not restored: got %+v want %+v", m.avail, cached)
+	}
+	if m.nextRefresh != deadline || !m.usageStale || !m.fetching || !m.hadUsage {
+		t.Fatalf("per-vault cache metadata was not restored: deadline=%v stale=%v fetching=%v had=%v",
+			m.nextRefresh, m.usageStale, m.fetching, m.hadUsage)
 	}
 }
 

--- a/pkgs/code-tui/vault_test.go
+++ b/pkgs/code-tui/vault_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -55,6 +56,90 @@ func TestLoadVaultsFromMachineLocalFile(t *testing.T) {
 	override := loadVaults(`[{"id":"override","profile":"one-shot"}]`, path)
 	if len(override) != 1 || override[0].ID != "override" {
 		t.Fatalf("explicit JSON must override the local file: %#v", override)
+	}
+}
+
+func TestResolveVaultsRetainsOnlyWritableManifestPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vaults.json")
+	_, gotPath := resolveVaults("", path)
+	if gotPath != path {
+		t.Fatalf("resolved manifest path = %q, want %q", gotPath, path)
+	}
+	_, gotPath = resolveVaults(`[{"id":"raw"}]`, path)
+	if gotPath != "" {
+		t.Fatalf("raw JSON override must disable editing, path=%q", gotPath)
+	}
+	_, gotPath = resolveVaults("", "vaults-in-repository.json")
+	if gotPath != "" {
+		t.Fatalf("repository-relative manifest must disable editing, path=%q", gotPath)
+	}
+}
+
+func TestNewVaultSlugCollisionAndLocalPaths(t *testing.T) {
+	state, cache := t.TempDir(), t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+	t.Setenv("XDG_CACHE_HOME", cache)
+	existing := []vault{{
+		ID: "team-vault", Profile: "team-vault", BrokerURL: "http://127.0.0.1:43123",
+	}}
+	got, err := newVault("  Team Vault!  ", existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "team-vault-2" || got.Profile != "team-vault-2" || got.Label != "Team Vault!" {
+		t.Fatalf("collision-safe identity = %+v", got)
+	}
+	if !strings.HasPrefix(got.BrokerURL, "http://127.0.0.1:") || got.BrokerURL == existing[0].BrokerURL {
+		t.Fatalf("broker URL is not unique loopback: %q", got.BrokerURL)
+	}
+	if got.TokenFile != filepath.Join(state, "atyrode", "code-auth-vaults", got.ID, "broker.token") {
+		t.Fatalf("token path = %q", got.TokenFile)
+	}
+	if got.SnapshotCache != filepath.Join(cache, "atyrode", "code-auth-vaults", got.ID, "snapshot.json") {
+		t.Fatalf("snapshot path = %q", got.SnapshotCache)
+	}
+}
+
+func TestWriteVaultManifestAtomicPrivateAndPreservesEntries(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "private")
+	path := filepath.Join(parent, "vaults.json")
+	first := vault{
+		ID: "primary", Label: "Primary", Profile: "default", Claude: "configured owner",
+		Codex: "configured owner", BrokerURL: "http://127.0.0.1:43123",
+		TokenFile: "/state/primary/token", SnapshotCache: "/cache/primary/snapshot.json",
+	}
+	second := vault{
+		ID: "secondary", Label: "Secondary", Profile: "secondary",
+		BrokerURL: "http://127.0.0.1:43124", TokenFile: "/state/secondary/token",
+		SnapshotCache: "/cache/secondary/snapshot.json",
+	}
+	if err := writeVaultManifest(path, []vault{first, second}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("manifest mode = %o, want 600", info.Mode().Perm())
+	}
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parentInfo.Mode().Perm() != 0o700 {
+		t.Fatalf("manifest parent mode = %o, want 700", parentInfo.Mode().Perm())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var roundTrip []vault
+	if err := json.Unmarshal(data, &roundTrip); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(roundTrip, []vault{first, second}) {
+		t.Fatalf("manifest round trip changed entries: %#v", roundTrip)
 	}
 }
 
@@ -412,10 +497,10 @@ func TestWithOMPProfileOverridesForwardedProfile(t *testing.T) {
 	}
 }
 
-// TestUsagePanelNamesWholeVaultCombination locks the identity move: the effective
-// provider/account combination lives in the provider headings ("Codex
-// (account)", "Claude (account)") and the switch cue names vaults.
-func TestUsagePanelNamesWholeVaultCombination(t *testing.T) {
+// TestUsagePanelNamesActiveVaultAndBrokerAccounts locks the identity boundary:
+// the title names the custom vault, provider headings stay provider-only, and
+// account identity never comes from configured login-owner labels.
+func TestUsagePanelNamesActiveVaultAndBrokerAccounts(t *testing.T) {
 	m := model{
 		vaults: []vault{
 			{ID: "primary", Label: "primary", Profile: "default", Claude: "Operator", Codex: "Operator"},
@@ -425,13 +510,15 @@ func TestUsagePanelNamesWholeVaultCombination(t *testing.T) {
 		avail:    availability{bucket: map[string]string{}, reset: map[string]int64{}},
 	}
 	panel := stripAnsi(m.usagePanel())
-	for _, text := range []string{"usage", "Claude (Collaborator)", "Codex (Operator)", "a switch vault"} {
+	for _, text := range []string{"usage", "secondary", "Codex", "Claude", "account status unavailable", "a switch vault"} {
 		if !strings.Contains(panel, text) {
 			t.Fatalf("usage panel missing %q: %q", text, panel)
 		}
 	}
-	if strings.Contains(panel, "auth ·") || strings.Contains(panel, " + ") {
-		t.Fatalf("usage panel must not repeat the auth equation: %q", panel)
+	for _, configuredOwner := range []string{"Collaborator", "Operator", "Claude (", "Codex ("} {
+		if strings.Contains(panel, configuredOwner) {
+			t.Fatalf("usage panel leaked configured owner %q: %q", configuredOwner, panel)
+		}
 	}
 }
 

--- a/pkgs/code-tui/vault_test.go
+++ b/pkgs/code-tui/vault_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -12,14 +14,14 @@ const day = int64(86400)
 
 func TestParseVaults(t *testing.T) {
 	got := parseVaults(`[
-		{"id":"mine","label":"mine","profile":"default","claude":"Alex","codex":"Alex","brokerUrl":"u1","tokenFile":"t1","snapshotCache":"c1"},
-		{"id":"mum","profile":"mum","claude":"Mum"},
+		{"id":"primary","label":"primary","profile":"default","claude":"Operator","codex":"Operator","brokerUrl":"u1","tokenFile":"t1","snapshotCache":"c1"},
+		{"id":"secondary","profile":"secondary","claude":"Collaborator"},
 		{"id":"../bad","label":"bad"},
-		{"id":"mine","label":"duplicate"}
+		{"id":"primary","label":"duplicate"}
 	]`)
 	want := []vault{
-		{ID: "mine", Label: "mine", Profile: "default", Claude: "Alex", Codex: "Alex", BrokerURL: "u1", TokenFile: "t1", SnapshotCache: "c1"},
-		{ID: "mum", Label: "mum", Profile: "mum", Claude: "Mum", Codex: "mum"},
+		{ID: "primary", Label: "primary", Profile: "default", Claude: "Operator", Codex: "Operator", BrokerURL: "u1", TokenFile: "t1", SnapshotCache: "c1"},
+		{ID: "secondary", Label: "secondary", Profile: "secondary", Claude: "Collaborator", Codex: "secondary"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("vaults = %#v, want %#v", got, want)
@@ -33,15 +35,120 @@ func TestParseVaultsEmptyFallback(t *testing.T) {
 	}
 }
 
-func TestLoadVaultStateMigratesPlainFile(t *testing.T) {
-	p := filepath.Join(t.TempDir(), "state")
-	if err := os.WriteFile(p, []byte("mum\n"), 0o600); err != nil {
+func TestLoadVaultsFromMachineLocalFile(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	path := filepath.Join(configHome, "atyrode", "code-auth-vaults.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	vaults := []vault{{ID: "mine"}, {ID: "mum"}, {ID: "victor"}}
+	if err := os.WriteFile(path, []byte(`[
+		{"id":"local","profile":"local-profile","claude":"Owner A","codex":"Owner B"}
+	]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := loadVaults("", "")
+	if len(got) != 1 || got[0].ID != "local" || got[0].Profile != "local-profile" {
+		t.Fatalf("XDG-local vault manifest was not loaded: %#v", got)
+	}
+
+	override := loadVaults(`[{"id":"override","profile":"one-shot"}]`, path)
+	if len(override) != 1 || override[0].ID != "override" {
+		t.Fatalf("explicit JSON must override the local file: %#v", override)
+	}
+}
+
+func TestLoadVaultAccountsReadsOnlyRedactedIdentityMetadata(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("vault-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/snapshot" {
+			t.Fatalf("identity discovery request = %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer vault-secret" {
+			t.Fatal("identity discovery omitted the vault bearer token")
+		}
+		_, _ = w.Write([]byte(`{"credentials":[
+			{"provider":"anthropic","identityKey":"email:collaborator@example.test","credential":{"email":"collaborator@example.test","access":"must-not-decode","refresh":"must-not-decode"}},
+			{"provider":"openai-codex","identityKey":"email:operator@example.test","credential":{"email":"operator@example.test","access":"must-not-decode"}},
+			{"provider":"cerebras","identityKey":"key:ignored","credential":{}}
+		]}`))
+	}))
+	defer server.Close()
+
+	accounts, err := loadVaultAccounts(vault{BrokerURL: server.URL, TokenFile: tokenPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 {
+		t.Fatalf("snapshot requests = %d, want 1", requests)
+	}
+	if got := accounts["anthropic"]; len(got) != 1 || got[0].Email != "collaborator@example.test" {
+		t.Fatalf("Claude identity = %#v", got)
+	}
+	if got := accounts["openai-codex"]; len(got) != 1 || got[0].IdentityKey != "email:operator@example.test" {
+		t.Fatalf("Codex identity = %#v", got)
+	}
+	if _, ok := accounts["cerebras"]; ok {
+		t.Fatal("unmanaged provider leaked into vault identity display")
+	}
+	if got, err := os.ReadFile(tokenPath); err != nil || string(got) != "vault-secret\n" {
+		t.Fatal("identity discovery mutated the token file")
+	}
+}
+
+func TestLoadAvailabilityUsesReadOnlyBrokerUsage(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("vault-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var methods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method+" "+r.URL.Path)
+		switch r.URL.Path {
+		case "/v1/snapshot":
+			_, _ = w.Write([]byte(`{"credentials":[
+				{"provider":"anthropic","identityKey":"email:collaborator@example.test","credential":{"email":"collaborator@example.test"}}
+			]}`))
+		case "/v1/usage":
+			_, _ = w.Write([]byte(`{"reports":[
+				{"provider":"anthropic","limits":[
+					{"label":"Claude 5 Hour","scope":{"tier":"-"},"amount":{"usedFraction":0.42},"window":{"resetsAt":4102444800000,"durationMs":18000000}}
+				]}
+			]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	v := vault{BrokerURL: server.URL, TokenFile: tokenPath}
+	got := loadAvailability("/definitely/not/a/command usage --json", v)
+	if !got.ok || !got.accountsOK {
+		t.Fatalf("broker availability was not loaded: %+v", got)
+	}
+	if len(got.wins) != 1 || got.wins[0].pct != 42 || got.wins[0].prov != "anthropic" {
+		t.Fatalf("broker usage = %+v", got.wins)
+	}
+	wantMethods := []string{"GET /v1/snapshot", "GET /v1/usage"}
+	if !reflect.DeepEqual(methods, wantMethods) {
+		t.Fatalf("broker discovery requests = %v, want read-only %v", methods, wantMethods)
+	}
+}
+
+func TestLoadVaultStateMigratesPlainFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "state")
+	if err := os.WriteFile(p, []byte("secondary\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	vaults := []vault{{ID: "primary"}, {ID: "secondary"}, {ID: "tertiary"}}
 	sel, dis := loadVaultState(vaults, p)
-	if sel != "mum" {
-		t.Fatalf("plain selected-id file must migrate to selected=mum, got %q", sel)
+	if sel != "secondary" {
+		t.Fatalf("plain selected-id file must migrate to selected=secondary, got %q", sel)
 	}
 	if len(dis) != 0 {
 		t.Fatalf("migration must leave no disabled vaults, got %#v", dis)
@@ -49,39 +156,39 @@ func TestLoadVaultStateMigratesPlainFile(t *testing.T) {
 }
 
 func TestLoadVaultStateJSON(t *testing.T) {
-	vaults := []vault{{ID: "mine"}, {ID: "mum"}, {ID: "victor"}}
+	vaults := []vault{{ID: "primary"}, {ID: "secondary"}, {ID: "tertiary"}}
 	p := filepath.Join(t.TempDir(), "state")
 
-	// mine can never be disabled; unknown ids are dropped.
-	if err := os.WriteFile(p, []byte(`{"selected":"victor","disabled":["mum","mine","ghost"]}`), 0o600); err != nil {
+	// The first entry can never be disabled; unknown ids are dropped.
+	if err := os.WriteFile(p, []byte(`{"selected":"tertiary","disabled":["secondary","primary","ghost"]}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	sel, dis := loadVaultState(vaults, p)
-	if sel != "victor" {
-		t.Fatalf("selected = %q, want victor", sel)
+	if sel != "tertiary" {
+		t.Fatalf("selected = %q, want tertiary", sel)
 	}
-	if !dis["mum"] || dis["mine"] || dis["ghost"] {
-		t.Fatalf("disabled must keep mum, strip mine, drop ghost, got %#v", dis)
+	if !dis["secondary"] || dis["primary"] || dis["ghost"] {
+		t.Fatalf("disabled must keep secondary, strip primary, drop ghost, got %#v", dis)
 	}
 
 	// A selection that is itself disabled collapses onto the fallback vault.
-	if err := os.WriteFile(p, []byte(`{"selected":"mum","disabled":["mum"]}`), 0o600); err != nil {
+	if err := os.WriteFile(p, []byte(`{"selected":"secondary","disabled":["secondary"]}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	sel, _ = loadVaultState(vaults, p)
-	if sel != "mine" {
+	if sel != "primary" {
 		t.Fatalf("a disabled selection must fall back to the first vault, got %q", sel)
 	}
 }
 
 func TestVaultStatePersistRoundTrip(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "nested", "state")
-	if err := writeVaultState(p, "victor", map[string]bool{"mum": true}); err != nil {
+	if err := writeVaultState(p, "tertiary", map[string]bool{"secondary": true}); err != nil {
 		t.Fatal(err)
 	}
-	vaults := []vault{{ID: "mine"}, {ID: "mum"}, {ID: "victor"}}
+	vaults := []vault{{ID: "primary"}, {ID: "secondary"}, {ID: "tertiary"}}
 	sel, dis := loadVaultState(vaults, p)
-	if sel != "victor" || !dis["mum"] {
+	if sel != "tertiary" || !dis["secondary"] {
 		t.Fatalf("round trip lost state: selected=%q disabled=%#v", sel, dis)
 	}
 	info, err := os.Stat(p)
@@ -95,62 +202,62 @@ func TestVaultStatePersistRoundTrip(t *testing.T) {
 
 func TestCycleVaultSkipsDisabled(t *testing.T) {
 	m := model{
-		vaults:   []vault{{ID: "mine"}, {ID: "mum"}, {ID: "victor"}},
-		disabled: map[string]bool{"mum": true},
+		vaults:   []vault{{ID: "primary"}, {ID: "secondary"}, {ID: "tertiary"}},
+		disabled: map[string]bool{"secondary": true},
 		avail:    availability{bucket: map[string]string{}, reset: map[string]int64{}},
 	}
 	changed, err := m.cycleVault()
 	if err != nil || !changed {
-		t.Fatalf("cycle from mine must advance: changed=%v err=%v", changed, err)
+		t.Fatalf("cycle from the fallback must advance: changed=%v err=%v", changed, err)
 	}
-	if got := m.activeVault().ID; got != "victor" {
-		t.Fatalf("cycle skipped the disabled mum but landed on %q, want victor", got)
+	if got := m.activeVault().ID; got != "tertiary" {
+		t.Fatalf("cycle skipped the disabled secondary but landed on %q, want tertiary", got)
 	}
 	changed, _ = m.cycleVault()
-	if !changed || m.activeVault().ID != "mine" {
-		t.Fatalf("cycle from victor must wrap past disabled mum to mine, got %q", m.activeVault().ID)
+	if !changed || m.activeVault().ID != "primary" {
+		t.Fatalf("cycle from tertiary must wrap past disabled secondary to primary, got %q", m.activeVault().ID)
 	}
 }
 
 func TestCycleVaultSingleEnabledIsNoop(t *testing.T) {
 	m := model{
-		vaults:   []vault{{ID: "mine"}, {ID: "mum"}},
-		disabled: map[string]bool{"mum": true},
+		vaults:   []vault{{ID: "primary"}, {ID: "secondary"}},
+		disabled: map[string]bool{"secondary": true},
 		avail:    availability{bucket: map[string]string{}, reset: map[string]int64{}},
 	}
 	changed, err := m.cycleVault()
 	if err != nil || changed {
-		t.Fatalf("with only mine enabled, cycle must be a no-op: changed=%v err=%v", changed, err)
+		t.Fatalf("with only the fallback enabled, cycle must be a no-op: changed=%v err=%v", changed, err)
 	}
-	if m.activeVault().ID != "mine" {
-		t.Fatalf("active vault moved off mine: %q", m.activeVault().ID)
+	if m.activeVault().ID != "primary" {
+		t.Fatalf("active vault moved off the fallback: %q", m.activeVault().ID)
 	}
 }
 
-func TestMineProtection(t *testing.T) {
+func TestFallbackProtection(t *testing.T) {
 	m := model{
-		vaults:   []vault{{ID: "mine"}, {ID: "mum"}},
+		vaults:   []vault{{ID: "primary"}, {ID: "secondary"}},
 		disabled: map[string]bool{},
 		avail:    availability{bucket: map[string]string{}, reset: map[string]int64{}},
 	}
 	if changed, err := m.toggleVault(0); changed || err != nil {
 		t.Fatalf("toggling the fallback vault must be a no-op: changed=%v err=%v", changed, err)
 	}
-	if m.disabled["mine"] || !m.isEnabled(0) {
+	if m.disabled["primary"] || !m.isEnabled(0) {
 		t.Fatal("the fallback vault must never become disabled")
 	}
 
 	// Disabling the active vault falls the selection back to the fallback.
-	m.selected = "mum"
+	m.selected = "secondary"
 	changed, err := m.toggleVault(1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !m.disabled["mum"] {
-		t.Fatal("mum must be disabled after toggle")
+	if !m.disabled["secondary"] {
+		t.Fatal("secondary must be disabled after toggle")
 	}
-	if !changed || m.activeVault().ID != "mine" {
-		t.Fatalf("disabling the active vault must fall back to mine (changed=%v active=%q)", changed, m.activeVault().ID)
+	if !changed || m.activeVault().ID != "primary" {
+		t.Fatalf("disabling the active vault must fall back to primary (changed=%v active=%q)", changed, m.activeVault().ID)
 	}
 	if m.enabledCount() != 1 {
 		t.Fatalf("at least one vault must stay enabled, enabledCount=%d", m.enabledCount())
@@ -162,14 +269,14 @@ func TestBrokerEnv(t *testing.T) {
 	if err := os.WriteFile(tokenPath, []byte("s3cr3t\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	v := vault{BrokerURL: "http://127.0.0.1:9", TokenFile: tokenPath, SnapshotCache: "/cache/mum"}
+	v := vault{BrokerURL: "http://127.0.0.1:9", TokenFile: tokenPath, SnapshotCache: "/cache/secondary"}
 	env, err := brokerEnv(v)
 	if err != nil {
 		t.Fatal(err)
 	}
 	want := []string{
 		"OMP_AUTH_BROKER_URL=http://127.0.0.1:9",
-		"OMP_AUTH_BROKER_SNAPSHOT_CACHE=/cache/mum",
+		"OMP_AUTH_BROKER_SNAPSHOT_CACHE=/cache/secondary",
 		"OMP_AUTH_BROKER_TOKEN=s3cr3t",
 	}
 	if !reflect.DeepEqual(env, want) {
@@ -188,57 +295,42 @@ func TestBrokerEnvTokenFailure(t *testing.T) {
 	}
 }
 
-func TestLoadAvailabilityForcesDefaultProfileAndBrokerEnv(t *testing.T) {
+func TestLoadAvailabilityStandaloneForcesDefaultProfile(t *testing.T) {
 	dir := t.TempDir()
 	argsPath := filepath.Join(dir, "args")
-	envPath := filepath.Join(dir, "env")
-	tokenPath := filepath.Join(dir, "token")
-	if err := os.WriteFile(tokenPath, []byte("s3cr3t\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
 	script := filepath.Join(dir, "usage")
 	body := "#!/bin/sh\n" +
 		"printf '%s\\n' \"$@\" > \"$ARGS_PATH\"\n" +
-		"printf '%s\\n' \"$OMP_AUTH_BROKER_URL\" \"$OMP_AUTH_BROKER_TOKEN\" \"$OMP_AUTH_BROKER_SNAPSHOT_CACHE\" > \"$ENV_PATH\"\n" +
 		"printf '%s\\n' '{\"reports\":[]}'\n"
 	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("ARGS_PATH", argsPath)
-	t.Setenv("ENV_PATH", envPath)
-	v := vault{ID: "mum", Profile: "mum", BrokerURL: "http://127.0.0.1:9", TokenFile: tokenPath, SnapshotCache: "/cache/mum"}
 
-	got := loadAvailability(script+" --profile mum usage --json", v)
+	got := loadAvailability(script+" --profile secondary usage --json", vault{ID: "standalone"})
 	if !got.ok {
-		t.Fatal("usage response was not accepted")
+		t.Fatal("standalone usage response was not accepted")
 	}
 	args, err := os.ReadFile(argsPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if want := "--profile\ndefault\nusage\n--json\n"; string(args) != want {
-		t.Fatalf("usage must force the shared default profile: args = %q, want %q", args, want)
-	}
-	env, err := os.ReadFile(envPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := "http://127.0.0.1:9\ns3cr3t\n/cache/mum\n"; string(env) != want {
-		t.Fatalf("usage must apply the vault broker env: %q, want %q", env, want)
+		t.Fatalf("standalone usage must force the shared default profile: args = %q, want %q", args, want)
 	}
 }
 
 func TestTrustedLaunchForcesDefaultProfile(t *testing.T) {
 	// Both trusted launch paths force --profile default and strip any forwarded
 	// profile, regardless of the selected vault's own profile.
-	forwarded := []string{"--config", "/tmp/x.yml", "--profile", "mum", "--resume"}
+	forwarded := []string{"--config", "/tmp/x.yml", "--profile", "secondary", "--resume"}
 	managed := managedLaunchArgv("/bin/omp", forwarded, "hello")
 	wantManaged := []string{"/bin/omp", "--profile", "default", "--config", "/tmp/x.yml", "--resume", "hello"}
 	if !reflect.DeepEqual(managed, wantManaged) {
 		t.Fatalf("managed launch argv = %#v, want %#v", managed, wantManaged)
 	}
 
-	gen := generatedLaunchArgv("/bin/omp", "/tmp/gen.yml", []string{"--profile", "mum", "--resume"}, "")
+	gen := generatedLaunchArgv("/bin/omp", "/tmp/gen.yml", []string{"--profile", "secondary", "--resume"}, "")
 	wantGen := []string{"/bin/omp", "--profile", "default", "--config", "/tmp/gen.yml", "--resume"}
 	if !reflect.DeepEqual(gen, wantGen) {
 		t.Fatalf("generated launch argv = %#v, want %#v", gen, wantGen)
@@ -246,7 +338,7 @@ func TestTrustedLaunchForcesDefaultProfile(t *testing.T) {
 }
 
 func TestSandboxLaunchStripsProfile(t *testing.T) {
-	got := sandboxLaunchArgv("/bin/ompu", []string{"--profile", "mum", "--resume"}, "")
+	got := sandboxLaunchArgv("/bin/ompu", []string{"--profile", "secondary", "--resume"}, "")
 	want := []string{"/bin/ompu", "--resume"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sandbox launch argv = %#v, want %#v (profile must be stripped, none forced)", got, want)
@@ -254,10 +346,10 @@ func TestSandboxLaunchStripsProfile(t *testing.T) {
 }
 
 func TestLoginArgv(t *testing.T) {
-	if got := loginArgv("victor", "anthropic"); !reflect.DeepEqual(got, []string{"--profile", "victor", "auth-broker", "login", "anthropic"}) {
+	if got := loginArgv("tertiary", "anthropic"); !reflect.DeepEqual(got, []string{"--profile", "tertiary", "auth-broker", "login", "anthropic"}) {
 		t.Fatalf("anthropic login argv = %#v", got)
 	}
-	if got := loginArgv("mum", "openai-codex"); !reflect.DeepEqual(got, []string{"--profile", "mum", "auth-broker", "login", "openai-codex"}) {
+	if got := loginArgv("secondary", "openai-codex"); !reflect.DeepEqual(got, []string{"--profile", "secondary", "auth-broker", "login", "openai-codex"}) {
 		t.Fatalf("openai-codex login argv = %#v", got)
 	}
 }
@@ -288,13 +380,13 @@ func TestWithOMPProfileOverridesForwardedProfile(t *testing.T) {
 		{
 			name:    "separate override",
 			profile: "default",
-			args:    []string{"--config", "/tmp/generated.yml", "--profile", "mum", "--resume"},
+			args:    []string{"--config", "/tmp/generated.yml", "--profile", "secondary", "--resume"},
 			want:    []string{"--profile", "default", "--config", "/tmp/generated.yml", "--resume"},
 		},
 		{
 			name:    "equals override",
 			profile: "default",
-			args:    []string{"--profile=mum", "--resume"},
+			args:    []string{"--profile=secondary", "--resume"},
 			want:    []string{"--profile", "default", "--resume"},
 		},
 		{
@@ -306,7 +398,7 @@ func TestWithOMPProfileOverridesForwardedProfile(t *testing.T) {
 		{
 			name:    "sandbox strips override",
 			profile: "",
-			args:    []string{"--profile", "mum", "--resume"},
+			args:    []string{"--profile", "secondary", "--resume"},
 			want:    []string{"--resume"},
 		},
 	}
@@ -326,14 +418,14 @@ func TestWithOMPProfileOverridesForwardedProfile(t *testing.T) {
 func TestUsagePanelNamesWholeVaultCombination(t *testing.T) {
 	m := model{
 		vaults: []vault{
-			{ID: "mine", Label: "mine", Profile: "default", Claude: "Alex", Codex: "Alex"},
-			{ID: "mum", Label: "mum", Profile: "mum", Claude: "Mum", Codex: "Alex"},
+			{ID: "primary", Label: "primary", Profile: "default", Claude: "Operator", Codex: "Operator"},
+			{ID: "secondary", Label: "secondary", Profile: "secondary", Claude: "Collaborator", Codex: "Operator"},
 		},
-		selected: "mum",
+		selected: "secondary",
 		avail:    availability{bucket: map[string]string{}, reset: map[string]int64{}},
 	}
 	panel := stripAnsi(m.usagePanel())
-	for _, text := range []string{"usage", "Claude (Mum)", "Codex (Alex)", "a switch vault"} {
+	for _, text := range []string{"usage", "Claude (Collaborator)", "Codex (Operator)", "a switch vault"} {
 		if !strings.Contains(panel, text) {
 			t.Fatalf("usage panel missing %q: %q", text, panel)
 		}
@@ -376,7 +468,7 @@ func TestCreditLine(t *testing.T) {
 
 func TestUsagePanelShowsOpenAIResetCredits(t *testing.T) {
 	m := model{
-		vaults: []vault{{ID: "mine", Label: "mine", Profile: "default", Claude: "Alex", Codex: "Alex"}},
+		vaults: []vault{{ID: "primary", Label: "primary", Profile: "default", Claude: "Operator", Codex: "Operator"}},
 		avail: availability{
 			ok:      true,
 			bucket:  map[string]string{},
@@ -393,7 +485,7 @@ func TestUsagePanelShowsOpenAIResetCredits(t *testing.T) {
 
 func TestUsagePanelWithoutResetCredits(t *testing.T) {
 	m := model{
-		vaults: []vault{{ID: "mine", Label: "mine", Profile: "default", Claude: "Alex", Codex: "Alex"}},
+		vaults: []vault{{ID: "primary", Label: "primary", Profile: "default", Claude: "Operator", Codex: "Operator"}},
 		avail: availability{
 			ok:     true,
 			bucket: map[string]string{},

--- a/pkgs/code-tui/vault_test.go
+++ b/pkgs/code-tui/vault_test.go
@@ -225,6 +225,80 @@ func TestLoadAvailabilityUsesReadOnlyBrokerUsage(t *testing.T) {
 	}
 }
 
+func TestLoadAvailabilitySupplementsMissingFableFromVaultProfile(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token")
+	argsPath := filepath.Join(dir, "args")
+	envPath := filepath.Join(dir, "env")
+	if err := os.WriteFile(tokenPath, []byte("vault-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(dir, "usage")
+	body := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > \"$ARGS_PATH\"\n" +
+		"printf '%s|%s|%s\\n' \"${OMP_AUTH_BROKER_URL+set}\" \"${OMP_AUTH_BROKER_TOKEN+set}\" \"${OMP_AUTH_BROKER_SNAPSHOT_CACHE+set}\" > \"$ENV_PATH\"\n" +
+		"printf '%s\\n' '{\"reports\":[{\"provider\":\"anthropic\",\"limits\":[{\"id\":\"anthropic:5h\",\"label\":\"Claude 5 Hour\",\"scope\":{\"provider\":\"anthropic\",\"windowId\":\"5h\",\"shared\":true},\"amount\":{\"usedFraction\":0.12},\"window\":{\"resetsAt\":4102444800000,\"durationMs\":18000000}},{\"id\":\"anthropic:7d:fable\",\"label\":\"Claude 7 Day (Fable)\",\"scope\":{\"provider\":\"anthropic\",\"windowId\":\"7d\",\"tier\":\"fable\"},\"amount\":{\"usedFraction\":0.27},\"window\":{\"resetsAt\":4102444800000,\"durationMs\":604800000}}]}]}'\n"
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ARGS_PATH", argsPath)
+	t.Setenv("ENV_PATH", envPath)
+	t.Setenv("OMP_AUTH_BROKER_URL", "http://ambient.invalid")
+	t.Setenv("OMP_AUTH_BROKER_TOKEN", "ambient-secret")
+	t.Setenv("OMP_AUTH_BROKER_SNAPSHOT_CACHE", "/ambient/cache")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/snapshot":
+			_, _ = w.Write([]byte(`{"credentials":[]}`))
+		case "/v1/usage":
+			_, _ = w.Write([]byte(`{"reports":[
+				{"provider":"openai-codex","limits":[
+					{"id":"openai-codex:primary","label":"7 days","scope":{"tier":"-"},"amount":{"usedFraction":0.31},"window":{"resetsAt":4102444800000,"durationMs":604800000}}
+				]},
+				{"provider":"anthropic","limits":[
+					{"id":"anthropic:5h","label":"Claude 5 Hour","scope":{"tier":"-"},"amount":{"usedFraction":0.42},"window":{"resetsAt":4102444800000,"durationMs":18000000}}
+				]}
+			]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	v := vault{ID: "mine", Profile: "mine", BrokerURL: server.URL, TokenFile: tokenPath}
+	got := loadAvailability(script+" --profile default usage --json", v)
+	var codex, fable *usageWin
+	for i := range got.wins {
+		switch {
+		case got.wins[i].prov == "openai-codex":
+			codex = &got.wins[i]
+		case got.wins[i].tier == "fable":
+			fable = &got.wins[i]
+		}
+	}
+	if codex == nil || codex.pct != 31 {
+		t.Fatalf("broker Codex usage was not preserved: %+v", got.wins)
+	}
+	if fable == nil || fable.pct != 27 || got.bucket["claude-fable"] != "ok" {
+		t.Fatalf("profile-local Fable usage was not supplemented: wins=%+v buckets=%+v", got.wins, got.bucket)
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "--profile\nmine\nusage\n--json\n--provider\nanthropic\n"; string(args) != want {
+		t.Fatalf("Fable supplement argv = %q, want %q", args, want)
+	}
+	env, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(env) != "||\n" {
+		t.Fatalf("Fable supplement inherited broker routing: %q", env)
+	}
+}
+
 func TestLoadVaultStateMigratesPlainFile(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "state")
 	if err := os.WriteFile(p, []byte("secondary\n"), 0o600); err != nil {

--- a/pkgs/omp-configured/README.md
+++ b/pkgs/omp-configured/README.md
@@ -53,9 +53,12 @@ That puts `code`, `omp`, `omp-managed`, and `ompu` on your PATH. It's self-conta
   environment.
 - The wrapper reads machine-local vault metadata from
   `$XDG_CONFIG_HOME/atyrode/code-auth-vaults.json`; `CODE_AUTH_VAULTS` can
-  override it. Without either source it falls back to the local OMP `default`
-  profile, keeping the package neutral. Home Manager runs an identity-agnostic
-  broker supervisor against that local file; it never generates the entries.
+  provide a read-only override. Without either source it falls back to the local
+  OMP `default` profile, keeping the package neutral. The `code` vault manager
+  can create entries and rename display labels only in the machine-local file.
+  Home Manager's identity-agnostic broker supervisor validates that file and
+  automatically reloads valid atomic changes while retaining current brokers
+  after an invalid edit; it never generates vault identities.
 - Broker bearer tokens remain mutable mode-0600 files outside the Nix store and
   are read fresh for each usage fetch or launch. The selected vault therefore
   cannot diverge between the displayed quota and subsequent session.

--- a/pkgs/omp-configured/README.md
+++ b/pkgs/omp-configured/README.md
@@ -51,11 +51,11 @@ That puts `code`, `omp`, `omp-managed`, and `ompu` on your PATH. It's self-conta
 - Your bare `omp` configuration remains mutable. `code` keeps trusted client
   sessions/settings in profile `default` and changes only its auth-broker
   environment.
-- The wrapper reads non-secret vault metadata from
+- The wrapper reads machine-local vault metadata from
   `$XDG_CONFIG_HOME/atyrode/code-auth-vaults.json`; `CODE_AUTH_VAULTS` can
   override it. Without either source it falls back to the local OMP `default`
-  profile, keeping the standalone package neutral. The dotfiles' Home Manager
-  module owns the managed manifest and loopback broker services.
+  profile, keeping the package neutral. Home Manager runs an identity-agnostic
+  broker supervisor against that local file; it never generates the entries.
 - Broker bearer tokens remain mutable mode-0600 files outside the Nix store and
   are read fresh for each usage fetch or launch. The selected vault therefore
   cannot diverge between the displayed quota and subsequent session.

--- a/pkgs/omp-configured/default.nix
+++ b/pkgs/omp-configured/default.nix
@@ -1254,17 +1254,6 @@ let
       export CODE_OMP_RAW="$omp_bin"
       export CODE_OMP_UNTRUSTED=${lib.getExe ompUntrusted}
       export CODE_USAGE="''${CODE_USAGE:-$omp_bin --profile default usage --json}"
-      if [[ ! -v CODE_AUTH_VAULTS ]]; then
-        auth_vaults_file="''${XDG_CONFIG_HOME:-$HOME/.config}/atyrode/code-auth-vaults.json"
-        if [[ -r "$auth_vaults_file" ]]; then
-          CODE_AUTH_VAULTS="$(cat "$auth_vaults_file")"
-        else
-          CODE_AUTH_VAULTS='[]'
-        fi
-        # JSON quotes are data consumed by code-tui, not shell syntax.
-        # shellcheck disable=SC2090
-        export CODE_AUTH_VAULTS
-      fi
       export CODE_AUTH_STATE="''${CODE_AUTH_STATE:-''${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/code-auth-vault-state.json}"
       export CODE_SELECTION_STATE="''${CODE_SELECTION_STATE:-''${XDG_STATE_HOME:-$HOME/.local/state}/atyrode/code-generator-selection.json}"
       # The generator's prompt→profile classifier runs on the resident,


### PR DESCRIPTION
## Context

Follow-up to #212: vault owner labels could diverge from the broker's authenticated identity, cancelled login handoffs could trigger an upstream readline crash, and repository-managed vault identities made personal topology part of the shared configuration.

## Solution

- show redacted broker-reported identities and provider-specific usage rather than treating configured labels as authenticated accounts
- serialize provider login handoffs and treat cancellation as non-fatal
- retain last-known Fable usage when a successful refresh temporarily omits that scoped limit, showing its relative cache age
- preload independent per-vault usage snapshots so switching is immediate and only timer/manual refreshes refetch
- share responsive section delimiters and footer styling through `cli-kit`
- load vault definitions from a mode-0600 machine-local XDG manifest
- supervise arbitrary manifest entries through one generic loopback broker service

## How to test

- `nix shell nixpkgs#go -c go test ./...` from `pkgs/code-tui`
- `nix shell nixpkgs#go nixpkgs#gcc -c go test -race ./...` from `pkgs/code-tui`
- `nix build .#checks.x86_64-linux.auth-vaults`
- `nix build .#checks.x86_64-linux.omp-stack`
- `nix build .#omp-configured`
- apply the branch, open `code`, press `v`, and verify identities, cached switching, refresh state, responsive section boundaries, and provider-specific login labels

Refs #212
