### PR TITLE
feat(atyrode): complete cockpit workspaces

### DIFF
--- a/pkgs/atyrode-tui/README.md
+++ b/pkgs/atyrode-tui/README.md
@@ -1,33 +1,44 @@
 # atyrode-tui
 
-Interactive Bubble Tea cockpit for the scriptable `atyrode` Bash CLI. It uses
-`cli-kit` for the shared palette and layout primitives, and delegates every
-operation to the existing CLI rather than reimplementing activation logic.
+Interactive Bubble Tea cockpit for the scriptable `atyrode` Bash CLI. It inherits
+shared panel chrome, persistent workspace navigation, clipped lists, palette,
+and PromptBox behavior from `cli-kit`, while delegating every operation to the
+existing CLI rather than reimplementing activation or lifecycle policy.
 
 ## Entry behavior
 
-- Bare `atyrode` with stdin and stdout attached to a TTY opens the cockpit.
+- Bare `atyrode` with stdin and stdout attached to a TTY opens the cockpit on
+  its neutral Overview workspace.
+- Opening Overview performs no Apply evaluation or mutation.
 - Any subcommand continues through the Bash CLI unchanged.
 - Bare non-TTY invocation continues to print CLI help.
 
 The wrapper exports `ATYRODE_CLI` before launching the cockpit. The TUI uses
-that exact executable for plan, preview, apply, and Ask grounding, so packaged
-and checkout-specific behavior remain aligned.
+that exact executable for every JSON report, preview, confirmed mutation, and
+Ask grounding, so packaged and checkout-specific behavior remain aligned.
+
+## Overview and navigation
+
+Overview explains the cockpit and lists every workspace without preallocating
+empty panel height. `Tab` and `Shift+Tab` cycle persistent workspaces; `1`–`6`
+jump directly to Overview, Apply, Generations/Clean, Doctor, Capabilities, and
+Ask. Local loading, selection, scroll, preview, and confirmation state survives
+round trips between workspaces. Narrow and medium layouts shorten controls and
+clip navigation chrome without allowing a row to enter the terminal auto-wrap
+column.
 
 ## Apply panel
 
-Startup runs only `atyrode apply --plan --json`. That command supplies the host,
-system, immutable target revision, backend, and active capabilities rendered in
-the plan panel; remote plans include the full commit as `resolvedRevision`.
-Once the plan is validated, apply confirmation is immediately available.
+The first visit to Apply runs only `atyrode apply --plan --json`. That command
+supplies the host, system, immutable target revision, backend, and active
+capabilities rendered in the plan panel; remote plans include the full commit
+as `resolvedRevision`. Once validated, confirmation is immediately available.
 
-The expensive read-only inspections are opt-in so a constrained host never
-starts multiple Nix evaluations merely by opening the cockpit:
+The expensive read-only inspections remain opt-in:
 
 - Press `v` to start `atyrode apply --ref <resolvedRevision> --preview-json`.
-  It runs the same read-only `nh … --dry` preview and returns the stable schema
-  described below. Press `v` again to cancel it.
-- Press `c` (or `Tab`) to open capabilities and lazily start
+  Press `v` again to cancel it.
+- Press `c` to focus capabilities and lazily start
   `atyrode inventory --ref <resolvedRevision> --json`.
 
 Preview and inventory requests never overlap. Their subprocess groups are
@@ -37,36 +48,54 @@ apply plan.
 
 No activation occurs during startup or inspection. Pressing `a` or `enter`
 opens a confirmation step; only `y` then runs
-`atyrode apply --ref <resolvedRevision>` in the terminal. The preview,
-inventory, and activation therefore address the same immutable commit even if
-the published branch advances while the cockpit is open. `n` or `esc` cancels
-confirmation, `r` resolves the branch again, arrow keys or `j`/`k` scroll the
-focused pane, and `d` toggles normalized technical details after a preview is
-loaded. Press `c` to open or focus capabilities and `c`/`esc` to return to the
-preview without resetting either pane.
+`atyrode apply --ref <resolvedRevision>`. `n` or `esc` cancels, `r` resolves the
+branch again, arrow keys or `j`/`k` scroll the focused pane, and `d` toggles
+normalized technical details after a preview is loaded.
 
-## Capability panel
+## Capability workspace
 
-Capabilities appear in the apply plan's declared active order. The selected
+The standalone Capabilities workspace reuses the same exact-revision inventory
+authority as Apply. Before Apply resolves an identity it explains that
+dependency; afterwards it lazily loads and retains the validated inventory.
+
+Capabilities appear in the Apply plan's declared active order. The selected
 view shows `Title  n/N`, textual active/applicable state, resolved item count,
 purpose, deliverables grouped by kind, and delivery, system, security, and
-mutable-state boundaries. Deliberate marker capabilities such as `server`
-explicitly say that they have no direct deliverables. Descriptions lead each
-item; name, version, source, and delivery are secondary.
-
-Use `[`/`]` or left/right arrows to cycle backward and forward with wrapping.
-On wide terminals the activation preview remains beside a 42-cell capability
-panel; `Tab` moves scrolling focus between them. Medium terminals open a
-full-width capability view, while narrow terminals stack the selection summary
-over a safely wrapped, scrollable detail list. Selection and both independent
-scroll positions survive `c`, `esc`, focus changes, and the Ask overlay.
+mutable-state boundaries. Use `[`/`]` or left/right arrows to cycle. Apply uses
+`c` to move focus between preview and capability panes; global `Tab` remains
+workspace navigation.
 
 The parser accepts inventory schema version 1 only, requires the manifest's
-full revision and system to equal the apply plan, derives the platform from that
+full revision and system to equal the Apply plan, derives the platform from that
 system, and resolves the planned host through its canonical id or aliases.
-Loading, command failures, and identity/schema mismatches remain visible as
-text inside the capability view. They never substitute stale inventory and
-never change preview or confirmation state.
+Failures remain local and never substitute stale inventory or change Apply
+confirmation state.
+
+## Doctor workspace
+
+Doctor renders the existing `doctor host`, `doctor system`, and `doctor tools`
+JSON contracts as three lazy tabs. Valid reports remain visible when the CLI
+returns a semantic nonzero status, so host mismatches, incomplete system checks,
+and missing expected tools are diagnostics rather than transport failures.
+Malformed or absent JSON remains a local report error. Refresh, cancellation,
+and generation-scoped stale-reply rejection match the existing inspection
+behavior.
+
+## Generations / Clean workspace
+
+The lifecycle workspace lists `generations --json --sizes`, marks the current
+generation, and keeps rollback and cleanup behind preview-first confirmation:
+
+- rollback runs `rollback --to N --dry-run`, displays the exact target, then
+  requires `y` before `rollback --to N --yes`;
+- cleanup runs `clean --dry-run --json`, displays the exact `keep` and
+  `keepSince` policy and candidates, then requires `y` before forwarding those
+  same values to `clean --keep N --keep-since D --yes`.
+
+The current generation cannot be selected for rollback, cancellation before
+confirmation performs no mutation, and the cockpit never adds `--all`. Once
+confirmed, a real lifecycle mutation cannot be cancelled or left until its
+authoritative command result is reported.
 
 ## Ask panel
 
@@ -103,21 +132,19 @@ host, system, or full revision differs from the plan.
 
 ## Scope
 
-This package owns the apply cockpit from issue #110, its read-only Ask panel
-from issue #117, and the capability inventory panel from issue #196. Follow-up
-operational panels remain separate:
-
-- issue #111: generations, rollback, and clean;
-- issue #112: doctor and remaining operational read panels.
+This package owns the Apply cockpit from #110, Ask from #117, exact-revision
+capabilities from #196, the Overview/navigation shell from #215,
+Generations/Clean from #111, and Doctor/read panels from #112.
 
 ## Verification
 
-`nix build .#atyrode-tui` runs the focused Go tests. They cover plan, preview,
-and exact-revision inventory command sequencing; schema and identity
-validation; active order; cycling and focus; independent scroll preservation;
-grouping, empty markers, long text, platform state, loading and failure safety;
-explicit apply confirmation; responsive 140-, 100-, 72-, and 44-column
-layouts; CLI-derived Ask grounding; streaming; and cancellation. Visual changes
-also follow `docs/tui-verification.md`: capture the app in tmux under the
-truecolor environment, verify PUA codepoints and row bounds from the character
-grid, and inspect `freeze` renders.
+`nix build .#atyrode-tui` runs focused Go tests covering navigation and lazy
+Apply entry; state retention; exact-revision preview and inventory; Doctor
+semantic nonzero reports, malformed JSON, cancellation, and stale replies;
+rollback preview/confirmation; Clean policy propagation and cancellation;
+explicit Apply confirmation; and responsive 150-, 100-, 80-, 72-, and
+44-column layouts.
+
+Visual changes follow `docs/tui-verification.md`: drive the packaged cockpit in
+tmux under the truecolor environment, verify exact PUA codepoints and row bounds
+from the character grid, and inspect `freeze` PNG renders.

--- a/pkgs/atyrode-tui/doctor.go
+++ b/pkgs/atyrode-tui/doctor.go
@@ -153,7 +153,7 @@ func (m *model) startDoctor(tab doctorTab) tea.Cmd {
 	}
 	m.doctorGeneration++
 	generation := m.doctorGeneration
-	m.doctorLoading[tab], m.doctorErrors[tab] = true, nil
+	m.doctorRequested[tab], m.doctorLoading[tab], m.doctorErrors[tab] = true, true, nil
 	ctx, cancel := context.WithCancel(context.Background())
 	m.doctorCancel = cancel
 	runner, cli := m.runner, m.cli
@@ -176,6 +176,11 @@ func (m *model) cancelDoctor() {
 	}
 	if m.doctorLoading[doctorHostTab] || m.doctorLoading[doctorSystemTab] || m.doctorLoading[doctorToolsTab] {
 		m.doctorGeneration++
+		for tab := range m.doctorLoading {
+			if m.doctorLoading[tab] {
+				m.doctorRequested[tab] = false
+			}
+		}
 		m.doctorLoading = [3]bool{}
 	}
 }
@@ -188,9 +193,8 @@ func (m *model) doctorRefresh() tea.Cmd {
 	return m.startDoctor(m.doctorTab)
 }
 
-func (m model) doctorReportMissing(tab doctorTab) bool {
-	report := m.doctorReports[tab]
-	return report.host == nil && report.system == nil && report.tools == nil
+func (m model) doctorReportUnrequested(tab doctorTab) bool {
+	return !m.doctorRequested[tab]
 }
 
 func (m *model) doctorUpdate(key string) tea.Cmd {
@@ -212,13 +216,15 @@ func (m *model) doctorUpdate(key string) tea.Cmd {
 	case "pgdown":
 		m.doctorCursor = clampCursor(m.doctorCursor+m.paneBodyHeight(), len(m.doctorRows(m.contentPanelWidth()-4)))
 	}
-	if m.doctorReportMissing(m.doctorTab) && !m.doctorLoading[m.doctorTab] {
+	if m.doctorReportUnrequested(m.doctorTab) && !m.doctorLoading[m.doctorTab] {
 		return m.startDoctor(m.doctorTab)
 	}
 	return nil
 }
 
 func (m *model) capabilitiesWorkspaceUpdate(key string) tea.Cmd {
+	_, panelWidth := m.horizontalLayout()
+	rowCount := len(m.capabilitiesWorkspaceRows(panelWidth))
 	switch key {
 	case "r":
 		if m.plan.ResolvedRevision == "" {
@@ -233,13 +239,13 @@ func (m *model) capabilitiesWorkspaceUpdate(key string) tea.Cmd {
 	case "right", "]":
 		*m = m.cycleCapability(1)
 	case "up", "k":
-		m.capabilityCursor = clampCursor(m.capabilityCursor-1, len(m.capabilityRows()))
+		m.capabilityCursor = clampCursor(m.capabilityCursor-1, rowCount)
 	case "down", "j":
-		m.capabilityCursor = clampCursor(m.capabilityCursor+1, len(m.capabilityRows()))
+		m.capabilityCursor = clampCursor(m.capabilityCursor+1, rowCount)
 	case "pgup":
-		m.capabilityCursor = clampCursor(m.capabilityCursor-m.paneBodyHeight(), len(m.capabilityRows()))
+		m.capabilityCursor = clampCursor(m.capabilityCursor-m.paneBodyHeight(), rowCount)
 	case "pgdown":
-		m.capabilityCursor = clampCursor(m.capabilityCursor+m.paneBodyHeight(), len(m.capabilityRows()))
+		m.capabilityCursor = clampCursor(m.capabilityCursor+m.paneBodyHeight(), rowCount)
 	}
 	return nil
 }
@@ -313,12 +319,17 @@ func truncateDoctorRow(row string, width int) string {
 	return ansi.Truncate(row, width, "…")
 }
 
+func (m model) capabilitiesWorkspaceRows(width int) []string {
+	bodyWidth := max(1, clikit.PanelContentWidth(width)-1)
+	return m.capabilityRowsForWidth(max(1, bodyWidth-1))
+}
+
 func (m model) capabilitiesWorkspaceView(width int) string {
 	if m.plan.ResolvedRevision == "" {
 		return clikit.Panel(width, titleStyle.Render("Capabilities")+"\n\n"+clikit.StDim.Render("Open Apply to resolve the current host and exact revision."))
 	}
 	bodyWidth := max(1, clikit.PanelContentWidth(width)-1)
-	rows := m.capabilityRowsForWidth(max(1, bodyWidth-1))
+	rows := m.capabilitiesWorkspaceRows(width)
 	bodyHeight := min(max(1, len(rows)), m.workspaceBodyHeight())
 	body := clikit.WindowList(rows, m.capabilityCursor, bodyHeight, bodyWidth)
 	return clikit.Panel(width, titleStyle.Render("Capabilities")+"\n\n"+body+"\n\n"+clikit.StDim.Render("r refresh · ←/→ capability · ↑/↓ scroll"))

--- a/pkgs/atyrode-tui/doctor.go
+++ b/pkgs/atyrode-tui/doctor.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	inventorydata "atyrode-tui/inventory"
+	clikit "cli-kit"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+type doctorTab int
+
+const (
+	doctorHostTab doctorTab = iota
+	doctorSystemTab
+	doctorToolsTab
+)
+
+type doctorHostReport struct {
+	OK     bool   `json:"ok"`
+	Host   string `json:"host"`
+	Actual struct {
+		System   string `json:"system"`
+		Username string `json:"username"`
+		Hostname string `json:"hostname"`
+	} `json:"actual"`
+	Registered json.RawMessage `json:"registered"`
+}
+
+type doctorCheck struct {
+	ID          string          `json:"id"`
+	Owner       string          `json:"owner"`
+	Required    bool            `json:"required"`
+	Status      string          `json:"status"`
+	Code        *string         `json:"code"`
+	Summary     string          `json:"summary"`
+	Remediation *string         `json:"remediation"`
+	Expected    json.RawMessage `json:"expected"`
+	Actual      json.RawMessage `json:"actual"`
+}
+
+type doctorSystemReport struct {
+	SchemaVersion    int           `json:"schemaVersion"`
+	Command          string        `json:"command"`
+	OK               bool          `json:"ok"`
+	Host             string        `json:"host"`
+	System           string        `json:"system"`
+	Platform         string        `json:"platform"`
+	Capabilities     []string      `json:"capabilities"`
+	Checks           []doctorCheck `json:"checks"`
+	MutationBoundary string        `json:"mutationBoundary"`
+}
+
+type doctorTool struct {
+	Name         string   `json:"name"`
+	Command      string   `json:"command"`
+	Capability   string   `json:"capability"`
+	Platform     *string  `json:"platform"`
+	Status       string   `json:"status"`
+	Path         string   `json:"path"`
+	Expected     bool     `json:"expected"`
+	Remediation  *string  `json:"remediation"`
+	Version      string   `json:"version"`
+	VersionOwner string   `json:"versionOwner"`
+	MutableState string   `json:"mutableState"`
+	LaunchModes  []string `json:"launchModes"`
+}
+
+type doctorReport struct {
+	host        *doctorHostReport
+	system      *doctorSystemReport
+	tools       []doctorTool
+	semanticErr error
+	err         error
+}
+
+type doctorMsg struct {
+	tab        doctorTab
+	generation uint64
+	report     doctorReport
+}
+
+func decodeDoctorJSON(out []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(out))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(new(any)); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func parseDoctorReport(tab doctorTab, out []byte) (doctorReport, error) {
+	var report doctorReport
+	switch tab {
+	case doctorHostTab:
+		value := new(doctorHostReport)
+		if err := decodeDoctorJSON(out, value); err != nil {
+			return report, fmt.Errorf("decode doctor host: %w", err)
+		}
+		if value.Host == "" || value.Actual.System == "" || value.Actual.Username == "" || value.Actual.Hostname == "" || len(value.Registered) == 0 || !json.Valid(value.Registered) {
+			return report, fmt.Errorf("decode doctor host: incomplete report")
+		}
+		report.host = value
+	case doctorSystemTab:
+		value := new(doctorSystemReport)
+		if err := decodeDoctorJSON(out, value); err != nil {
+			return report, fmt.Errorf("decode doctor system: %w", err)
+		}
+		if value.SchemaVersion != 1 || value.Command != "doctor system" || value.Host == "" || value.System == "" || value.Platform == "" || value.MutationBoundary != "read-only probes" {
+			return report, fmt.Errorf("decode doctor system: unsupported or incomplete report")
+		}
+		for _, check := range value.Checks {
+			if check.ID == "" || check.Owner == "" || check.Summary == "" || (check.Status != "ok" && check.Status != "incomplete" && check.Status != "not-applicable") || !json.Valid(check.Expected) || !json.Valid(check.Actual) {
+				return report, fmt.Errorf("decode doctor system: malformed check %q", check.ID)
+			}
+		}
+		report.system = value
+	case doctorToolsTab:
+		if err := decodeDoctorJSON(out, &report.tools); err != nil {
+			return report, fmt.Errorf("decode doctor tools: %w", err)
+		}
+		for _, tool := range report.tools {
+			if tool.Name == "" || tool.Command == "" || tool.Capability == "" || (tool.Status != "ok" && tool.Status != "missing") || (tool.Status == "ok" && tool.Path == "") || (tool.Status == "missing" && tool.Remediation == nil) {
+				return doctorReport{}, fmt.Errorf("decode doctor tools: malformed tool %q", tool.Name)
+			}
+		}
+	}
+	return report, nil
+}
+
+func doctorCommand(tab doctorTab) string {
+	return [...]string{"host", "system", "tools"}[tab]
+}
+
+func (m *model) startDoctor(tab doctorTab) tea.Cmd {
+	if m.doctorLoading[tab] {
+		return nil
+	}
+	if m.doctorLoading[doctorHostTab] || m.doctorLoading[doctorSystemTab] || m.doctorLoading[doctorToolsTab] {
+		m.cancelDoctor()
+	}
+	m.doctorGeneration++
+	generation := m.doctorGeneration
+	m.doctorLoading[tab], m.doctorErrors[tab] = true, nil
+	ctx, cancel := context.WithCancel(context.Background())
+	m.doctorCancel = cancel
+	runner, cli := m.runner, m.cli
+	return func() tea.Msg {
+		out, err := runner.Output(ctx, cli, "doctor", doctorCommand(tab), "--json")
+		report, decodeErr := parseDoctorReport(tab, out)
+		if decodeErr != nil {
+			report.err = decodeErr
+		} else if err != nil {
+			report.semanticErr = fmt.Errorf("doctor %s reported problems: %w", doctorCommand(tab), err)
+		}
+		return doctorMsg{tab: tab, generation: generation, report: report}
+	}
+}
+
+func (m *model) cancelDoctor() {
+	if m.doctorCancel != nil {
+		m.doctorCancel()
+		m.doctorCancel = nil
+	}
+	if m.doctorLoading[doctorHostTab] || m.doctorLoading[doctorSystemTab] || m.doctorLoading[doctorToolsTab] {
+		m.doctorGeneration++
+		m.doctorLoading = [3]bool{}
+	}
+}
+
+func (m *model) doctorRefresh() tea.Cmd {
+	m.cancelDoctor()
+	m.doctorReports[m.doctorTab] = doctorReport{}
+	m.doctorErrors[m.doctorTab] = nil
+	m.doctorCursor = 0
+	return m.startDoctor(m.doctorTab)
+}
+
+func (m model) doctorReportMissing(tab doctorTab) bool {
+	report := m.doctorReports[tab]
+	return report.host == nil && report.system == nil && report.tools == nil
+}
+
+func (m *model) doctorUpdate(key string) tea.Cmd {
+	switch key {
+	case "r":
+		return m.doctorRefresh()
+	case "left", "[":
+		m.doctorTab = doctorTab((int(m.doctorTab) + 2) % 3)
+		m.doctorCursor = 0
+	case "right", "]":
+		m.doctorTab = doctorTab((int(m.doctorTab) + 1) % 3)
+		m.doctorCursor = 0
+	case "up", "k":
+		m.doctorCursor = clampCursor(m.doctorCursor-1, len(m.doctorRows(m.contentPanelWidth()-4)))
+	case "down", "j":
+		m.doctorCursor = clampCursor(m.doctorCursor+1, len(m.doctorRows(m.contentPanelWidth()-4)))
+	case "pgup":
+		m.doctorCursor = clampCursor(m.doctorCursor-m.paneBodyHeight(), len(m.doctorRows(m.contentPanelWidth()-4)))
+	case "pgdown":
+		m.doctorCursor = clampCursor(m.doctorCursor+m.paneBodyHeight(), len(m.doctorRows(m.contentPanelWidth()-4)))
+	}
+	if m.doctorReportMissing(m.doctorTab) && !m.doctorLoading[m.doctorTab] {
+		return m.startDoctor(m.doctorTab)
+	}
+	return nil
+}
+
+func (m *model) capabilitiesWorkspaceUpdate(key string) tea.Cmd {
+	switch key {
+	case "r":
+		if m.plan.ResolvedRevision == "" {
+			return nil
+		}
+		m.cancelInventory()
+		m.inventory, m.inventoryErr = inventorydata.Document{}, nil
+		m.inventoryRequested = false
+		return m.startInventory()
+	case "left", "[":
+		*m = m.cycleCapability(-1)
+	case "right", "]":
+		*m = m.cycleCapability(1)
+	case "up", "k":
+		m.capabilityCursor = clampCursor(m.capabilityCursor-1, len(m.capabilityRows()))
+	case "down", "j":
+		m.capabilityCursor = clampCursor(m.capabilityCursor+1, len(m.capabilityRows()))
+	case "pgup":
+		m.capabilityCursor = clampCursor(m.capabilityCursor-m.paneBodyHeight(), len(m.capabilityRows()))
+	case "pgdown":
+		m.capabilityCursor = clampCursor(m.capabilityCursor+m.paneBodyHeight(), len(m.capabilityRows()))
+	}
+	return nil
+}
+
+func (m model) doctorView(width int) string {
+	tabs := []string{"Host", "System", "Tools"}
+	for i := range tabs {
+		if doctorTab(i) == m.doctorTab {
+			tabs[i] = clikit.StHead.Render("[" + tabs[i] + "]")
+		}
+	}
+	bodyWidth := max(1, clikit.PanelContentWidth(width)-1)
+	rows := m.doctorRows(max(1, bodyWidth-1))
+	bodyHeight := min(max(1, len(rows)), m.workspaceBodyHeight())
+	body := clikit.WindowList(rows, m.doctorCursor, bodyHeight, bodyWidth)
+	return clikit.Panel(width, titleStyle.Render("Doctor")+"\n"+clikit.StDim.Render(strings.Join(tabs, "  "))+"\n\n"+body+"\n\n"+clikit.StDim.Render("←/→ tab · r refresh · ↑/↓ scroll"))
+}
+
+func (m model) doctorRows(width int) []string {
+	if m.doctorLoading[m.doctorTab] {
+		return []string{clikit.StDim.Render("Loading doctor " + doctorCommand(m.doctorTab) + " report…")}
+	}
+	if err := m.doctorErrors[m.doctorTab]; err != nil {
+		return []string{titleStyle.Render("Report unavailable"), clikit.StDim.Render(err.Error())}
+	}
+	report := m.doctorReports[m.doctorTab]
+	var rows []string
+	if report.semanticErr != nil {
+		rows = append(rows, clikit.StDim.Render(report.semanticErr.Error()))
+	}
+	switch m.doctorTab {
+	case doctorHostTab:
+		if report.host == nil {
+			return []string{clikit.StDim.Render("Press r to load the host report.")}
+		}
+		status := "OK"
+		if !report.host.OK {
+			status = "MISMATCH"
+		}
+		rows = append(rows, titleStyle.Render(status), "Host: "+report.host.Host, "System: "+report.host.Actual.System, "User: "+report.host.Actual.Username, "Hostname: "+report.host.Actual.Hostname)
+	case doctorSystemTab:
+		if report.system == nil {
+			return []string{clikit.StDim.Render("Press r to load the system report.")}
+		}
+		status := "OK"
+		if !report.system.OK {
+			status = "PROBLEMS FOUND"
+		}
+		rows = append(rows, titleStyle.Render(status), "Host: "+report.system.Host, "System: "+report.system.System)
+		for _, check := range report.system.Checks {
+			rows = append(rows, strings.ToUpper(check.Status)+" · "+check.ID+" · "+check.Summary)
+		}
+	case doctorToolsTab:
+		if report.tools == nil {
+			return []string{clikit.StDim.Render("Press r to load the tools report.")}
+		}
+		for _, tool := range report.tools {
+			rows = append(rows, strings.ToUpper(tool.Status)+" · "+tool.Name+" · "+tool.Capability)
+		}
+	}
+	for i, row := range rows {
+		rows[i] = truncateDoctorRow(row, width)
+	}
+	return rows
+}
+
+func truncateDoctorRow(row string, width int) string {
+	if width < 1 {
+		return ""
+	}
+	return ansi.Truncate(row, width, "…")
+}
+
+func (m model) capabilitiesWorkspaceView(width int) string {
+	if m.plan.ResolvedRevision == "" {
+		return clikit.Panel(width, titleStyle.Render("Capabilities")+"\n\n"+clikit.StDim.Render("Open Apply to resolve the current host and exact revision."))
+	}
+	bodyWidth := max(1, clikit.PanelContentWidth(width)-1)
+	rows := m.capabilityRowsForWidth(max(1, bodyWidth-1))
+	bodyHeight := min(max(1, len(rows)), m.workspaceBodyHeight())
+	body := clikit.WindowList(rows, m.capabilityCursor, bodyHeight, bodyWidth)
+	return clikit.Panel(width, titleStyle.Render("Capabilities")+"\n\n"+body+"\n\n"+clikit.StDim.Render("r refresh · ←/→ capability · ↑/↓ scroll"))
+}

--- a/pkgs/atyrode-tui/doctor_test.go
+++ b/pkgs/atyrode-tui/doctor_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const doctorHostJSON = `{"ok":true,"host":"workstation","actual":{"system":"x86_64-linux","username":"alex","hostname":"desk"},"registered":{"id":"workstation"}}`
+const doctorSystemJSON = `{"schemaVersion":1,"command":"doctor system","ok":false,"host":"workstation","system":"x86_64-linux","platform":"linux","capabilities":["base"],"checks":[{"id":"nix-daemon","owner":"nixos","required":true,"status":"incomplete","code":"inactive","summary":"daemon inactive","remediation":"enable it","expected":{},"actual":{}}],"mutationBoundary":"read-only probes"}`
+const doctorToolsJSON = `[{"name":"Nix","command":"nix","capability":"base","version":"1","versionOwner":"nixpkgs","mutableState":"store","launchModes":["build"],"status":"missing","path":"","expected":true,"remediation":"apply"}]`
+
+func TestDoctorPreservesSemanticFailureJSON(t *testing.T) {
+	m := newModel("atyrode")
+	m.runner = runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		return []byte(doctorSystemJSON), errors.New("exit status 65")
+	})
+	cmd := m.startDoctor(doctorSystemTab)
+	next, _ := m.Update(cmd())
+	m = next.(model)
+	if m.doctorReports[doctorSystemTab].system == nil || m.doctorReports[doctorSystemTab].system.Checks[0].Status != "incomplete" {
+		t.Fatal("semantic nonzero discarded valid report")
+	}
+	if m.doctorErrors[doctorSystemTab] != nil || m.doctorReports[doctorSystemTab].semanticErr == nil {
+		t.Fatal("semantic nonzero was not retained separately")
+	}
+}
+
+func TestDoctorMalformedJSONTakesPrecedence(t *testing.T) {
+	m := newModel("atyrode")
+	m.runner = runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		return []byte(`{`), errors.New("exit status 65")
+	})
+	msg := m.startDoctor(doctorHostTab)().(doctorMsg)
+	if msg.report.err == nil || !strings.Contains(msg.report.err.Error(), "decode doctor host") || strings.Contains(msg.report.err.Error(), "exit status") {
+		t.Fatalf("malformed JSON error = %v", msg.report.err)
+	}
+}
+
+func TestDoctorCancelsAndRejectsStaleReply(t *testing.T) {
+	started, cancelled := make(chan struct{}), make(chan struct{})
+	m := newModel("atyrode")
+	m.runner = runnerFunc(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		close(started)
+		<-ctx.Done()
+		close(cancelled)
+		return []byte(doctorHostJSON), ctx.Err()
+	})
+	cmd := m.startDoctor(doctorHostTab)
+	result := make(chan tea.Msg, 1)
+	go func() { result <- cmd() }()
+	<-started
+	m.cancelDoctor()
+	<-cancelled
+	next, _ := m.Update(<-result)
+	m = next.(model)
+	if m.doctorReports[doctorHostTab].host != nil || m.doctorErrors[doctorHostTab] != nil {
+		t.Fatal("stale doctor reply changed cancelled state")
+	}
+}
+
+func TestDoctorTabsShowPartialFailureAndStayBounded(t *testing.T) {
+	m := newModel("atyrode")
+	m.width, m.height = 30, 12
+	host, _ := parseDoctorReport(doctorHostTab, []byte(doctorHostJSON))
+	m.doctorReports[doctorHostTab] = host
+	m.nav.Select(workspaceDoctor)
+	tools, _ := parseDoctorReport(doctorToolsTab, []byte(doctorToolsJSON))
+	m.doctorReports[doctorToolsTab] = tools
+	m.doctorErrors[doctorSystemTab] = errors.New("system probe unavailable")
+	m.doctorTab = doctorSystemTab
+	if view := stripTerminalControls(m.View()); !strings.Contains(view, "Report unavailable") {
+		t.Fatalf("partial failure not shown: %q", view)
+	}
+	m.doctorTab = doctorToolsTab
+	for _, row := range m.doctorRows(12) {
+		if len([]rune(row)) > 12 {
+			t.Fatalf("unbounded row %q", row)
+		}
+	}
+}
+
+func TestStandaloneCapabilitiesWaitForApplyIdentityAndRetainInventory(t *testing.T) {
+	m := newModel("atyrode")
+	m.nav.Select(workspaceCapability)
+	if view := stripTerminalControls(m.capabilitiesWorkspaceView(44)); !strings.Contains(view, "Open Apply") {
+		t.Fatalf("identity empty state = %q", view)
+	}
+	m.plan.ResolvedRevision = testRevision
+	m.inventoryRequested = true
+	m.inventory = readyInventoryModel(80).inventory
+	if view := stripTerminalControls(m.capabilitiesWorkspaceView(44)); !strings.Contains(view, "Base") {
+		t.Fatalf("inventory was not retained: %q", view)
+	}
+}

--- a/pkgs/atyrode-tui/doctor_test.go
+++ b/pkgs/atyrode-tui/doctor_test.go
@@ -62,6 +62,63 @@ func TestDoctorCancelsAndRejectsStaleReply(t *testing.T) {
 	}
 }
 
+func TestDoctorFailureWaitsForExplicitRefresh(t *testing.T) {
+	calls := 0
+	m := newModel("atyrode")
+	m.doctorTab = doctorSystemTab
+	m.runner = runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		calls++
+		return nil, errors.New("exit status 65")
+	})
+	cmd := m.startDoctor(doctorSystemTab)
+	next, _ := m.Update(cmd())
+	m = next.(model)
+
+	if cmd := m.doctorUpdate("j"); cmd != nil {
+		t.Fatal("failed Doctor report retried on navigation")
+	}
+	if calls != 1 || m.doctorErrors[doctorSystemTab] == nil {
+		t.Fatalf("failed Doctor request calls=%d error=%v", calls, m.doctorErrors[doctorSystemTab])
+	}
+	if cmd := m.doctorUpdate("r"); cmd == nil {
+		t.Fatal("explicit Doctor refresh did not retry")
+	}
+}
+
+func TestCancelledDoctorTabCanBeRequestedAgain(t *testing.T) {
+	m := newModel("atyrode")
+	m.runner = runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		return []byte(doctorHostJSON), nil
+	})
+	if cmd := m.startDoctor(doctorHostTab); cmd == nil {
+		t.Fatal("initial Doctor request was not started")
+	}
+	if cmd := m.startDoctor(doctorSystemTab); cmd == nil {
+		t.Fatal("switching Doctor tabs did not start the next report")
+	}
+	if m.doctorRequested[doctorHostTab] {
+		t.Fatal("cancelled Doctor request remained marked requested")
+	}
+	if cmd := m.startDoctor(doctorHostTab); cmd == nil {
+		t.Fatal("cancelled Doctor tab could not be requested again")
+	}
+}
+
+func TestDoctorFullListStaysInsideTerminalHeight(t *testing.T) {
+	m := newModel("atyrode")
+	m.width, m.height = 80, 20
+	m.nav.Select(workspaceDoctor)
+	m.doctorTab = doctorToolsTab
+	m.doctorRequested[doctorToolsTab] = true
+	m.doctorReports[doctorToolsTab].tools = make([]doctorTool, 20)
+	for i := range m.doctorReports[doctorToolsTab].tools {
+		m.doctorReports[doctorToolsTab].tools[i] = doctorTool{Name: "tool", Capability: "base", Status: "ok"}
+	}
+	if rows := len(strings.Split(m.View(), "\n")); rows > m.height {
+		t.Fatalf("Doctor view rendered %d rows into %d-row terminal", rows, m.height)
+	}
+}
+
 func TestDoctorTabsShowPartialFailureAndStayBounded(t *testing.T) {
 	m := newModel("atyrode")
 	m.width, m.height = 30, 12
@@ -94,5 +151,25 @@ func TestStandaloneCapabilitiesWaitForApplyIdentityAndRetainInventory(t *testing
 	m.inventory = readyInventoryModel(80).inventory
 	if view := stripTerminalControls(m.capabilitiesWorkspaceView(44)); !strings.Contains(view, "Base") {
 		t.Fatalf("inventory was not retained: %q", view)
+	}
+}
+
+func TestStandaloneCapabilitiesScrollUsesRenderedWidth(t *testing.T) {
+	m := newModel("atyrode")
+	m.width, m.height = 150, 30
+	m.nav.Select(workspaceCapability)
+	m.plan.ResolvedRevision = testRevision
+	m.inventoryRequested = true
+	m.inventory = readyInventoryModel(80).inventory
+	_, panelWidth := m.horizontalLayout()
+	standaloneRows := m.capabilitiesWorkspaceRows(panelWidth)
+	if len(standaloneRows) == len(m.capabilityRows()) {
+		t.Fatal("capability fixture does not distinguish standalone and Apply pane widths")
+	}
+
+	m.capabilityCursor = len(standaloneRows) - 1
+	m.capabilitiesWorkspaceUpdate("j")
+	if m.capabilityCursor != len(standaloneRows)-1 {
+		t.Fatalf("standalone cursor escaped rendered rows: cursor=%d rows=%d", m.capabilityCursor, len(standaloneRows))
 	}
 }

--- a/pkgs/atyrode-tui/lifecycle.go
+++ b/pkgs/atyrode-tui/lifecycle.go
@@ -1,0 +1,375 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	clikit "cli-kit"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+const (
+	defaultCleanKeep      = 5
+	defaultCleanKeepSince = "30d"
+)
+
+type lifecyclePhase int
+
+const (
+	lifecycleBrowsing lifecyclePhase = iota
+	lifecycleRollbackPreviewing
+	lifecycleRollbackConfirming
+	lifecycleCleanPreviewing
+	lifecycleCleanConfirming
+	lifecycleMutating
+	lifecycleSucceeded
+	lifecycleFailed
+)
+
+type generation struct {
+	Generation  uint64 `json:"generation"`
+	Date        string `json:"date"`
+	Current     bool   `json:"current"`
+	ClosureSize string `json:"closureSize,omitempty"`
+}
+
+type cleanCandidate struct {
+	Generation  uint64 `json:"generation"`
+	Date        string `json:"date"`
+	ClosureSize string `json:"closureSize,omitempty"`
+}
+
+type cleanPreview struct {
+	Scope       string `json:"scope"`
+	Platform    string `json:"platform"`
+	Profile     string `json:"profile"`
+	Keep        int    `json:"keep"`
+	KeepSince   string `json:"keepSince"`
+	DryRun      bool   `json:"dryRun"`
+	Generations struct {
+		Total      int `json:"total"`
+		Candidates int `json:"candidates"`
+	} `json:"generations"`
+	ReclaimCandidates []cleanCandidate `json:"reclaimCandidates"`
+	Note              string           `json:"note"`
+}
+
+type lifecycleAction int
+
+const (
+	loadGenerations lifecycleAction = iota
+	previewRollback
+	previewClean
+	executeRollback
+	executeClean
+)
+
+type lifecycleMsg struct {
+	generation  uint64
+	action      lifecycleAction
+	generations []generation
+	clean       cleanPreview
+	output      string
+	err         error
+}
+
+func decodeLifecycleJSON[T any](out []byte, target *T) error {
+	decoder := json.NewDecoder(bytes.NewReader(out))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func validateGenerations(generations []generation) error {
+	seen := make(map[uint64]struct{}, len(generations))
+	current := 0
+	for _, generation := range generations {
+		if generation.Generation == 0 || strings.TrimSpace(generation.Date) == "" {
+			return fmt.Errorf("generation records require a positive generation and date")
+		}
+		if _, ok := seen[generation.Generation]; ok {
+			return fmt.Errorf("duplicate generation %d", generation.Generation)
+		}
+		seen[generation.Generation] = struct{}{}
+		if generation.Current {
+			current++
+		}
+	}
+	if current > 1 {
+		return fmt.Errorf("more than one generation is current")
+	}
+	return nil
+}
+
+func validateCleanPreview(preview cleanPreview) error {
+	if preview.Keep < 0 || strings.TrimSpace(preview.KeepSince) == "" || !preview.DryRun {
+		return fmt.Errorf("clean preview has invalid retention policy")
+	}
+	seen := make(map[uint64]struct{}, len(preview.ReclaimCandidates))
+	for _, candidate := range preview.ReclaimCandidates {
+		if candidate.Generation == 0 || strings.TrimSpace(candidate.Date) == "" {
+			return fmt.Errorf("clean candidate requires a positive generation and date")
+		}
+		if _, ok := seen[candidate.Generation]; ok {
+			return fmt.Errorf("duplicate clean candidate %d", candidate.Generation)
+		}
+		seen[candidate.Generation] = struct{}{}
+	}
+	return nil
+}
+
+func (m *model) loadLifecycle() tea.Cmd {
+	m.cancelLifecycle()
+	m.lifecycleGeneration++
+	requestGeneration := m.lifecycleGeneration
+	ctx, cancel := context.WithCancel(context.Background())
+	m.lifecycleCancel = cancel
+	m.lifecycleLoading, m.lifecycleErr = true, nil
+	runner, cli := m.runner, m.cli
+	return func() tea.Msg {
+		out, err := runner.Output(ctx, cli, "generations", "--json", "--sizes")
+		if err != nil {
+			return lifecycleMsg{generation: requestGeneration, action: loadGenerations, err: commandError("load generations", out, err)}
+		}
+		var generations []generation
+		if err := decodeLifecycleJSON(out, &generations); err != nil {
+			return lifecycleMsg{generation: requestGeneration, action: loadGenerations, err: fmt.Errorf("decode generations: %w", err)}
+		}
+		if err := validateGenerations(generations); err != nil {
+			return lifecycleMsg{generation: requestGeneration, action: loadGenerations, err: fmt.Errorf("decode generations: %w", err)}
+		}
+		return lifecycleMsg{generation: requestGeneration, action: loadGenerations, generations: generations}
+	}
+}
+
+func (m *model) lifecycleCommand(action lifecycleAction, args ...string) tea.Cmd {
+	m.cancelLifecycle()
+	m.lifecycleGeneration++
+	generation := m.lifecycleGeneration
+	ctx, cancel := context.WithCancel(context.Background())
+	m.lifecycleCancel = cancel
+	m.lifecycleErr = nil
+	runner, cli := m.runner, m.cli
+	return func() tea.Msg {
+		out, err := runner.Output(ctx, cli, args...)
+		if err != nil {
+			return lifecycleMsg{generation: generation, action: action, err: commandError("lifecycle command", out, err)}
+		}
+		if action == previewClean {
+			var preview cleanPreview
+			if err := decodeLifecycleJSON(out, &preview); err != nil {
+				return lifecycleMsg{generation: generation, action: action, err: fmt.Errorf("decode clean preview: %w", err)}
+			}
+			if err := validateCleanPreview(preview); err != nil {
+				return lifecycleMsg{generation: generation, action: action, err: fmt.Errorf("decode clean preview: %w", err)}
+			}
+			return lifecycleMsg{generation: generation, action: action, clean: preview}
+		}
+		return lifecycleMsg{generation: generation, action: action, output: boundedLifecycleOutput(out)}
+	}
+}
+
+func (m *model) cancelLifecycle() {
+	if m.lifecycleCancel != nil {
+		m.lifecycleCancel()
+		m.lifecycleCancel = nil
+	}
+	m.lifecycleLoading = false
+}
+
+func (m model) selectedGeneration() (generation, bool) {
+	if m.lifecycleCursor < 0 || m.lifecycleCursor >= len(m.generations) {
+		return generation{}, false
+	}
+	return m.generations[m.lifecycleCursor], true
+}
+
+func (m *model) lifecycleUpdate(key string) tea.Cmd {
+	switch key {
+	case "r":
+		if m.lifecyclePhase == lifecycleBrowsing || m.lifecyclePhase == lifecycleSucceeded || m.lifecyclePhase == lifecycleFailed {
+			selected, ok := m.selectedGeneration()
+			if ok && !selected.Current {
+				m.lifecyclePhase, m.lifecycleTarget = lifecycleRollbackPreviewing, selected.Generation
+				return m.lifecycleCommand(previewRollback, "rollback", "--to", strconv.FormatUint(selected.Generation, 10), "--dry-run")
+			}
+		}
+	case "c":
+		if m.lifecyclePhase == lifecycleBrowsing || m.lifecyclePhase == lifecycleSucceeded || m.lifecyclePhase == lifecycleFailed {
+			m.lifecyclePhase = lifecycleCleanPreviewing
+			return m.lifecycleCommand(previewClean, "clean", "--dry-run", "--json")
+		}
+	case "y":
+		switch m.lifecyclePhase {
+		case lifecycleRollbackConfirming:
+			m.lifecyclePhase = lifecycleMutating
+			return m.lifecycleCommand(executeRollback, "rollback", "--to", strconv.FormatUint(m.lifecycleTarget, 10), "--yes")
+		case lifecycleCleanConfirming:
+			m.lifecyclePhase = lifecycleMutating
+			return m.lifecycleCommand(executeClean, "clean", "--keep", strconv.Itoa(m.clean.Keep), "--keep-since", m.clean.KeepSince, "--yes")
+		}
+	case "n", "esc":
+		switch m.lifecyclePhase {
+		case lifecycleRollbackConfirming, lifecycleCleanConfirming:
+			m.lifecyclePhase = lifecycleBrowsing
+			m.lifecycleStatus = "Cancelled — nothing changed."
+		case lifecycleRollbackPreviewing, lifecycleCleanPreviewing, lifecycleMutating:
+			m.cancelLifecycle()
+			m.lifecycleGeneration++
+			m.lifecyclePhase, m.lifecycleStatus = lifecycleBrowsing, "Cancelled — nothing changed."
+		}
+	case "up", "k":
+		if m.lifecyclePhase == lifecycleBrowsing {
+			m.lifecycleCursor = clampCursor(m.lifecycleCursor-1, len(m.generations))
+		}
+	case "down", "j":
+		if m.lifecyclePhase == lifecycleBrowsing {
+			m.lifecycleCursor = clampCursor(m.lifecycleCursor+1, len(m.generations))
+		}
+	case "pgup":
+		if m.lifecyclePhase == lifecycleBrowsing {
+			m.lifecycleCursor = clampCursor(m.lifecycleCursor-m.paneBodyHeight(), len(m.generations))
+		}
+	case "pgdown":
+		if m.lifecyclePhase == lifecycleBrowsing {
+			m.lifecycleCursor = clampCursor(m.lifecycleCursor+m.paneBodyHeight(), len(m.generations))
+		}
+	case "refresh", "ctrl+r":
+		if m.lifecyclePhase != lifecycleMutating {
+			m.lifecyclePhase, m.lifecycleStatus = lifecycleBrowsing, ""
+			return m.loadLifecycle()
+		}
+	}
+	return nil
+}
+
+func (m *model) handleLifecycleMsg(msg lifecycleMsg) {
+	if msg.generation != m.lifecycleGeneration {
+		return
+	}
+	m.lifecycleCancel, m.lifecycleLoading = nil, false
+	if msg.err != nil {
+		m.lifecycleErr, m.lifecyclePhase = msg.err, lifecycleFailed
+		return
+	}
+	switch msg.action {
+	case loadGenerations:
+		m.generations, m.lifecycleCursor, m.lifecyclePhase = msg.generations, 0, lifecycleBrowsing
+	case previewRollback:
+		m.lifecyclePreview, m.lifecyclePhase = msg.output, lifecycleRollbackConfirming
+	case previewClean:
+		m.clean, m.lifecyclePhase = msg.clean, lifecycleCleanConfirming
+	case executeRollback:
+		m.lifecyclePreview, m.lifecycleStatus, m.lifecyclePhase = msg.output, fmt.Sprintf("Rolled back to generation %d.", m.lifecycleTarget), lifecycleSucceeded
+	case executeClean:
+		m.lifecyclePreview, m.lifecycleStatus, m.lifecyclePhase = msg.output, "Clean completed successfully.", lifecycleSucceeded
+	}
+}
+
+func boundedLifecycleOutput(out []byte) string {
+	text := strings.TrimSpace(stripTerminalControls(string(out)))
+	if text == "" {
+		return "Command completed."
+	}
+	lines := strings.Split(text, "\n")
+	if len(lines) > maxErrorLines {
+		lines = lines[:maxErrorLines]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m model) lifecycleView(width int) string {
+	bodyWidth := max(1, clikit.PanelContentWidth(width)-1)
+	rows := m.lifecycleRowsForWidth(max(1, bodyWidth-1))
+	bodyHeight := min(max(1, len(rows)), m.workspaceBodyHeight())
+	rowCursor := 0
+	if m.lifecyclePhase == lifecycleBrowsing {
+		rowCursor = m.lifecycleCursor
+		if m.lifecycleStatus != "" {
+			rowCursor += 2
+		}
+	}
+	body := clikit.WindowList(rows, rowCursor, bodyHeight, bodyWidth)
+	panel := clikit.Panel(width, titleStyle.Render("Generations / Clean")+"\n\n"+body)
+	return strings.Join([]string{panel, m.lifecycleFooter(width)}, "\n\n")
+}
+
+func (m model) lifecycleRowsForWidth(width int) []string {
+	if m.lifecycleLoading {
+		return []string{clikit.StDim.Render("Loading lifecycle data…")}
+	}
+	if m.lifecycleErr != nil {
+		return []string{clikit.StBrk.Render("Lifecycle command failed"), clikit.StDim.Render(ansi.Truncate(m.lifecycleErr.Error(), width, "…"))}
+	}
+	switch m.lifecyclePhase {
+	case lifecycleRollbackPreviewing:
+		return []string{clikit.StDim.Render("Previewing rollback…")}
+	case lifecycleRollbackConfirming:
+		return []string{clikit.StWarn.Render(fmt.Sprintf("Preview: rollback to generation %d", m.lifecycleTarget)), m.lifecyclePreview, "", clikit.StHead.Render("Confirm rollback? y / n")}
+	case lifecycleCleanPreviewing:
+		return []string{clikit.StDim.Render("Loading cleanup preview…")}
+	case lifecycleCleanConfirming:
+		rows := []string{
+			clikit.StWarn.Render("Cleanup preview"),
+			fmt.Sprintf("Keep newest: %d", m.clean.Keep),
+			"Keep since: " + m.clean.KeepSince,
+			clikit.StDim.Render("Current generation is always retained."),
+		}
+		for _, candidate := range m.clean.ReclaimCandidates {
+			line := fmt.Sprintf("  %d  %s", candidate.Generation, candidate.Date)
+			if candidate.ClosureSize != "" {
+				line += "  " + candidate.ClosureSize
+			}
+			rows = append(rows, ansi.Truncate(line, width, "…"))
+		}
+		return append(rows, "", clikit.StHead.Render("Confirm clean? y / n"))
+	case lifecycleMutating:
+		return []string{clikit.StDim.Render("Applying confirmed lifecycle action…")}
+	}
+	rows := make([]string, 0, len(m.generations)+2)
+	if m.lifecycleStatus != "" {
+		rows = append(rows, clikit.StOk.Render(m.lifecycleStatus), "")
+	}
+	for index, generation := range m.generations {
+		marker := " "
+		if index == m.lifecycleCursor {
+			marker = ">"
+		}
+		state := ""
+		if generation.Current {
+			state = "  current"
+		}
+		line := fmt.Sprintf("%s %d  %s%s", marker, generation.Generation, generation.Date, state)
+		if generation.ClosureSize != "" {
+			line += "  " + generation.ClosureSize
+		}
+		rows = append(rows, ansi.Truncate(line, width, "…"))
+	}
+	return rows
+}
+
+func (m model) lifecycleFooter(width int) string {
+	text := "↑↓ select  ·  r preview rollback  ·  c preview clean  ·  Ctrl+R refresh"
+	if width < 60 {
+		text = "↑↓ select  ·  r rollback  ·  c clean"
+	}
+	if m.lifecyclePhase == lifecycleRollbackConfirming || m.lifecyclePhase == lifecycleCleanConfirming {
+		text = "y confirm  ·  n / Esc cancel"
+	}
+	return clikit.ClipLines(clikit.StDim.Render(text), width)
+}

--- a/pkgs/atyrode-tui/lifecycle.go
+++ b/pkgs/atyrode-tui/lifecycle.go
@@ -14,11 +14,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-const (
-	defaultCleanKeep      = 5
-	defaultCleanKeepSince = "30d"
-)
-
 type lifecyclePhase int
 
 const (
@@ -228,7 +223,7 @@ func (m *model) lifecycleUpdate(key string) tea.Cmd {
 		case lifecycleRollbackConfirming, lifecycleCleanConfirming:
 			m.lifecyclePhase = lifecycleBrowsing
 			m.lifecycleStatus = "Cancelled — nothing changed."
-		case lifecycleRollbackPreviewing, lifecycleCleanPreviewing, lifecycleMutating:
+		case lifecycleRollbackPreviewing, lifecycleCleanPreviewing:
 			m.cancelLifecycle()
 			m.lifecycleGeneration++
 			m.lifecyclePhase, m.lifecycleStatus = lifecycleBrowsing, "Cancelled — nothing changed."
@@ -258,14 +253,18 @@ func (m *model) lifecycleUpdate(key string) tea.Cmd {
 	return nil
 }
 
-func (m *model) handleLifecycleMsg(msg lifecycleMsg) {
+func (m *model) handleLifecycleMsg(msg lifecycleMsg) tea.Cmd {
 	if msg.generation != m.lifecycleGeneration {
-		return
+		return nil
 	}
 	m.lifecycleCancel, m.lifecycleLoading = nil, false
+	if msg.err != nil && msg.action == loadGenerations && m.lifecyclePhase == lifecycleSucceeded {
+		m.lifecycleStatus += " Refresh failed: " + msg.err.Error()
+		return nil
+	}
 	if msg.err != nil {
 		m.lifecycleErr, m.lifecyclePhase = msg.err, lifecycleFailed
-		return
+		return nil
 	}
 	switch msg.action {
 	case loadGenerations:
@@ -276,9 +275,12 @@ func (m *model) handleLifecycleMsg(msg lifecycleMsg) {
 		m.clean, m.lifecyclePhase = msg.clean, lifecycleCleanConfirming
 	case executeRollback:
 		m.lifecyclePreview, m.lifecycleStatus, m.lifecyclePhase = msg.output, fmt.Sprintf("Rolled back to generation %d.", m.lifecycleTarget), lifecycleSucceeded
+		return m.loadLifecycle()
 	case executeClean:
 		m.lifecyclePreview, m.lifecycleStatus, m.lifecyclePhase = msg.output, "Clean completed successfully.", lifecycleSucceeded
+		return m.loadLifecycle()
 	}
+	return nil
 }
 
 func boundedLifecycleOutput(out []byte) string {

--- a/pkgs/atyrode-tui/lifecycle_test.go
+++ b/pkgs/atyrode-tui/lifecycle_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func lifecycleTestModel(t *testing.T, runner commandRunner) model {
+	t.Helper()
+	m := newModel("atyrode")
+	m.runner = runner
+	m.nav.Select(workspaceLifecycle)
+	return m
+}
+
+func generationJSON() []byte {
+	return []byte(`[
+		{"generation":42,"date":"2026-07-14 10:00:00","current":false,"closureSize":"1.2 GiB"},
+		{"generation":43,"date":"2026-07-15 10:00:00","current":true}
+	]`)
+}
+
+func runLifecycleCmd(t *testing.T, m *model, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected lifecycle command")
+	}
+	updated, _ := m.Update(cmd())
+	*m = updated.(model)
+}
+
+func TestLifecycleRollbackPreviewsBeforeExactMutation(t *testing.T) {
+	var calls [][]string
+	m := lifecycleTestModel(t, runnerFunc(func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		switch len(calls) {
+		case 1:
+			return generationJSON(), nil
+		case 2:
+			if !reflect.DeepEqual(args, []string{"rollback", "--to", "42", "--dry-run"}) {
+				t.Fatalf("preview arguments = %#v", args)
+			}
+			return []byte("would activate 42"), nil
+		case 3:
+			if !reflect.DeepEqual(args, []string{"rollback", "--to", "42", "--yes"}) {
+				t.Fatalf("mutation arguments = %#v", args)
+			}
+			return []byte("activated 42"), nil
+		default:
+			t.Fatalf("unexpected command %#v", args)
+			return nil, nil
+		}
+	}))
+
+	runLifecycleCmd(t, &m, m.loadLifecycle())
+	if m.lifecyclePhase != lifecycleBrowsing {
+		t.Fatalf("phase after load = %v", m.lifecyclePhase)
+	}
+	runLifecycleCmd(t, &m, m.lifecycleUpdate("r"))
+	if m.lifecyclePhase != lifecycleRollbackConfirming || !strings.Contains(m.lifecyclePreview, "would activate") {
+		t.Fatalf("rollback preview state = phase %v preview %q", m.lifecyclePhase, m.lifecyclePreview)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("calls before confirmation = %#v", calls)
+	}
+	runLifecycleCmd(t, &m, m.lifecycleUpdate("y"))
+	if m.lifecyclePhase != lifecycleSucceeded || m.lifecycleStatus != "Rolled back to generation 42." {
+		t.Fatalf("rollback result = phase %v status %q", m.lifecyclePhase, m.lifecycleStatus)
+	}
+}
+
+func TestLifecycleCancelAndCurrentGenerationHaveNoSideEffects(t *testing.T) {
+	calls := 0
+	m := lifecycleTestModel(t, runnerFunc(func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		calls++
+		return generationJSON(), nil
+	}))
+	runLifecycleCmd(t, &m, m.loadLifecycle())
+	m.lifecycleCursor = 1 // current generation
+	if cmd := m.lifecycleUpdate("r"); cmd != nil {
+		t.Fatal("current generation scheduled rollback preview")
+	}
+	if calls != 1 {
+		t.Fatalf("current generation commands = %d, want only load", calls)
+	}
+	m.lifecycleCursor = 0
+	m.lifecyclePhase = lifecycleRollbackConfirming
+	m.lifecycleTarget = 42
+	if cmd := m.lifecycleUpdate("n"); cmd != nil {
+		t.Fatal("cancel scheduled mutation")
+	}
+	if calls != 1 || m.lifecyclePhase != lifecycleBrowsing {
+		t.Fatalf("cancel state: calls=%d phase=%v", calls, m.lifecyclePhase)
+	}
+}
+
+func TestLifecycleCleanUsesPreviewPolicyExactly(t *testing.T) {
+	var calls [][]string
+	m := lifecycleTestModel(t, runnerFunc(func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if len(calls) == 1 {
+			if !reflect.DeepEqual(args, []string{"clean", "--dry-run", "--json"}) {
+				t.Fatalf("clean preview arguments = %#v", args)
+			}
+			return []byte(`{"scope":"user","platform":"linux","profile":"/nix/var/nix/profiles/per-user/alex/home-manager","keep":7,"keepSince":"45d","dryRun":true,"generations":{"total":3,"candidates":1},"reclaimCandidates":[{"generation":2,"date":"2026-01-01 00:00:00","closureSize":"800 MiB"}],"note":"sizes may overlap"}`), nil
+		}
+		if !reflect.DeepEqual(args, []string{"clean", "--keep", "7", "--keep-since", "45d", "--yes"}) {
+			t.Fatalf("clean mutation arguments = %#v", args)
+		}
+		for _, arg := range args {
+			if arg == "--all" {
+				t.Fatal("clean mutation must never pass --all")
+			}
+		}
+		return []byte("cleaned"), nil
+	}))
+
+	runLifecycleCmd(t, &m, m.lifecycleUpdate("c"))
+	if m.lifecyclePhase != lifecycleCleanConfirming {
+		t.Fatalf("clean preview phase = %v", m.lifecyclePhase)
+	}
+	runLifecycleCmd(t, &m, m.lifecycleUpdate("y"))
+	if len(calls) != 2 || m.lifecyclePhase != lifecycleSucceeded {
+		t.Fatalf("clean result calls=%#v phase=%v", calls, m.lifecyclePhase)
+	}
+}
+
+func TestLifecycleStaleAndFailureRepliesStayLocal(t *testing.T) {
+	m := lifecycleTestModel(t, runnerFunc(func(context.Context, string, ...string) ([]byte, error) { return nil, nil }))
+	m.lifecycleGeneration = 4
+	m.generations = []generation{{Generation: 9, Date: "today"}}
+	m.handleLifecycleMsg(lifecycleMsg{generation: 3, action: loadGenerations, generations: []generation{{Generation: 1, Date: "old"}}})
+	if m.generations[0].Generation != 9 {
+		t.Fatal("stale lifecycle reply replaced data")
+	}
+	m.handleLifecycleMsg(lifecycleMsg{generation: 4, action: previewClean, err: errors.New("nh unavailable")})
+	if m.lifecyclePhase != lifecycleFailed || !strings.Contains(m.lifecycleErr.Error(), "nh unavailable") {
+		t.Fatalf("failure not retained locally: phase=%v err=%v", m.lifecyclePhase, m.lifecycleErr)
+	}
+}
+
+func TestLifecycleRenderingIsBounded(t *testing.T) {
+	m := lifecycleTestModel(t, runnerFunc(func(context.Context, string, ...string) ([]byte, error) { return nil, nil }))
+	m.width, m.height = 44, 12
+	m.lifecyclePhase = lifecycleCleanConfirming
+	m.clean = cleanPreview{Keep: 5, KeepSince: "30d", DryRun: true, ReclaimCandidates: []cleanCandidate{{Generation: 12, Date: strings.Repeat("long-date ", 12), ClosureSize: strings.Repeat("large ", 10)}}}
+	for _, line := range strings.Split(m.lifecycleView(40), "\n") {
+		if lipgloss.Width(line) > 40 {
+			t.Fatalf("rendered line width %d exceeds panel width: %q", lipgloss.Width(line), line)
+		}
+	}
+}

--- a/pkgs/atyrode-tui/lifecycle_test.go
+++ b/pkgs/atyrode-tui/lifecycle_test.go
@@ -145,6 +145,74 @@ func TestLifecycleStaleAndFailureRepliesStayLocal(t *testing.T) {
 	}
 }
 
+func TestConfirmedLifecycleMutationCannotBeCancelledOrQuit(t *testing.T) {
+	cancelled := false
+	m := lifecycleTestModel(t, runnerFunc(func(context.Context, string, ...string) ([]byte, error) { return nil, nil }))
+	m.lifecyclePhase = lifecycleMutating
+	m.lifecycleCancel = func() { cancelled = true }
+
+	if cmd := m.lifecycleUpdate("n"); cmd != nil {
+		t.Fatal("n scheduled work during confirmed mutation")
+	}
+	if cancelled || m.lifecyclePhase != lifecycleMutating {
+		t.Fatalf("n interrupted confirmed mutation: cancelled=%t phase=%v", cancelled, m.lifecyclePhase)
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	m = next.(model)
+	if cancelled || cmd != nil || m.lifecyclePhase != lifecycleMutating {
+		t.Fatalf("q interrupted confirmed mutation: cancelled=%t cmd=%v phase=%v", cancelled, cmd, m.lifecyclePhase)
+	}
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(model)
+	if cmd != nil || m.nav.Active() != workspaceLifecycle {
+		t.Fatalf("Tab left confirmed mutation: active=%q cmd=%v", m.nav.Active(), cmd)
+	}
+}
+
+func TestLifecycleSuccessReloadsAuthoritativeGenerations(t *testing.T) {
+	m := lifecycleTestModel(t, runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		return []byte(`[
+			{"generation":42,"date":"2026-07-14 10:00:00","current":true},
+			{"generation":43,"date":"2026-07-15 10:00:00","current":false}
+		]`), nil
+	}))
+	m.lifecycleGeneration = 7
+	m.lifecyclePhase = lifecycleMutating
+	m.lifecycleTarget = 42
+	m.generations = []generation{{Generation: 42, Date: "old", Current: false}, {Generation: 43, Date: "old", Current: true}}
+
+	cmd := m.handleLifecycleMsg(lifecycleMsg{generation: 7, action: executeRollback, output: "activated"})
+	if cmd == nil || !m.lifecycleLoading {
+		t.Fatalf("successful mutation did not start refresh: cmd=%v loading=%t", cmd, m.lifecycleLoading)
+	}
+	next, _ := m.Update(cmd())
+	m = next.(model)
+	if len(m.generations) != 2 || !m.generations[0].Current || m.generations[1].Current {
+		t.Fatalf("authoritative generations were not refreshed: %#v", m.generations)
+	}
+}
+
+func TestLifecycleRefreshFailurePreservesSuccessfulMutation(t *testing.T) {
+	m := lifecycleTestModel(t, runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		return nil, errors.New("inventory unavailable")
+	}))
+	m.lifecycleGeneration = 9
+	m.lifecyclePhase = lifecycleMutating
+	m.lifecycleTarget = 42
+
+	cmd := m.handleLifecycleMsg(lifecycleMsg{generation: 9, action: executeRollback, output: "activated"})
+	next, _ := m.Update(cmd())
+	m = next.(model)
+	if m.lifecyclePhase != lifecycleSucceeded || m.lifecycleErr != nil {
+		t.Fatalf("refresh failure replaced mutation success: phase=%v err=%v", m.lifecyclePhase, m.lifecycleErr)
+	}
+	for _, want := range []string{"Rolled back to generation 42.", "Refresh failed:", "inventory unavailable"} {
+		if !strings.Contains(m.lifecycleStatus, want) {
+			t.Fatalf("mutation status missing %q: %q", want, m.lifecycleStatus)
+		}
+	}
+}
+
 func TestLifecycleRenderingIsBounded(t *testing.T) {
 	m := lifecycleTestModel(t, runnerFunc(func(context.Context, string, ...string) ([]byte, error) { return nil, nil }))
 	m.width, m.height = 44, 12

--- a/pkgs/atyrode-tui/main.go
+++ b/pkgs/atyrode-tui/main.go
@@ -144,12 +144,14 @@ func buildAskGrounding(help []byte) (clikit.DocCorpus, error) {
 }
 
 type model struct {
-	cli    string
-	runner commandRunner
-	apply  applyFunc
-	asker  clikit.Asker
-	phase  phase
-	plan   applyPlan
+	cli            string
+	runner         commandRunner
+	apply          applyFunc
+	asker          clikit.Asker
+	nav            clikit.WorkspaceNav
+	phase          phase
+	plan           applyPlan
+	applyRequested bool
 
 	preview             previewdata.Document
 	previewLoading      bool
@@ -206,7 +208,8 @@ func newModel(cli string) model {
 		runner: execCommandRunner{},
 		apply:  execApply,
 		asker:  asker,
-		phase:  loadingPlan,
+		nav:    newCockpitNav(),
+		phase:  ready,
 		width:  100,
 		height: 30,
 	}
@@ -216,7 +219,7 @@ func (m model) Asker() clikit.Asker { return m.asker }
 
 func (model) BoxTitle() string { return "ASK ATYRODE · read-only" }
 
-func (m model) Init() tea.Cmd { return m.loadPlan() }
+func (m model) Init() tea.Cmd { return nil }
 
 func (m model) loadPlan() tea.Cmd {
 	runner := m.runner
@@ -455,10 +458,23 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case tea.KeyMsg:
-		switch msg.String() {
+		key := msg.String()
+		switch key {
 		case "ctrl+c", "q":
 			m.cancelInspections()
 			return m, tea.Quit
+		case "tab":
+			return m, m.nextWorkspace(1)
+		case "shift+tab":
+			return m, m.nextWorkspace(-1)
+		}
+		if id, ok := workspaceForShortcut(key); ok {
+			return m, m.activateWorkspace(id)
+		}
+		if m.nav.Active() != workspaceApply {
+			return m, nil
+		}
+		switch key {
 		case "r":
 			if m.phase != applying {
 				m.cancelInspections()
@@ -487,15 +503,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if !m.isWide() {
 						m.capabilitiesOpen = false
 					}
-				} else {
-					m.focus, m.capabilitiesOpen = capabilityPane, true
-					return m, m.startInventory()
-				}
-			}
-		case "tab":
-			if m.isWide() && (m.phase == ready || m.phase == confirming || m.phase == applied) {
-				if m.focus == capabilityPane {
-					m.focus = previewPane
 				} else {
 					m.focus, m.capabilitiesOpen = capabilityPane, true
 					return m, m.startInventory()
@@ -587,7 +594,6 @@ func clampCursor(cursor, rows int) int {
 var (
 	titleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(clikit.CHead))
 	pillStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#11151c")).Background(lipgloss.Color(clikit.CAcc)).Padding(0, 1)
-	boxStyle   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color(clikit.CBord)).Padding(0, 1)
 	labelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(clikit.CDim)).Width(14)
 	chipStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(clikit.CHead)).Background(lipgloss.Color(clikit.CSelBg)).Padding(0, 1)
 	iconStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(clikit.CAcc))
@@ -595,6 +601,27 @@ var (
 
 func (m model) View() string {
 	margin, panelWidth := m.horizontalLayout()
+	var content string
+	switch m.nav.Active() {
+	case workspaceApply:
+		content = m.applyView(panelWidth)
+	case workspaceAsk:
+		content = m.askWorkspaceView(panelWidth)
+	case workspaceLifecycle, workspaceDoctor, workspaceCapability:
+		content = m.pendingWorkspaceView(panelWidth)
+	default:
+		content = m.overviewView(panelWidth)
+	}
+	sections := []string{
+		titleStyle.Render("ATYRODE") + "  " + pillStyle.Render(m.workspaceTitle()),
+		m.workspaceTabs(panelWidth),
+		content,
+		m.shellFooter(),
+	}
+	return clikit.PadLeft(strings.Join(sections, "\n\n"), margin)
+}
+
+func (m model) applyView(panelWidth int) string {
 	content := m.previewBox(panelWidth)
 	if m.isWide() {
 		previewWidth, capabilityWidth := m.splitWidths(panelWidth)
@@ -602,14 +629,7 @@ func (m model) View() string {
 	} else if m.capabilitiesOpen {
 		content = m.capabilityBox(panelWidth)
 	}
-
-	sections := []string{
-		titleStyle.Render("ATYRODE") + "  " + pillStyle.Render("apply"),
-		m.header(panelWidth),
-		content,
-		m.footer(),
-	}
-	return clikit.PadLeft(strings.Join(sections, "\n\n"), margin)
+	return strings.Join([]string{m.header(panelWidth), content, m.footer()}, "\n\n")
 }
 
 func (m model) isWide() bool { return m.width >= 112 }
@@ -637,7 +657,7 @@ func (m model) contentPanelWidth() int {
 
 func (m model) contentOuterHeight() int {
 	_, width := m.horizontalLayout()
-	fixed := 1 + lipgloss.Height(m.header(width)) + lipgloss.Height(m.footer()) + 7
+	fixed := 1 + lipgloss.Height(m.header(width)) + lipgloss.Height(m.footer()) + lipgloss.Height(m.shellFooter()) + 11
 	return max(4, m.height-fixed)
 }
 
@@ -660,16 +680,16 @@ func (m model) horizontalLayout() (margin, panelWidth int) {
 func (m model) header(width int) string {
 	if m.plan.Host == "" {
 		if m.phase == failed {
-			return panel(width, clikit.StBrk.Render("Unable to load apply plan"))
+			return clikit.Panel(width, clikit.StBrk.Render("Unable to load apply plan"))
 		}
-		return panel(width, clikit.StDim.Render("Resolving host and apply plan…"))
+		return clikit.Panel(width, clikit.StDim.Render("Resolving host and apply plan…"))
 	}
 
 	dirty := clikit.StOk.Render("clean")
 	if m.plan.Dirty {
 		dirty = clikit.StWarn.Render("dirty")
 	}
-	available := panelContentWidth(width)
+	available := clikit.PanelContentWidth(width)
 	targetWidth := available - lipgloss.Width(labelStyle.Render("target")) - 2
 	if targetWidth < 1 {
 		targetWidth = 1
@@ -705,32 +725,7 @@ func (m model) header(width int) string {
 			labelStyle.Render("capabilities") + capabilityChips(m.plan.Capabilities, available-14),
 		}
 	}
-	return panel(width, strings.Join(lines, "\n"))
-}
-
-func panel(width int, content string) string {
-	if width < 1 {
-		width = 1
-	}
-	inner := panelContentWidth(width)
-	content = clipLines(content, inner)
-	return boxStyle.Width(inner).Render(content)
-}
-
-func clipLines(content string, width int) string {
-	lines := strings.Split(content, "\n")
-	for i := range lines {
-		lines[i] = ansi.Truncate(lines[i], width, "")
-	}
-	return strings.Join(lines, "\n")
-}
-
-func panelContentWidth(width int) int {
-	inner := width - boxStyle.GetHorizontalFrameSize() - 2 // padding is outside lipgloss Width
-	if inner < 1 {
-		return 1
-	}
-	return inner
+	return clikit.Panel(width, strings.Join(lines, "\n"))
 }
 
 func capabilityChips(capabilities []string, width int) string {
@@ -769,7 +764,7 @@ func (m model) previewHeight() int {
 }
 
 func (m model) previewBox(width int) string {
-	previewWidth := max(1, panelContentWidth(width)-4)
+	previewWidth := max(1, clikit.PanelContentWidth(width)-4)
 	var body string
 	if m.preview.SchemaVersion != 0 {
 		body = clikit.WindowList(m.previewRowsForWidth(max(1, previewWidth-1)), m.previewCursor, m.previewHeight(), previewWidth)
@@ -780,7 +775,7 @@ func (m model) previewBox(width int) string {
 	if m.focus == previewPane {
 		label += clikit.StHead.Render("  ·  FOCUSED")
 	}
-	return panel(width, label+"\n"+body)
+	return clikit.Panel(width, label+"\n"+body)
 }
 
 func (m model) previewStatusRows(width int) []string {
@@ -835,18 +830,18 @@ func (m model) capabilityPanelWidth() int {
 }
 
 func (m model) capabilityBox(width int) string {
-	bodyWidth := max(1, panelContentWidth(width)-4)
+	bodyWidth := max(1, clikit.PanelContentWidth(width)-4)
 	rows := m.capabilityRowsForWidth(max(1, bodyWidth-1))
 	body := clikit.WindowList(rows, m.capabilityCursor, m.paneBodyHeight(), bodyWidth)
 	label := iconStyle.Render("\uf085") + "  " + titleStyle.Render("CAPABILITIES")
 	if m.focus == capabilityPane {
 		label += clikit.StHead.Render("  ·  FOCUSED")
 	}
-	return panel(width, label+"\n"+body)
+	return clikit.Panel(width, label+"\n"+body)
 }
 
 func (m model) capabilityRows() []string {
-	width := max(1, panelContentWidth(m.capabilityPanelWidth())-5)
+	width := max(1, clikit.PanelContentWidth(m.capabilityPanelWidth())-5)
 	return m.capabilityRowsForWidth(width)
 }
 
@@ -997,7 +992,7 @@ func (m model) previewRows() []string {
 	if m.isWide() {
 		width, _ = m.splitWidths(width)
 	}
-	previewWidth := max(1, panelContentWidth(width)-4)
+	previewWidth := max(1, clikit.PanelContentWidth(width)-4)
 	return m.previewRowsForWidth(max(1, previewWidth-1))
 }
 

--- a/pkgs/atyrode-tui/main.go
+++ b/pkgs/atyrode-tui/main.go
@@ -180,6 +180,7 @@ type model struct {
 	doctorReports    [3]doctorReport
 	doctorErrors     [3]error
 	doctorLoading    [3]bool
+	doctorRequested  [3]bool
 	doctorTab        doctorTab
 	doctorCursor     int
 	doctorGeneration uint64
@@ -485,8 +486,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case lifecycleMsg:
-		m.handleLifecycleMsg(msg)
-		return m, nil
+		return m, m.handleLifecycleMsg(msg)
 	case applyDoneMsg:
 		if msg.err != nil {
 			m.phase, m.err = failed, fmt.Errorf("apply failed: %w", msg.err)
@@ -496,6 +496,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		key := msg.String()
+		if m.lifecyclePhase == lifecycleMutating {
+			switch key {
+			case "ctrl+c", "q", "tab", "shift+tab":
+				return m, nil
+			}
+			if _, ok := workspaceForShortcut(key); ok {
+				return m, nil
+			}
+		}
 		switch key {
 		case "ctrl+c", "q":
 			m.cancelInspections()

--- a/pkgs/atyrode-tui/main.go
+++ b/pkgs/atyrode-tui/main.go
@@ -165,6 +165,26 @@ type model struct {
 	inventoryGeneration uint64
 	inventoryCancel     context.CancelFunc
 
+	lifecyclePhase      lifecyclePhase
+	lifecycleGeneration uint64
+	lifecycleCancel     context.CancelFunc
+	lifecycleLoading    bool
+	lifecycleErr        error
+	lifecycleStatus     string
+	lifecyclePreview    string
+	lifecycleTarget     uint64
+	lifecycleCursor     int
+	generations         []generation
+	clean               cleanPreview
+
+	doctorReports    [3]doctorReport
+	doctorErrors     [3]error
+	doctorLoading    [3]bool
+	doctorTab        doctorTab
+	doctorCursor     int
+	doctorGeneration uint64
+	doctorCancel     context.CancelFunc
+
 	inventoryDiagnostic  string
 	inventoryDetailsOpen bool
 	details              bool
@@ -327,8 +347,10 @@ func (m *model) cancelInventory() {
 }
 
 func (m *model) cancelInspections() {
+	m.cancelDoctor()
 	m.cancelPreview()
 	m.cancelInventory()
+	m.cancelLifecycle()
 }
 
 func (m model) applyArgs(preview bool) []string {
@@ -450,6 +472,21 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
+	case doctorMsg:
+		if msg.generation != m.doctorGeneration {
+			return m, nil
+		}
+		m.doctorLoading[msg.tab] = false
+		if msg.report.err != nil {
+			m.doctorReports[msg.tab], m.doctorErrors[msg.tab] = doctorReport{}, msg.report.err
+		} else {
+			m.doctorReports[msg.tab], m.doctorErrors[msg.tab] = msg.report, nil
+			m.doctorCursor = 0
+		}
+		return m, nil
+	case lifecycleMsg:
+		m.handleLifecycleMsg(msg)
+		return m, nil
 	case applyDoneMsg:
 		if msg.err != nil {
 			m.phase, m.err = failed, fmt.Errorf("apply failed: %w", msg.err)
@@ -470,6 +507,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if id, ok := workspaceForShortcut(key); ok {
 			return m, m.activateWorkspace(id)
+		}
+		if m.nav.Active() == workspaceDoctor {
+			return m, m.doctorUpdate(key)
+		}
+		if m.nav.Active() == workspaceCapability {
+			return m, m.capabilitiesWorkspaceUpdate(key)
+		}
+		if m.nav.Active() == workspaceLifecycle {
+			return m, m.lifecycleUpdate(key)
 		}
 		if m.nav.Active() != workspaceApply {
 			return m, nil
@@ -605,10 +651,14 @@ func (m model) View() string {
 	switch m.nav.Active() {
 	case workspaceApply:
 		content = m.applyView(panelWidth)
+	case workspaceLifecycle:
+		content = m.lifecycleView(panelWidth)
 	case workspaceAsk:
 		content = m.askWorkspaceView(panelWidth)
-	case workspaceLifecycle, workspaceDoctor, workspaceCapability:
-		content = m.pendingWorkspaceView(panelWidth)
+	case workspaceDoctor:
+		content = m.doctorView(panelWidth)
+	case workspaceCapability:
+		content = m.capabilitiesWorkspaceView(panelWidth)
 	default:
 		content = m.overviewView(panelWidth)
 	}
@@ -1181,7 +1231,7 @@ func (m model) footer() string {
 	if m.focus == capabilityPane {
 		controls := "↑/↓ scroll  ·  [/] cycle  ·  c back"
 		if m.isWide() {
-			controls = "↑/↓ capability  ·  [/] cycle  ·  Tab/c preview"
+			controls = "↑/↓ capability  ·  [/] cycle  ·  c preview"
 		}
 		if m.inventoryErr != nil && m.inventoryDiagnostic != "" && m.width >= 80 {
 			diagnosticMode := "diagnostics"
@@ -1235,7 +1285,7 @@ func (m model) footer() string {
 			}
 			return clikit.StDim.Render("↑/↓ scroll  ·  " + mediumControl + "  ·  c capabilities  ·  enter apply  ·  q")
 		}
-		return clikit.StDim.Render("↑/↓ preview  ·  " + previewControl + "  ·  Tab/c capabilities  ·  enter apply  ·  r refresh  ·  ^O ask  ·  q")
+		return clikit.StDim.Render("↑/↓ preview  ·  " + previewControl + "  ·  c capabilities  ·  enter apply  ·  r refresh  ·  ^O ask  ·  q")
 	default:
 		return clikit.StDim.Render("^O ask  ·  q quit")
 	}

--- a/pkgs/atyrode-tui/main_test.go
+++ b/pkgs/atyrode-tui/main_test.go
@@ -25,6 +25,13 @@ func (f runnerFunc) Output(ctx context.Context, name string, args ...string) ([]
 	return f(ctx, name, args...)
 }
 
+func newApplyTestModel(cli string) model {
+	m := newModel(cli)
+	m.nav.Select(workspaceApply)
+	m.applyRequested = true
+	return m
+}
+
 func testPreviewDocument() previewdata.Document {
 	return previewdata.Document{
 		SchemaVersion:    previewdata.SchemaVersion,
@@ -193,7 +200,7 @@ func TestGroundedAskerCancellationClosesStream(t *testing.T) {
 	}
 }
 
-func TestInitLoadsOnlyPlanAndPreviewIsExplicit(t *testing.T) {
+func TestOverviewStartsWithoutApplyWorkAndApplyPreviewRemainsExplicit(t *testing.T) {
 	var calls [][]string
 	m := newModel("/bin/atyrode")
 	m.runner = runnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
@@ -209,14 +216,32 @@ func TestInitLoadsOnlyPlanAndPreviewIsExplicit(t *testing.T) {
 		}
 	})
 
-	plan := m.Init()().(planMsg)
-	next, cmd := m.Update(plan)
+	if cmd := m.Init(); cmd != nil {
+		t.Fatal("Overview startup unexpectedly scheduled an Apply command")
+	}
+	if len(calls) != 0 {
+		t.Fatalf("Overview startup commands = %#v, want none", calls)
+	}
+	overview := stripTerminalControls(m.View())
+	for _, want := range []string{"overview", "Your Nix operating environment", "1  Overview", "2  Apply", "Tab next workspace"} {
+		if !strings.Contains(overview, want) {
+			t.Errorf("Overview missing %q", want)
+		}
+	}
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m = next.(model)
+	if cmd == nil || m.nav.Active() != workspaceApply || m.phase != loadingPlan {
+		t.Fatalf("enter Apply state = active %q phase %v cmd %v", m.nav.Active(), m.phase, cmd)
+	}
+	plan := cmd().(planMsg)
+	next, cmd = m.Update(plan)
 	m = next.(model)
 	if cmd != nil || m.phase != ready {
 		t.Fatalf("plan completion phase/cmd = %v/%v, want ready/nil", m.phase, cmd)
 	}
 	if want := [][]string{{"/bin/atyrode", "apply", "--plan", "--json"}}; !reflect.DeepEqual(calls, want) {
-		t.Fatalf("startup commands = %#v, want %#v", calls, want)
+		t.Fatalf("Apply entry commands = %#v, want %#v", calls, want)
 	}
 	unloaded := stripTerminalControls(m.View())
 	for _, want := range []string{"workstation", "feedfacefeed", "Preview not loaded", "v preview", "enter apply"} {
@@ -250,19 +275,52 @@ func TestInitLoadsOnlyPlanAndPreviewIsExplicit(t *testing.T) {
 	}
 }
 
-func TestRemotePlanRequiresResolvedRevision(t *testing.T) {
+func TestWorkspaceNavigationPreservesApplyState(t *testing.T) {
 	m := newModel("atyrode")
+	m.runner = runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		return []byte(`{"host":"workstation","system":"x86_64-linux","resolvedRevision":"` + testRevision + `"}`), nil
+	})
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(model)
+	if m.nav.Active() != workspaceApply || cmd == nil {
+		t.Fatalf("Tab entered %q with cmd %v, want Apply load", m.nav.Active(), cmd)
+	}
+	next, _ = m.Update(cmd())
+	m = next.(model)
+	m.previewCursor = 3
+
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(model)
+	if m.nav.Active() != workspaceLifecycle || cmd != nil {
+		t.Fatalf("second Tab entered %q with cmd %v, want lifecycle/nil", m.nav.Active(), cmd)
+	}
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	m = next.(model)
+	if m.nav.Active() != workspaceApply || cmd != nil || m.previewCursor != 3 || m.plan.Host != "workstation" {
+		t.Fatalf("Apply state was not retained: active=%q cmd=%v cursor=%d host=%q", m.nav.Active(), cmd, m.previewCursor, m.plan.Host)
+	}
+
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+	m = next.(model)
+	if m.nav.Active() != workspaceDoctor {
+		t.Fatalf("direct shortcut entered %q, want Doctor", m.nav.Active())
+	}
+}
+
+func TestRemotePlanRequiresResolvedRevision(t *testing.T) {
+	m := newApplyTestModel("atyrode")
 	m.runner = runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
 		return []byte(`{"source":"remote","revision":"feedfacefeed"}`), nil
 	})
-	msg := m.Init()().(planMsg)
+	msg := m.loadPlan()().(planMsg)
 	if msg.err == nil || !strings.Contains(msg.err.Error(), "full resolved revision") {
 		t.Fatalf("missing resolved revision error = %v", msg.err)
 	}
 }
 
 func TestPreviewMustMatchPlannedIdentity(t *testing.T) {
-	m := newModel("atyrode")
+	m := newApplyTestModel("atyrode")
 	m.phase = ready
 	m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", Source: "remote", ResolvedRevision: testRevision}
 	result := testPreviewDocument()
@@ -283,7 +341,7 @@ func TestPreviewMustMatchPlannedIdentity(t *testing.T) {
 }
 
 func TestApplyRequiresExplicitConfirmation(t *testing.T) {
-	m := newModel("/bin/atyrode")
+	m := newApplyTestModel("/bin/atyrode")
 	m.phase = ready
 	m.plan = applyPlan{Source: "remote", ResolvedRevision: testRevision}
 	applies := 0
@@ -326,7 +384,7 @@ func TestApplyRequiresExplicitConfirmation(t *testing.T) {
 }
 
 func TestPreviewFailureIsPanelLocalAndApplyRemainsAvailable(t *testing.T) {
-	m := newModel("atyrode")
+	m := newApplyTestModel("atyrode")
 	m.phase = ready
 	m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", ResolvedRevision: testRevision}
 	m.previewGeneration = 3
@@ -352,7 +410,7 @@ func TestPreviewLoadingRemainsResponsiveAndCancellationIsStaleSafe(t *testing.T)
 	for _, key := range []string{"a", "v", "r", "q"} {
 		t.Run(key, func(t *testing.T) {
 			started, cancelled := make(chan struct{}), make(chan struct{})
-			m := newModel("atyrode")
+			m := newApplyTestModel("atyrode")
 			m.phase = ready
 			m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", Source: "remote", ResolvedRevision: testRevision}
 			m.runner = runnerFunc(func(ctx context.Context, _ string, args ...string) ([]byte, error) {
@@ -406,7 +464,7 @@ func TestPreviewLoadingRemainsResponsiveAndCancellationIsStaleSafe(t *testing.T)
 }
 
 func TestPreviewRepliesAreScopedToRevisionAndGeneration(t *testing.T) {
-	m := newModel("atyrode")
+	m := newApplyTestModel("atyrode")
 	m.phase = ready
 	m.plan.ResolvedRevision = testRevision
 	m.previewGeneration = 9
@@ -427,7 +485,7 @@ func TestPreviewRepliesAreScopedToRevisionAndGeneration(t *testing.T) {
 }
 
 func TestConfirmationExplainsOptionalPreviewStatus(t *testing.T) {
-	m := newModel("atyrode")
+	m := newApplyTestModel("atyrode")
 	m.phase = ready
 	m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", ResolvedRevision: testRevision}
 	m = press(m, "enter")
@@ -446,7 +504,7 @@ func TestConfirmationExplainsOptionalPreviewStatus(t *testing.T) {
 }
 
 func TestDetailsToggleLabelsGenerationPaths(t *testing.T) {
-	m := newModel("atyrode")
+	m := newApplyTestModel("atyrode")
 	m.phase = ready
 	m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", ResolvedRevision: testRevision}
 	m.preview = testPreviewDocument()
@@ -479,7 +537,7 @@ func TestDetailsToggleLabelsGenerationPaths(t *testing.T) {
 }
 
 func TestSummaryOmitsEmptyGroupsAndUnreportedFacts(t *testing.T) {
-	m := newModel("atyrode")
+	m := newApplyTestModel("atyrode")
 	m.phase = ready
 	m.preview = previewdata.Document{
 		SchemaVersion:    previewdata.SchemaVersion,
@@ -541,19 +599,19 @@ func TestStripTerminalControlsUsesANSIParser(t *testing.T) {
 }
 
 func TestLongPlanFailureStaysInsideNarrowWindow(t *testing.T) {
-	m := newModel("atyrode")
+	m := newApplyTestModel("atyrode")
 	m.width, m.height = 44, 26
 	m.runner = runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
 		output := "\x1b]0;unsafe\x07" + strings.Repeat("plan-failure-with-an-unbroken-path/", 12)
 		return []byte(output), errors.New("exit status 69")
 	})
-	msg := m.Init()().(planMsg)
+	msg := m.loadPlan()().(planMsg)
 	next, _ := m.Update(msg)
 	assertFailureViewContained(t, next.(model))
 }
 
 func TestLongPreviewFailureStaysInsideNarrowWindow(t *testing.T) {
-	m := newModel("atyrode")
+	m := newApplyTestModel("atyrode")
 	m.width, m.height, m.phase = 44, 26, ready
 	m.plan = applyPlan{
 		Host: "fixture", System: "x86_64-linux", User: "alex",
@@ -600,7 +658,7 @@ func assertFailureViewContained(t *testing.T, m model) {
 
 func TestPanelsKeepRightBorderWithinWindow(t *testing.T) {
 	for _, windowWidth := range []int{44, 72, 80, 100} {
-		m := newModel("atyrode")
+		m := newApplyTestModel("atyrode")
 		m.width, m.height, m.phase = windowWidth, 26, ready
 		m.plan = applyPlan{
 			Host:         "alex-x86_64-linux",
@@ -652,7 +710,7 @@ func TestCapabilityChipsAdaptToAvailableWidth(t *testing.T) {
 }
 
 func readyInventoryModel(width int) model {
-	m := newModel("atyrode")
+	m := newApplyTestModel("atyrode")
 	m.width, m.height, m.phase = width, 34, ready
 	m.plan = applyPlan{
 		Host: "workstation", System: "x86_64-linux", User: "alex", Source: "remote",
@@ -715,9 +773,9 @@ func TestCapabilityCyclingWrapsBothDirectionsInPlanOrder(t *testing.T) {
 func TestCapabilityFocusAndIndependentScrollSurviveReturn(t *testing.T) {
 	m := readyInventoryModel(140)
 	m.previewCursor = 3
-	m = press(m, "tab")
+	m = press(m, "c")
 	if m.focus != capabilityPane {
-		t.Fatal("Tab did not move focus to capability pane")
+		t.Fatal("c did not move focus to capability pane")
 	}
 	for range 5 {
 		m = press(m, "j")
@@ -815,7 +873,7 @@ func TestInventoryLoadingAndFailureNeverAlterApplyConfirmation(t *testing.T) {
 
 func TestCapabilityInventoryIsLazyExactRevisionAndRequestedOnce(t *testing.T) {
 	var calls [][]string
-	m := newModel("/bin/atyrode")
+	m := newApplyTestModel("/bin/atyrode")
 	m.phase = ready
 	m.plan = applyPlan{
 		Host: "workstation", System: "x86_64-linux", Source: "remote",
@@ -848,7 +906,7 @@ func TestCapabilityInventoryIsLazyExactRevisionAndRequestedOnce(t *testing.T) {
 }
 
 func TestInspectionRequestsNeverOverlap(t *testing.T) {
-	previewing := newModel("atyrode")
+	previewing := newApplyTestModel("atyrode")
 	previewing.phase = ready
 	previewing.plan.ResolvedRevision = testRevision
 	previewing.previewLoading = true
@@ -858,7 +916,7 @@ func TestInspectionRequestsNeverOverlap(t *testing.T) {
 		t.Fatal("capability inspection overlapped a running preview")
 	}
 
-	inventoryLoading := newModel("atyrode")
+	inventoryLoading := newApplyTestModel("atyrode")
 	inventoryLoading.phase = ready
 	inventoryLoading.plan.ResolvedRevision = testRevision
 	inventoryLoading.inventoryRequested, inventoryLoading.inventoryLoading = true, true
@@ -873,7 +931,7 @@ func TestInventoryContextIsCancelledByRefreshAndQuit(t *testing.T) {
 	for _, key := range []string{"r", "q"} {
 		t.Run(key, func(t *testing.T) {
 			started, cancelled := make(chan struct{}), make(chan struct{})
-			m := newModel("atyrode")
+			m := newApplyTestModel("atyrode")
 			m.phase = ready
 			m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", ResolvedRevision: testRevision}
 			m.runner = runnerFunc(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
@@ -1004,7 +1062,7 @@ func TestInventoryRepliesAreScopedToRevisionAndGeneration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := newModel("atyrode")
+			m := newApplyTestModel("atyrode")
 			m.plan.ResolvedRevision = currentRevision
 			m.inventoryGeneration, m.inventoryRequested, m.inventoryLoading = 8, true, true
 

--- a/pkgs/atyrode-tui/main_test.go
+++ b/pkgs/atyrode-tui/main_test.go
@@ -223,7 +223,7 @@ func TestOverviewStartsWithoutApplyWorkAndApplyPreviewRemainsExplicit(t *testing
 		t.Fatalf("Overview startup commands = %#v, want none", calls)
 	}
 	overview := stripTerminalControls(m.View())
-	for _, want := range []string{"overview", "Your Nix operating environment", "1  Overview", "2  Apply", "Tab next workspace"} {
+	for _, want := range []string{"overview", "Your Nix operating environment", "1  Overview", "2  Apply", "Tab/Shift+Tab navigate"} {
 		if !strings.Contains(overview, want) {
 			t.Errorf("Overview missing %q", want)
 		}
@@ -292,8 +292,8 @@ func TestWorkspaceNavigationPreservesApplyState(t *testing.T) {
 
 	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = next.(model)
-	if m.nav.Active() != workspaceLifecycle || cmd != nil {
-		t.Fatalf("second Tab entered %q with cmd %v, want lifecycle/nil", m.nav.Active(), cmd)
+	if m.nav.Active() != workspaceLifecycle || cmd == nil {
+		t.Fatalf("second Tab entered %q with cmd %v, want lifecycle load", m.nav.Active(), cmd)
 	}
 	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
 	m = next.(model)
@@ -305,6 +305,26 @@ func TestWorkspaceNavigationPreservesApplyState(t *testing.T) {
 	m = next.(model)
 	if m.nav.Active() != workspaceDoctor {
 		t.Fatalf("direct shortcut entered %q, want Doctor", m.nav.Active())
+	}
+}
+
+func TestOverviewAndAskStayWithinRepresentativeWindows(t *testing.T) {
+	for _, size := range []struct{ width, height int }{{44, 18}, {80, 26}, {100, 30}, {150, 44}} {
+		m := newModel("atyrode")
+		m.width, m.height = size.width, size.height
+		m.plan = applyPlan{Host: "workstation", System: "x86_64-linux", Revision: "feedfacefeed"}
+		for _, workspace := range []clikit.WorkspaceID{workspaceOverview, workspaceAsk} {
+			m.nav.Select(workspace)
+			view := m.View()
+			if rows := strings.Split(view, "\n"); len(rows) > m.height {
+				t.Errorf("%s at %dx%d rendered %d rows", workspace, m.width, m.height, len(rows))
+			}
+			for _, row := range strings.Split(view, "\n") {
+				if got := lipgloss.Width(row); got >= m.width {
+					t.Errorf("%s at %dx%d rendered row width %d: %q", workspace, m.width, m.height, got, stripTerminalControls(row))
+				}
+			}
+		}
 	}
 }
 

--- a/pkgs/atyrode-tui/navigation.go
+++ b/pkgs/atyrode-tui/navigation.go
@@ -55,7 +55,7 @@ func (m *model) activateWorkspace(id clikit.WorkspaceID) tea.Cmd {
 		}
 		return m.loadLifecycle()
 	case workspaceDoctor:
-		if m.doctorReportMissing(m.doctorTab) && !m.doctorLoading[m.doctorTab] {
+		if m.doctorReportUnrequested(m.doctorTab) && !m.doctorLoading[m.doctorTab] {
 			return m.startDoctor(m.doctorTab)
 		}
 	case workspaceCapability:
@@ -112,12 +112,15 @@ func (m model) shellFooter() string {
 	return clikit.ClipLines(clikit.StDim.Render(text), width)
 }
 
-// workspaceBodyHeight reserves the shared shell title, tabs, footer, section
-// gaps, panel borders/title, and one local control row. Workspaces cap their
-// clipped lists with this value instead of preallocating unused terminal rows.
+// workspaceBodyHeight reserves the shared shell and panel chrome plus each
+// workspace's local tabs and controls. Workspaces cap clipped lists with this
+// value instead of preallocating unused terminal rows.
 func (m model) workspaceBodyHeight() int {
-	const shellAndPanelChromeRows = 12
-	return max(1, m.height-shellAndPanelChromeRows)
+	chromeRows := 12
+	if m.nav.Active() == workspaceDoctor {
+		chromeRows++
+	}
+	return max(1, m.height-chromeRows)
 }
 
 func intersperse(values []string, separator string) []string {

--- a/pkgs/atyrode-tui/navigation.go
+++ b/pkgs/atyrode-tui/navigation.go
@@ -41,12 +41,31 @@ func workspaceForShortcut(key string) (clikit.WorkspaceID, bool) {
 
 func (m *model) activateWorkspace(id clikit.WorkspaceID) tea.Cmd {
 	m.nav.Select(id)
-	if id != workspaceApply || m.applyRequested {
+	switch id {
+	case workspaceApply:
+		if m.applyRequested {
+			return nil
+		}
+		m.applyRequested = true
+		m.phase, m.err, m.status = loadingPlan, nil, ""
+		return m.loadPlan()
+	case workspaceLifecycle:
+		if m.lifecycleLoading || len(m.generations) > 0 || m.lifecycleErr != nil {
+			return nil
+		}
+		return m.loadLifecycle()
+	case workspaceDoctor:
+		if m.doctorReportMissing(m.doctorTab) && !m.doctorLoading[m.doctorTab] {
+			return m.startDoctor(m.doctorTab)
+		}
+	case workspaceCapability:
+		if m.plan.ResolvedRevision != "" {
+			return m.startInventory()
+		}
+	default:
 		return nil
 	}
-	m.applyRequested = true
-	m.phase, m.err, m.status = loadingPlan, nil, ""
-	return m.loadPlan()
+	return nil
 }
 
 func (m *model) nextWorkspace(delta int) tea.Cmd {
@@ -84,10 +103,21 @@ func (m model) workspaceTabs(width int) string {
 func (m model) shellFooter() string {
 	_, width := m.horizontalLayout()
 	text := "Tab next workspace  ·  Shift+Tab previous  ·  1–6 jump  ·  Ctrl+O ask  ·  q quit"
-	if m.width < 60 {
-		text = "Tab next  ·  ⇧Tab back  ·  1–6 jump  ·  q"
+	switch {
+	case m.width < 60:
+		text = "Tab/⇧Tab navigate  ·  1–6 jump  ·  q"
+	case m.width < 112:
+		text = "Tab/Shift+Tab navigate  ·  1–6 jump  ·  ^O ask  ·  q quit"
 	}
 	return clikit.ClipLines(clikit.StDim.Render(text), width)
+}
+
+// workspaceBodyHeight reserves the shared shell title, tabs, footer, section
+// gaps, panel borders/title, and one local control row. Workspaces cap their
+// clipped lists with this value instead of preallocating unused terminal rows.
+func (m model) workspaceBodyHeight() int {
+	const shellAndPanelChromeRows = 12
+	return max(1, m.height-shellAndPanelChromeRows)
 }
 
 func intersperse(values []string, separator string) []string {

--- a/pkgs/atyrode-tui/navigation.go
+++ b/pkgs/atyrode-tui/navigation.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"strings"
+
+	clikit "cli-kit"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	workspaceOverview   clikit.WorkspaceID = "overview"
+	workspaceApply      clikit.WorkspaceID = "apply"
+	workspaceLifecycle  clikit.WorkspaceID = "lifecycle"
+	workspaceDoctor     clikit.WorkspaceID = "doctor"
+	workspaceCapability clikit.WorkspaceID = "capabilities"
+	workspaceAsk        clikit.WorkspaceID = "ask"
+)
+
+var cockpitWorkspaceItems = []clikit.WorkspaceItem{
+	{ID: workspaceOverview, Label: "Overview", Shortcut: "1"},
+	{ID: workspaceApply, Label: "Apply", Shortcut: "2"},
+	{ID: workspaceLifecycle, Label: "Generations / Clean", Shortcut: "3"},
+	{ID: workspaceDoctor, Label: "Doctor", Shortcut: "4"},
+	{ID: workspaceCapability, Label: "Capabilities", Shortcut: "5"},
+	{ID: workspaceAsk, Label: "Ask", Shortcut: "6"},
+}
+
+func newCockpitNav() clikit.WorkspaceNav {
+	return clikit.NewWorkspaceNav(cockpitWorkspaceItems...)
+}
+
+func workspaceForShortcut(key string) (clikit.WorkspaceID, bool) {
+	for _, item := range cockpitWorkspaceItems {
+		if item.Shortcut == key {
+			return item.ID, true
+		}
+	}
+	return "", false
+}
+
+func (m *model) activateWorkspace(id clikit.WorkspaceID) tea.Cmd {
+	m.nav.Select(id)
+	if id != workspaceApply || m.applyRequested {
+		return nil
+	}
+	m.applyRequested = true
+	m.phase, m.err, m.status = loadingPlan, nil, ""
+	return m.loadPlan()
+}
+
+func (m *model) nextWorkspace(delta int) tea.Cmd {
+	var id clikit.WorkspaceID
+	if delta < 0 {
+		id = m.nav.Previous()
+	} else {
+		id = m.nav.Next()
+	}
+	return m.activateWorkspace(id)
+}
+
+func (m model) workspaceTitle() string {
+	item, ok := m.nav.ActiveItem()
+	if !ok {
+		return "overview"
+	}
+	return strings.ToLower(item.Label)
+}
+
+func (m model) workspaceTabs(width int) string {
+	items := m.nav.Items()
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		label := item.Shortcut + " " + item.Label
+		if item.ID == m.nav.Active() {
+			parts = append(parts, pillStyle.Render(label))
+		} else {
+			parts = append(parts, clikit.StDim.Render(label))
+		}
+	}
+	return clikit.ClipLines(lipgloss.JoinHorizontal(lipgloss.Top, intersperse(parts, "  ")...), width)
+}
+
+func (m model) shellFooter() string {
+	_, width := m.horizontalLayout()
+	text := "Tab next workspace  ·  Shift+Tab previous  ·  1–6 jump  ·  Ctrl+O ask  ·  q quit"
+	if m.width < 60 {
+		text = "Tab next  ·  ⇧Tab back  ·  1–6 jump  ·  q"
+	}
+	return clikit.ClipLines(clikit.StDim.Render(text), width)
+}
+
+func intersperse(values []string, separator string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	result := make([]string, 0, len(values)*2-1)
+	for i, value := range values {
+		if i > 0 {
+			result = append(result, separator)
+		}
+		result = append(result, value)
+	}
+	return result
+}

--- a/pkgs/atyrode-tui/overview.go
+++ b/pkgs/atyrode-tui/overview.go
@@ -8,28 +8,33 @@ import (
 )
 
 func (m model) overviewView(width int) string {
+	rows := make([]string, 0, len(m.nav.Items())*2)
+	detailed := m.height >= 34
+	for _, item := range m.nav.Items() {
+		rows = append(rows, clikit.StHead.Render(item.Shortcut+"  "+item.Label))
+		if detailed {
+			rows = append(rows, "   "+clikit.StDim.Render(workspacePurpose(item.ID)))
+		}
+	}
+	workspaces := clikit.Panel(width, titleStyle.Render("Workspaces")+"\n\n"+strings.Join(rows, "\n"))
+	if m.height < 24 {
+		return workspaces
+	}
+
 	identity := []string{
 		titleStyle.Render("Your Nix operating environment"),
 		clikit.StDim.Render("Inspect, plan, and maintain every registered configuration from one cockpit."),
 	}
-	if m.plan.Host != "" {
-		identity = append(identity, "", labelStyle.Render("host")+m.plan.Host, labelStyle.Render("system")+m.plan.System, labelStyle.Render("revision")+m.plan.Revision)
-	} else {
-		identity = append(identity, "", clikit.StDim.Render("Open Apply to resolve the current host and revision."))
+	if detailed {
+		if m.plan.Host != "" {
+			identity = append(identity, "", labelStyle.Render("host")+m.plan.Host, labelStyle.Render("system")+m.plan.System, labelStyle.Render("revision")+m.plan.Revision)
+		} else {
+			identity = append(identity, "", clikit.StDim.Render("Open Apply to resolve the current host and revision."))
+		}
+	} else if m.plan.Host != "" {
+		identity = append(identity, clikit.StDim.Render(m.plan.Host+" · "+m.plan.System+" · "+m.plan.Revision))
 	}
-
-	rows := make([]string, 0, len(m.nav.Items())*2)
-	for _, item := range m.nav.Items() {
-		purpose := workspacePurpose(item.ID)
-		rows = append(rows, clikit.StHead.Render(item.Shortcut+"  "+item.Label))
-		rows = append(rows, "   "+clikit.StDim.Render(purpose))
-	}
-
-	content := strings.Join([]string{
-		clikit.Panel(width, strings.Join(identity, "\n")),
-		clikit.Panel(width, titleStyle.Render("Workspaces")+"\n\n"+strings.Join(rows, "\n")),
-	}, "\n\n")
-	return content
+	return strings.Join([]string{clikit.Panel(width, strings.Join(identity, "\n")), workspaces}, "\n\n")
 }
 
 func workspacePurpose(id clikit.WorkspaceID) string {

--- a/pkgs/atyrode-tui/overview.go
+++ b/pkgs/atyrode-tui/overview.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	clikit "cli-kit"
+)
+
+func (m model) overviewView(width int) string {
+	identity := []string{
+		titleStyle.Render("Your Nix operating environment"),
+		clikit.StDim.Render("Inspect, plan, and maintain every registered configuration from one cockpit."),
+	}
+	if m.plan.Host != "" {
+		identity = append(identity, "", labelStyle.Render("host")+m.plan.Host, labelStyle.Render("system")+m.plan.System, labelStyle.Render("revision")+m.plan.Revision)
+	} else {
+		identity = append(identity, "", clikit.StDim.Render("Open Apply to resolve the current host and revision."))
+	}
+
+	rows := make([]string, 0, len(m.nav.Items())*2)
+	for _, item := range m.nav.Items() {
+		purpose := workspacePurpose(item.ID)
+		rows = append(rows, clikit.StHead.Render(item.Shortcut+"  "+item.Label))
+		rows = append(rows, "   "+clikit.StDim.Render(purpose))
+	}
+
+	content := strings.Join([]string{
+		clikit.Panel(width, strings.Join(identity, "\n")),
+		clikit.Panel(width, titleStyle.Render("Workspaces")+"\n\n"+strings.Join(rows, "\n")),
+	}, "\n\n")
+	return content
+}
+
+func workspacePurpose(id clikit.WorkspaceID) string {
+	switch id {
+	case workspaceOverview:
+		return "Orientation, current identity, and attention items."
+	case workspaceApply:
+		return "Resolve, preview, and activate a pinned configuration."
+	case workspaceLifecycle:
+		return "Inspect generations, preview rollback, and reclaim store space."
+	case workspaceDoctor:
+		return "Inspect host registration, system policy, and managed tools."
+	case workspaceCapability:
+		return "Browse active capabilities and their resolved deliverables."
+	case workspaceAsk:
+		return "Ask a read-only, command-grounded question about atyrode."
+	default:
+		return fmt.Sprintf("Workspace %q", id)
+	}
+}
+
+func (m model) askWorkspaceView(width int) string {
+	body := strings.Join([]string{
+		titleStyle.Render("Ask atyrode"),
+		"",
+		"Open the shared cli-kit PromptBox with " + clikit.StHead.Render("Ctrl+O") + ".",
+		clikit.StDim.Render("Answers are grounded in the installed atyrode command reference and remain read-only."),
+	}, "\n")
+	return clikit.Panel(width, body)
+}
+
+func (m model) pendingWorkspaceView(width int) string {
+	item, _ := m.nav.ActiveItem()
+	body := strings.Join([]string{
+		titleStyle.Render(item.Label),
+		"",
+		clikit.StDim.Render(workspacePurpose(item.ID)),
+		clikit.StDim.Render("This workspace is being connected to its existing atyrode JSON contract."),
+	}, "\n")
+	return clikit.Panel(width, body)
+}

--- a/pkgs/atyrode-tui/overview.go
+++ b/pkgs/atyrode-tui/overview.go
@@ -65,14 +65,3 @@ func (m model) askWorkspaceView(width int) string {
 	}, "\n")
 	return clikit.Panel(width, body)
 }
-
-func (m model) pendingWorkspaceView(width int) string {
-	item, _ := m.nav.ActiveItem()
-	body := strings.Join([]string{
-		titleStyle.Render(item.Label),
-		"",
-		clikit.StDim.Render(workspacePurpose(item.ID)),
-		clikit.StDim.Render("This workspace is being connected to its existing atyrode JSON contract."),
-	}, "\n")
-	return clikit.Panel(width, body)
-}

--- a/pkgs/cli-kit/README.md
+++ b/pkgs/cli-kit/README.md
@@ -13,6 +13,12 @@ Consumed as a local Go module via `replace cli-kit => ../cli-kit`.
   `PadLeft`/`Pad`, `WindowList` (a clipped, scrollbar'd column), `Scrollbar`,
   meters, and full-width `Rule`/`SeparatedSections` boundaries. Widths are
   terminal cells; empty sections produce no orphan rule.
+- **Workspace and panel primitives** (`workspace.go`, `panel.go`) —
+  `WorkspaceNav` owns ordered selection, wrapping next/previous navigation, and
+  stable application-defined IDs; `Panel`, `PanelContentWidth`, and `ClipLines`
+  provide shared rounded chrome with terminal-cell clipping and no wrap-driven
+  footer displacement. Domain models retain their own loading and mutation
+  state.
 - **Footer conventions** (`palette.go`, `layout.go`) — `NewHelp` applies the
   shared key/description/separator palette to Bubble Help, while `WrapHelp`
   wraps complete required cues without dropping them. Both remain ANSI-aware

--- a/pkgs/cli-kit/panel.go
+++ b/pkgs/cli-kit/panel.go
@@ -1,0 +1,50 @@
+package clikit
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+var panelStyle = lipgloss.NewStyle().
+	Border(lipgloss.RoundedBorder()).
+	BorderForeground(lipgloss.Color(CBord)).
+	Padding(0, 1)
+
+// Panel renders clipped content inside cli-kit's shared rounded chrome. The
+// returned block never exceeds width, preventing terminal auto-wrap from moving
+// footers below the viewport.
+func Panel(width int, content string) string {
+	if width < 1 {
+		width = 1
+	}
+	frame := panelStyle.GetHorizontalFrameSize()
+	if width <= frame {
+		return ClipLines(content, width)
+	}
+	inner := PanelContentWidth(width)
+	styleWidth := width - panelStyle.GetHorizontalBorderSize()
+	return panelStyle.Width(styleWidth).Render(ClipLines(content, inner))
+}
+
+// PanelContentWidth reports the usable content width inside Panel.
+func PanelContentWidth(width int) int {
+	inner := width - panelStyle.GetHorizontalFrameSize()
+	if inner < 1 {
+		return 1
+	}
+	return inner
+}
+
+// ClipLines truncates every physical row to width without wrapping.
+func ClipLines(content string, width int) string {
+	if width < 1 {
+		width = 1
+	}
+	lines := strings.Split(content, "\n")
+	for i := range lines {
+		lines[i] = ansi.Truncate(lines[i], width, "")
+	}
+	return strings.Join(lines, "\n")
+}

--- a/pkgs/cli-kit/panel_test.go
+++ b/pkgs/cli-kit/panel_test.go
@@ -1,0 +1,38 @@
+package clikit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestPanelClipsWithoutWrapping(t *testing.T) {
+	for _, width := range []int{1, 12, 40} {
+		out := Panel(width, strings.Repeat("x", 120)+"\nsecond")
+		if got := lipgloss.Width(out); got > width {
+			t.Fatalf("Panel width = %d, want <= %d\n%s", got, width, out)
+		}
+		wantHeight := 4
+		if width == 1 {
+			wantHeight = 2
+		}
+		if got := lipgloss.Height(out); got != wantHeight {
+			t.Fatalf("Panel(%d) height = %d, want %d physical rows\n%s", width, got, wantHeight, out)
+		}
+	}
+}
+
+func TestPanelContentWidthIsAlwaysUsable(t *testing.T) {
+	previous := 0
+	for width := -2; width <= 40; width++ {
+		got := PanelContentWidth(width)
+		if got < 1 {
+			t.Fatalf("PanelContentWidth(%d) = %d", width, got)
+		}
+		if width > 1 && got < previous {
+			t.Fatalf("PanelContentWidth decreased at %d: %d < %d", width, got, previous)
+		}
+		previous = got
+	}
+}

--- a/pkgs/cli-kit/workspace.go
+++ b/pkgs/cli-kit/workspace.go
@@ -1,0 +1,96 @@
+package clikit
+
+// WorkspaceID identifies one persistent destination in a TUI shell. IDs are
+// application-defined; cli-kit only owns ordering and navigation semantics.
+type WorkspaceID string
+
+// WorkspaceItem describes one destination shown by a TUI shell.
+type WorkspaceItem struct {
+	ID       WorkspaceID
+	Label    string
+	Shortcut string
+}
+
+// WorkspaceNav is a domain-free, persistent workspace navigator. It deliberately
+// owns no rendering or Bubble Tea messages so applications can keep their local
+// state while sharing one predictable navigation model.
+type WorkspaceNav struct {
+	items  []WorkspaceItem
+	active int
+}
+
+// NewWorkspaceNav constructs a navigator in declaration order. Empty and
+// duplicate IDs are ignored so Active always identifies an unambiguous item.
+func NewWorkspaceNav(items ...WorkspaceItem) WorkspaceNav {
+	seen := make(map[WorkspaceID]struct{}, len(items))
+	filtered := make([]WorkspaceItem, 0, len(items))
+	for _, item := range items {
+		if item.ID == "" {
+			continue
+		}
+		if _, exists := seen[item.ID]; exists {
+			continue
+		}
+		seen[item.ID] = struct{}{}
+		filtered = append(filtered, item)
+	}
+	return WorkspaceNav{items: filtered}
+}
+
+// Items returns a copy of the ordered workspace declarations.
+func (n WorkspaceNav) Items() []WorkspaceItem {
+	return append([]WorkspaceItem(nil), n.items...)
+}
+
+// Active returns the selected workspace ID, or the empty ID for an empty nav.
+func (n WorkspaceNav) Active() WorkspaceID {
+	if len(n.items) == 0 {
+		return ""
+	}
+	return n.items[n.activeIndex()].ID
+}
+
+// ActiveItem returns the selected declaration and whether one exists.
+func (n WorkspaceNav) ActiveItem() (WorkspaceItem, bool) {
+	if len(n.items) == 0 {
+		return WorkspaceItem{}, false
+	}
+	return n.items[n.activeIndex()], true
+}
+
+// Select activates id. Unknown IDs leave the navigator unchanged.
+func (n *WorkspaceNav) Select(id WorkspaceID) bool {
+	for i, item := range n.items {
+		if item.ID == id {
+			changed := n.activeIndex() != i
+			n.active = i
+			return changed
+		}
+	}
+	return false
+}
+
+// Next advances one destination, wrapping at the end.
+func (n *WorkspaceNav) Next() WorkspaceID {
+	if len(n.items) == 0 {
+		return ""
+	}
+	n.active = (n.activeIndex() + 1) % len(n.items)
+	return n.items[n.active].ID
+}
+
+// Previous moves back one destination, wrapping at the beginning.
+func (n *WorkspaceNav) Previous() WorkspaceID {
+	if len(n.items) == 0 {
+		return ""
+	}
+	n.active = (n.activeIndex() - 1 + len(n.items)) % len(n.items)
+	return n.items[n.active].ID
+}
+
+func (n WorkspaceNav) activeIndex() int {
+	if n.active < 0 || n.active >= len(n.items) {
+		return 0
+	}
+	return n.active
+}

--- a/pkgs/cli-kit/workspace_test.go
+++ b/pkgs/cli-kit/workspace_test.go
@@ -1,0 +1,67 @@
+package clikit
+
+import "testing"
+
+func TestWorkspaceNavCyclesInDeclarationOrder(t *testing.T) {
+	nav := NewWorkspaceNav(
+		WorkspaceItem{ID: "overview", Label: "Overview", Shortcut: "1"},
+		WorkspaceItem{ID: "apply", Label: "Apply", Shortcut: "2"},
+		WorkspaceItem{ID: "doctor", Label: "Doctor", Shortcut: "3"},
+	)
+
+	if got := nav.Active(); got != "overview" {
+		t.Fatalf("initial active = %q, want overview", got)
+	}
+	if got := nav.Next(); got != "apply" {
+		t.Fatalf("next = %q, want apply", got)
+	}
+	if got := nav.Next(); got != "doctor" {
+		t.Fatalf("next = %q, want doctor", got)
+	}
+	if got := nav.Next(); got != "overview" {
+		t.Fatalf("wrapped next = %q, want overview", got)
+	}
+	if got := nav.Previous(); got != "doctor" {
+		t.Fatalf("wrapped previous = %q, want doctor", got)
+	}
+}
+
+func TestWorkspaceNavSelectionAndItemsAreStable(t *testing.T) {
+	nav := NewWorkspaceNav(
+		WorkspaceItem{},
+		WorkspaceItem{ID: "overview", Label: "Overview"},
+		WorkspaceItem{ID: "overview", Label: "Duplicate"},
+		WorkspaceItem{ID: "apply", Label: "Apply"},
+	)
+
+	items := nav.Items()
+	if len(items) != 2 || items[0].Label != "Overview" || items[1].Label != "Apply" {
+		t.Fatalf("filtered items = %#v", items)
+	}
+	items[0].Label = "mutated copy"
+	if got := nav.Items()[0].Label; got != "Overview" {
+		t.Fatalf("Items exposed internal storage: %q", got)
+	}
+	if nav.Select("missing") {
+		t.Fatal("selecting an unknown workspace reported a change")
+	}
+	if !nav.Select("apply") || nav.Active() != "apply" {
+		t.Fatalf("select apply: changed=%v active=%q", nav.Select("apply"), nav.Active())
+	}
+	if nav.Select("apply") {
+		t.Fatal("selecting the active workspace reported a change")
+	}
+}
+
+func TestWorkspaceNavEmptyIsSafe(t *testing.T) {
+	var nav WorkspaceNav
+	if nav.Active() != "" || nav.Next() != "" || nav.Previous() != "" {
+		t.Fatalf("empty navigator produced an active workspace: %q", nav.Active())
+	}
+	if _, ok := nav.ActiveItem(); ok {
+		t.Fatal("empty navigator returned an active item")
+	}
+	if nav.Select("overview") {
+		t.Fatal("empty navigator selected an unknown workspace")
+	}
+}


### PR DESCRIPTION
## Context

The Apply cockpit is currently the root model, while #107 requires a neutral Overview and persistent navigation before the remaining workspaces land. This branch establishes the shared cli-kit shell and then completes the read-only and lifecycle panels.

## Plan

- add cli-kit-owned panel chrome and workspace navigation
- add Overview and lazy, state-preserving Apply entry
- implement Doctor and Capabilities for #112
- implement Generations, rollback preview, and Clean confirmation for #111
- verify responsive layout, mutation boundaries, and explicit/non-TTY CLI behavior

## Verification

In progress; focused Go/package tests and headless tmux/freeze verification will be recorded before this leaves draft.

Closes #215
Closes #111
Closes #112