### PR TITLE
feat(atyrode): expand cockpit clean controls

### DIFF
--- a/pkgs/atyrode-tui/README.md
+++ b/pkgs/atyrode-tui/README.md
@@ -20,11 +20,12 @@ Ask grounding, so packaged and checkout-specific behavior remain aligned.
 ## Overview and navigation
 
 Overview explains the cockpit and lists every workspace without preallocating
-empty panel height. `Tab` and `Shift+Tab` cycle persistent workspaces; `1`–`6`
-jump directly to Overview, Apply, Generations/Clean, Doctor, Capabilities, and
-Ask. Local loading, selection, scroll, preview, and confirmation state survives
-round trips between workspaces. Narrow and medium layouts shorten controls and
-clip navigation chrome without allowing a row to enter the terminal auto-wrap
+empty panel height. The top navigation is an aligned responsive grid of numbered
+titles (`1. Overview` through `6. Ask`); only the selected cell's background
+moves. `Tab` and `Shift+Tab` cycle persistent workspaces, while `1`–`6` jump
+directly. Local loading, selection, scroll, preview, and confirmation state
+survives round trips between workspaces. Narrow and medium layouts wrap the
+complete grid and shorten controls without entering the terminal auto-wrap
 column.
 
 ## Apply panel
@@ -88,14 +89,19 @@ generation, and keeps rollback and cleanup behind preview-first confirmation:
 
 - rollback runs `rollback --to N --dry-run`, displays the exact target, then
   requires `y` before `rollback --to N --yes`;
-- cleanup runs `clean --dry-run --json`, displays the exact `keep` and
-  `keepSince` policy and candidates, then requires `y` before forwarding those
-  same values to `clean --keep N --keep-since D --yes`.
+- cleanup opens a policy editor for every `atyrode clean` capability: keep
+  count, keep-since duration, user or all-profile scope (`--all`), and verbose
+  planning (`--verbose`);
+- `Ctrl+X` selects maximum reclaim (`--keep 0 --keep-since 0d`), which still
+  retains the current generation;
+- Enter runs the exact configured policy through `clean --dry-run --json`,
+  validates that the returned scope and retention values match, and displays
+  every candidate before `y` forwards the same policy with `--yes`.
 
-The current generation cannot be selected for rollback, cancellation before
-confirmation performs no mutation, and the cockpit never adds `--all`. Once
-confirmed, a real lifecycle mutation cannot be cancelled or left until its
-authoritative command result is reported.
+JSON stdout is decoded separately from progress and diagnostics on stderr. The
+current generation cannot be selected for rollback, cancellation before
+confirmation performs no mutation, and a confirmed lifecycle mutation cannot
+be cancelled or left until its authoritative command result is reported.
 
 ## Ask panel
 

--- a/pkgs/atyrode-tui/lifecycle.go
+++ b/pkgs/atyrode-tui/lifecycle.go
@@ -18,6 +18,7 @@ type lifecyclePhase int
 
 const (
 	lifecycleBrowsing lifecyclePhase = iota
+	lifecycleCleanConfiguring
 	lifecycleRollbackPreviewing
 	lifecycleRollbackConfirming
 	lifecycleCleanPreviewing
@@ -53,6 +54,29 @@ type cleanPreview struct {
 	} `json:"generations"`
 	ReclaimCandidates []cleanCandidate `json:"reclaimCandidates"`
 	Note              string           `json:"note"`
+}
+
+type cleanPolicyField int
+
+const (
+	cleanKeepField cleanPolicyField = iota
+	cleanKeepSinceField
+	cleanScopeField
+	cleanVerboseField
+	cleanPolicyFieldCount
+)
+
+type cleanPolicyDraft struct {
+	Keep      string
+	KeepSince string
+	All       bool
+	Verbose   bool
+	Field     cleanPolicyField
+	Err       string
+}
+
+func defaultCleanPolicyDraft() cleanPolicyDraft {
+	return cleanPolicyDraft{Keep: "5", KeepSince: "30d"}
 }
 
 type lifecycleAction int
@@ -112,7 +136,8 @@ func validateGenerations(generations []generation) error {
 }
 
 func validateCleanPreview(preview cleanPreview) error {
-	if preview.Keep < 0 || strings.TrimSpace(preview.KeepSince) == "" || !preview.DryRun {
+	if preview.Keep < 0 || strings.TrimSpace(preview.KeepSince) == "" || !preview.DryRun ||
+		(preview.Scope != "user" && preview.Scope != "all") || strings.TrimSpace(preview.Profile) == "" {
 		return fmt.Errorf("clean preview has invalid retention policy")
 	}
 	seen := make(map[uint64]struct{}, len(preview.ReclaimCandidates))
@@ -160,6 +185,7 @@ func (m *model) lifecycleCommand(action lifecycleAction, args ...string) tea.Cmd
 	m.lifecycleCancel = cancel
 	m.lifecycleErr = nil
 	runner, cli := m.runner, m.cli
+	cleanDraft := m.cleanDraft
 	return func() tea.Msg {
 		out, err := runner.Output(ctx, cli, args...)
 		if err != nil {
@@ -172,6 +198,14 @@ func (m *model) lifecycleCommand(action lifecycleAction, args ...string) tea.Cmd
 			}
 			if err := validateCleanPreview(preview); err != nil {
 				return lifecycleMsg{generation: generation, action: action, err: fmt.Errorf("decode clean preview: %w", err)}
+			}
+			expectedKeep, parseErr := strconv.Atoi(cleanDraft.Keep)
+			expectedScope := "user"
+			if cleanDraft.All {
+				expectedScope = "all"
+			}
+			if parseErr != nil || preview.Keep != expectedKeep || preview.KeepSince != cleanDraft.KeepSince || preview.Scope != expectedScope {
+				return lifecycleMsg{generation: generation, action: action, err: fmt.Errorf("clean preview does not match the requested retention policy")}
 			}
 			return lifecycleMsg{generation: generation, action: action, clean: preview}
 		}
@@ -194,7 +228,97 @@ func (m model) selectedGeneration() (generation, bool) {
 	return m.generations[m.lifecycleCursor], true
 }
 
+func (d cleanPolicyDraft) values() (int, string, error) {
+	keep, err := strconv.Atoi(d.Keep)
+	if err != nil || keep < 0 {
+		return 0, "", fmt.Errorf("keep newest must be a non-negative number")
+	}
+	keepSince := strings.TrimSpace(d.KeepSince)
+	if keepSince == "" {
+		return 0, "", fmt.Errorf("keep since must not be empty")
+	}
+	return keep, keepSince, nil
+}
+
+func cleanCommandArgs(keep int, keepSince string, all, verbose, preview bool) []string {
+	args := []string{"clean", "--keep", strconv.Itoa(keep), "--keep-since", keepSince}
+	if all {
+		args = append(args, "--all")
+	}
+	if verbose {
+		args = append(args, "--verbose")
+	}
+	if preview {
+		return append(args, "--dry-run", "--json")
+	}
+	return append(args, "--yes")
+}
+
+func trimLastRune(value string) string {
+	runes := []rune(value)
+	if len(runes) == 0 {
+		return value
+	}
+	return string(runes[:len(runes)-1])
+}
+
+func (m *model) cleanPolicyUpdate(key string) tea.Cmd {
+	switch key {
+	case "esc":
+		m.cleanDraft.Err = ""
+		m.lifecyclePhase = lifecycleBrowsing
+	case "tab", "down":
+		m.cleanDraft.Field = cleanPolicyField((int(m.cleanDraft.Field) + 1) % int(cleanPolicyFieldCount))
+	case "shift+tab", "up":
+		m.cleanDraft.Field = cleanPolicyField((int(m.cleanDraft.Field) + int(cleanPolicyFieldCount) - 1) % int(cleanPolicyFieldCount))
+	case "ctrl+x":
+		m.cleanDraft.Keep, m.cleanDraft.KeepSince, m.cleanDraft.Err = "0", "0d", ""
+	case "left", "right", "space":
+		switch m.cleanDraft.Field {
+		case cleanScopeField:
+			m.cleanDraft.All = !m.cleanDraft.All
+		case cleanVerboseField:
+			m.cleanDraft.Verbose = !m.cleanDraft.Verbose
+		}
+	case "backspace", "delete":
+		switch m.cleanDraft.Field {
+		case cleanKeepField:
+			m.cleanDraft.Keep = trimLastRune(m.cleanDraft.Keep)
+		case cleanKeepSinceField:
+			m.cleanDraft.KeepSince = trimLastRune(m.cleanDraft.KeepSince)
+		}
+	case "enter":
+		keep, keepSince, err := m.cleanDraft.values()
+		if err != nil {
+			m.cleanDraft.Err = err.Error()
+			return nil
+		}
+		m.cleanDraft.Keep, m.cleanDraft.KeepSince, m.cleanDraft.Err = strconv.Itoa(keep), keepSince, ""
+		m.lifecyclePhase = lifecycleCleanPreviewing
+		return m.lifecycleCommand(previewClean, cleanCommandArgs(keep, keepSince, m.cleanDraft.All, m.cleanDraft.Verbose, true)...)
+	default:
+		runes := []rune(key)
+		if len(runes) != 1 || len(key) > 4 {
+			return nil
+		}
+		switch m.cleanDraft.Field {
+		case cleanKeepField:
+			if runes[0] >= '0' && runes[0] <= '9' && len(m.cleanDraft.Keep) < 6 {
+				m.cleanDraft.Keep += key
+			}
+		case cleanKeepSinceField:
+			if !strings.ContainsAny(key, " \t\r\n") && len(m.cleanDraft.KeepSince) < 32 {
+				m.cleanDraft.KeepSince += key
+			}
+		}
+	}
+	return nil
+}
+
 func (m *model) lifecycleUpdate(key string) tea.Cmd {
+	if m.lifecyclePhase == lifecycleCleanConfiguring {
+		return m.cleanPolicyUpdate(key)
+	}
 	switch key {
 	case "r":
 		if m.lifecyclePhase == lifecycleBrowsing || m.lifecyclePhase == lifecycleSucceeded || m.lifecyclePhase == lifecycleFailed {
@@ -206,8 +330,9 @@ func (m *model) lifecycleUpdate(key string) tea.Cmd {
 		}
 	case "c":
 		if m.lifecyclePhase == lifecycleBrowsing || m.lifecyclePhase == lifecycleSucceeded || m.lifecyclePhase == lifecycleFailed {
-			m.lifecyclePhase = lifecycleCleanPreviewing
-			return m.lifecycleCommand(previewClean, "clean", "--dry-run", "--json")
+			m.cleanDraft.Err = ""
+			m.lifecycleErr = nil
+			m.lifecyclePhase = lifecycleCleanConfiguring
 		}
 	case "y":
 		switch m.lifecyclePhase {
@@ -216,7 +341,7 @@ func (m *model) lifecycleUpdate(key string) tea.Cmd {
 			return m.lifecycleCommand(executeRollback, "rollback", "--to", strconv.FormatUint(m.lifecycleTarget, 10), "--yes")
 		case lifecycleCleanConfirming:
 			m.lifecyclePhase = lifecycleMutating
-			return m.lifecycleCommand(executeClean, "clean", "--keep", strconv.Itoa(m.clean.Keep), "--keep-since", m.clean.KeepSince, "--yes")
+			return m.lifecycleCommand(executeClean, cleanCommandArgs(m.clean.Keep, m.clean.KeepSince, m.clean.Scope == "all", m.cleanDraft.Verbose, false)...)
 		}
 	case "n", "esc":
 		switch m.lifecyclePhase {
@@ -305,6 +430,8 @@ func (m model) lifecycleView(width int) string {
 		if m.lifecycleStatus != "" {
 			rowCursor += 2
 		}
+	} else if m.lifecyclePhase == lifecycleCleanConfiguring {
+		rowCursor = 1 + int(m.cleanDraft.Field)
 	}
 	body := clikit.WindowList(rows, rowCursor, bodyHeight, bodyWidth)
 	panel := clikit.Panel(width, titleStyle.Render("Generations / Clean")+"\n\n"+body)
@@ -319,6 +446,37 @@ func (m model) lifecycleRowsForWidth(width int) []string {
 		return []string{clikit.StBrk.Render("Lifecycle command failed"), clikit.StDim.Render(ansi.Truncate(m.lifecycleErr.Error(), width, "…"))}
 	}
 	switch m.lifecyclePhase {
+	case lifecycleCleanConfiguring:
+		scope := "user profile"
+		if m.cleanDraft.All {
+			scope = "all profiles (--all)"
+		}
+		verbose := "off"
+		if m.cleanDraft.Verbose {
+			verbose = "on"
+		}
+		values := []string{
+			"Keep newest: " + m.cleanDraft.Keep,
+			"Keep since: " + m.cleanDraft.KeepSince,
+			"Scope: " + scope,
+			"Verbose plan: " + verbose,
+		}
+		rows := []string{titleStyle.Render("Configure cleanup")}
+		for field, value := range values {
+			marker := "  "
+			if cleanPolicyField(field) == m.cleanDraft.Field {
+				marker = "> "
+			}
+			rows = append(rows, marker+value)
+		}
+		rows = append(rows, "",
+			clikit.StDim.Render("Ctrl+X selects maximum reclaim (keep 0, since 0d)."),
+			clikit.StDim.Render("The current generation is always retained."),
+		)
+		if m.cleanDraft.Err != "" {
+			rows = append(rows, clikit.StBrk.Render(m.cleanDraft.Err))
+		}
+		return rows
 	case lifecycleRollbackPreviewing:
 		return []string{clikit.StDim.Render("Previewing rollback…")}
 	case lifecycleRollbackConfirming:
@@ -330,6 +488,8 @@ func (m model) lifecycleRowsForWidth(width int) []string {
 			clikit.StWarn.Render("Cleanup preview"),
 			fmt.Sprintf("Keep newest: %d", m.clean.Keep),
 			"Keep since: " + m.clean.KeepSince,
+			"Scope: " + m.clean.Scope,
+			fmt.Sprintf("Verbose plan: %t", m.cleanDraft.Verbose),
 			clikit.StDim.Render("Current generation is always retained."),
 		}
 		for _, candidate := range m.clean.ReclaimCandidates {
@@ -366,11 +526,17 @@ func (m model) lifecycleRowsForWidth(width int) []string {
 }
 
 func (m model) lifecycleFooter(width int) string {
-	text := "↑↓ select  ·  r preview rollback  ·  c preview clean  ·  Ctrl+R refresh"
+	text := "↑↓ select  ·  r preview rollback  ·  c configure clean  ·  Ctrl+R refresh"
 	if width < 60 {
 		text = "↑↓ select  ·  r rollback  ·  c clean"
 	}
-	if m.lifecyclePhase == lifecycleRollbackConfirming || m.lifecyclePhase == lifecycleCleanConfirming {
+	switch m.lifecyclePhase {
+	case lifecycleCleanConfiguring:
+		text = "Tab field  ·  type edit  ·  ←/→ toggle  ·  Ctrl+X max  ·  Enter preview  ·  Esc cancel"
+		if width < 60 {
+			text = "Tab field  ·  ←/→ toggle  ·  Enter preview"
+		}
+	case lifecycleRollbackConfirming, lifecycleCleanConfirming:
 		text = "y confirm  ·  n / Esc cancel"
 	}
 	return clikit.ClipLines(clikit.StDim.Render(text), width)

--- a/pkgs/atyrode-tui/lifecycle_test.go
+++ b/pkgs/atyrode-tui/lifecycle_test.go
@@ -100,34 +100,91 @@ func TestLifecycleCancelAndCurrentGenerationHaveNoSideEffects(t *testing.T) {
 	}
 }
 
-func TestLifecycleCleanUsesPreviewPolicyExactly(t *testing.T) {
+func TestLifecycleCleanUsesConfiguredPolicyExactly(t *testing.T) {
 	var calls [][]string
 	m := lifecycleTestModel(t, runnerFunc(func(_ context.Context, _ string, args ...string) ([]byte, error) {
 		calls = append(calls, append([]string(nil), args...))
 		if len(calls) == 1 {
-			if !reflect.DeepEqual(args, []string{"clean", "--dry-run", "--json"}) {
-				t.Fatalf("clean preview arguments = %#v", args)
+			want := []string{"clean", "--keep", "7", "--keep-since", "45d", "--all", "--verbose", "--dry-run", "--json"}
+			if !reflect.DeepEqual(args, want) {
+				t.Fatalf("clean preview arguments = %#v, want %#v", args, want)
 			}
-			return []byte(`{"scope":"user","platform":"linux","profile":"/nix/var/nix/profiles/per-user/alex/home-manager","keep":7,"keepSince":"45d","dryRun":true,"generations":{"total":3,"candidates":1},"reclaimCandidates":[{"generation":2,"date":"2026-01-01 00:00:00","closureSize":"800 MiB"}],"note":"sizes may overlap"}`), nil
+			return []byte(`{"scope":"all","platform":"linux","profile":"/nix/var/nix/profiles/per-user/alex/home-manager","keep":7,"keepSince":"45d","dryRun":true,"generations":{"total":3,"candidates":1},"reclaimCandidates":[{"generation":2,"date":"2026-01-01 00:00:00","closureSize":"800 MiB"}],"note":"sizes may overlap"}`), nil
 		}
-		if !reflect.DeepEqual(args, []string{"clean", "--keep", "7", "--keep-since", "45d", "--yes"}) {
-			t.Fatalf("clean mutation arguments = %#v", args)
-		}
-		for _, arg := range args {
-			if arg == "--all" {
-				t.Fatal("clean mutation must never pass --all")
-			}
+		want := []string{"clean", "--keep", "7", "--keep-since", "45d", "--all", "--verbose", "--yes"}
+		if !reflect.DeepEqual(args, want) {
+			t.Fatalf("clean mutation arguments = %#v, want %#v", args, want)
 		}
 		return []byte("cleaned"), nil
 	}))
 
-	runLifecycleCmd(t, &m, m.lifecycleUpdate("c"))
+	if cmd := m.lifecycleUpdate("c"); cmd != nil || m.lifecyclePhase != lifecycleCleanConfiguring {
+		t.Fatalf("clean configuration entry: cmd=%v phase=%v", cmd, m.lifecyclePhase)
+	}
+	m.cleanDraft = cleanPolicyDraft{Keep: "7", KeepSince: "45d", All: true, Verbose: true}
+	runLifecycleCmd(t, &m, m.lifecycleUpdate("enter"))
 	if m.lifecyclePhase != lifecycleCleanConfirming {
 		t.Fatalf("clean preview phase = %v", m.lifecyclePhase)
 	}
 	runLifecycleCmd(t, &m, m.lifecycleUpdate("y"))
 	if len(calls) != 2 || m.lifecyclePhase != lifecycleSucceeded {
 		t.Fatalf("clean result calls=%#v phase=%v", calls, m.lifecyclePhase)
+	}
+}
+
+func TestCleanPolicyEditorOwnsTabAndNumberKeys(t *testing.T) {
+	m := lifecycleTestModel(t, runnerFunc(func(context.Context, string, ...string) ([]byte, error) { return nil, nil }))
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	m = next.(model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(model)
+	if m.nav.Active() != workspaceLifecycle || m.cleanDraft.Field != cleanKeepSinceField {
+		t.Fatalf("Tab escaped clean editor: active=%q field=%v", m.nav.Active(), m.cleanDraft.Field)
+	}
+	m.cleanDraft.Field = cleanKeepField
+	m.cleanDraft.Keep = ""
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	m = next.(model)
+	if m.nav.Active() != workspaceLifecycle || m.cleanDraft.Keep != "5" {
+		t.Fatalf("number shortcut escaped clean editor: active=%q keep=%q", m.nav.Active(), m.cleanDraft.Keep)
+	}
+}
+
+func TestCleanPolicyEditorSupportsMaximumReclaimAndValidation(t *testing.T) {
+	m := lifecycleTestModel(t, runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		return nil, errors.New("preview should not run for invalid input")
+	}))
+	m.lifecycleUpdate("c")
+	m.lifecycleUpdate("ctrl+x")
+	if m.cleanDraft.Keep != "0" || m.cleanDraft.KeepSince != "0d" {
+		t.Fatalf("maximum reclaim policy = %#v", m.cleanDraft)
+	}
+	m.lifecycleUpdate("tab")
+	m.lifecycleUpdate("tab")
+	m.lifecycleUpdate("space")
+	m.lifecycleUpdate("tab")
+	m.lifecycleUpdate("space")
+	if !m.cleanDraft.All || !m.cleanDraft.Verbose {
+		t.Fatalf("clean scope toggles = %#v", m.cleanDraft)
+	}
+
+	m.cleanDraft.Keep = ""
+	if cmd := m.lifecycleUpdate("enter"); cmd != nil {
+		t.Fatal("invalid clean policy scheduled a preview")
+	}
+	if m.lifecyclePhase != lifecycleCleanConfiguring || !strings.Contains(m.cleanDraft.Err, "non-negative number") {
+		t.Fatalf("invalid clean policy state: phase=%v error=%q", m.lifecyclePhase, m.cleanDraft.Err)
+	}
+}
+
+func TestCleanPreviewMustMatchRequestedPolicy(t *testing.T) {
+	m := lifecycleTestModel(t, runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		return []byte(`{"scope":"user","platform":"linux","profile":"/profile","keep":6,"keepSince":"30d","dryRun":true,"generations":{"total":1,"candidates":0},"reclaimCandidates":[],"note":""}`), nil
+	}))
+	m.lifecycleUpdate("c")
+	runLifecycleCmd(t, &m, m.lifecycleUpdate("enter"))
+	if m.lifecyclePhase != lifecycleFailed || m.lifecycleErr == nil || !strings.Contains(m.lifecycleErr.Error(), "does not match") {
+		t.Fatalf("mismatched clean preview accepted: phase=%v error=%v", m.lifecyclePhase, m.lifecycleErr)
 	}
 }
 

--- a/pkgs/atyrode-tui/main.go
+++ b/pkgs/atyrode-tui/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -89,7 +90,16 @@ func (execCommandRunner) Output(ctx context.Context, name string, args ...string
 		}
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 	}
-	return cmd.CombinedOutput()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	if stdout.Len() > 0 {
+		if err != nil && stderr.Len() > 0 {
+			err = fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+		}
+		return stdout.Bytes(), err
+	}
+	return stderr.Bytes(), err
 }
 
 type applyFunc func(string, ...string) tea.Cmd
@@ -176,6 +186,7 @@ type model struct {
 	lifecycleCursor     int
 	generations         []generation
 	clean               cleanPreview
+	cleanDraft          cleanPolicyDraft
 
 	doctorReports    [3]doctorReport
 	doctorErrors     [3]error
@@ -225,14 +236,15 @@ func newModel(cli string) model {
 		backend:   newAskBackend,
 	}
 	return model{
-		cli:    cli,
-		runner: execCommandRunner{},
-		apply:  execApply,
-		asker:  asker,
-		nav:    newCockpitNav(),
-		phase:  ready,
-		width:  100,
-		height: 30,
+		cli:        cli,
+		runner:     execCommandRunner{},
+		apply:      execApply,
+		asker:      asker,
+		nav:        newCockpitNav(),
+		phase:      ready,
+		cleanDraft: defaultCleanPolicyDraft(),
+		width:      100,
+		height:     30,
 	}
 }
 
@@ -496,6 +508,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		key := msg.String()
+		if m.nav.Active() == workspaceLifecycle && m.lifecyclePhase == lifecycleCleanConfiguring && key != "q" && key != "ctrl+c" {
+			return m, m.lifecycleUpdate(key)
+		}
 		if m.lifecyclePhase == lifecycleMutating {
 			switch key {
 			case "ctrl+c", "q", "tab", "shift+tab":
@@ -648,7 +663,6 @@ func clampCursor(cursor, rows int) int {
 
 var (
 	titleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(clikit.CHead))
-	pillStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#11151c")).Background(lipgloss.Color(clikit.CAcc)).Padding(0, 1)
 	labelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(clikit.CDim)).Width(14)
 	chipStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(clikit.CHead)).Background(lipgloss.Color(clikit.CSelBg)).Padding(0, 1)
 	iconStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(clikit.CAcc))
@@ -672,7 +686,7 @@ func (m model) View() string {
 		content = m.overviewView(panelWidth)
 	}
 	sections := []string{
-		titleStyle.Render("ATYRODE") + "  " + pillStyle.Render(m.workspaceTitle()),
+		titleStyle.Render("ATYRODE"),
 		m.workspaceTabs(panelWidth),
 		content,
 		m.shellFooter(),

--- a/pkgs/atyrode-tui/main_test.go
+++ b/pkgs/atyrode-tui/main_test.go
@@ -25,6 +25,18 @@ func (f runnerFunc) Output(ctx context.Context, name string, args ...string) ([]
 	return f(ctx, name, args...)
 }
 
+func TestExecCommandRunnerKeepsJSONSeparateFromStderr(t *testing.T) {
+	runner := execCommandRunner{}
+	out, err := runner.Output(context.Background(), "/bin/sh", "-c", `printf '{"ok":true}'; printf 'progress' >&2`)
+	if err != nil || string(out) != `{"ok":true}` {
+		t.Fatalf("successful split output = %q, %v", out, err)
+	}
+	out, err = runner.Output(context.Background(), "/bin/sh", "-c", `printf '{"ok":false}'; printf 'diagnostic' >&2; exit 65`)
+	if string(out) != `{"ok":false}` || err == nil || !strings.Contains(err.Error(), "diagnostic") {
+		t.Fatalf("failed split output = %q, %v", out, err)
+	}
+}
+
 func newApplyTestModel(cli string) model {
 	m := newModel(cli)
 	m.nav.Select(workspaceApply)
@@ -223,7 +235,7 @@ func TestOverviewStartsWithoutApplyWorkAndApplyPreviewRemainsExplicit(t *testing
 		t.Fatalf("Overview startup commands = %#v, want none", calls)
 	}
 	overview := stripTerminalControls(m.View())
-	for _, want := range []string{"overview", "Your Nix operating environment", "1  Overview", "2  Apply", "Tab/Shift+Tab navigate"} {
+	for _, want := range []string{"ATYRODE", "Your Nix operating environment", "1. Overview", "2. Apply", "Tab/Shift+Tab navigate"} {
 		if !strings.Contains(overview, want) {
 			t.Errorf("Overview missing %q", want)
 		}
@@ -271,6 +283,43 @@ func TestOverviewStartsWithoutApplyWorkAndApplyPreviewRemainsExplicit(t *testing
 	for _, want := range []string{"ACTIVATION PREVIEW", "Applying revision feedfacefeed", "Preview built", "1 added", "2 updated", "1 removed", "Disk usage decreases by 5.59 MiB"} {
 		if !strings.Contains(view, want) {
 			t.Errorf("visible summary missing %q", want)
+		}
+	}
+}
+
+func TestWorkspaceTabsStayAlignedAndOnlyMoveSelection(t *testing.T) {
+	m := newModel("atyrode")
+	for _, tc := range []struct {
+		width int
+		rows  int
+	}{{34, 3}, {64, 2}, {92, 2}, {142, 1}} {
+		tabs := m.workspaceTabs(tc.width)
+		lines := strings.Split(tabs, "\n")
+		if len(lines) != tc.rows {
+			t.Fatalf("tabs at width %d rendered %d rows, want %d", tc.width, len(lines), tc.rows)
+		}
+		for _, line := range lines {
+			if got := lipgloss.Width(line); got != tc.width {
+				t.Fatalf("tabs at width %d rendered row width %d", tc.width, got)
+			}
+		}
+	}
+
+	overview := m.workspaceTabs(142)
+	m.nav.Select(workspaceApply)
+	apply := m.workspaceTabs(142)
+	if stripTerminalControls(overview) != stripTerminalControls(apply) {
+		t.Fatal("selecting a workspace moved or changed tab labels")
+	}
+	if fmt.Sprint(workspaceTabStyle(20, false).GetBackground()) == fmt.Sprint(workspaceTabStyle(20, true).GetBackground()) {
+		t.Fatal("selected workspace tab has no distinct background")
+	}
+	if !strings.Contains(stripTerminalControls(m.workspaceTabs(34)), "3. Gen / Clean") {
+		t.Fatal("narrow workspace tabs obscured the Generations / Clean destination")
+	}
+	for _, want := range []string{"1. Overview", "2. Apply", "3. Generations / Clean", "4. Doctor", "5. Capabilities", "6. Ask"} {
+		if !strings.Contains(stripTerminalControls(apply), want) {
+			t.Fatalf("workspace tabs missing %q", want)
 		}
 	}
 }

--- a/pkgs/atyrode-tui/navigation.go
+++ b/pkgs/atyrode-tui/navigation.go
@@ -6,6 +6,7 @@ import (
 	clikit "cli-kit"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 const (
@@ -78,26 +79,56 @@ func (m *model) nextWorkspace(delta int) tea.Cmd {
 	return m.activateWorkspace(id)
 }
 
-func (m model) workspaceTitle() string {
-	item, ok := m.nav.ActiveItem()
-	if !ok {
-		return "overview"
+func workspaceTabStyle(width int, active bool) lipgloss.Style {
+	style := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color(clikit.CHead)).
+		Align(lipgloss.Center).
+		Width(width).
+		MaxWidth(width)
+	if active {
+		style = style.
+			Foreground(lipgloss.Color("#11151c")).
+			Background(lipgloss.Color(clikit.CAcc))
 	}
-	return strings.ToLower(item.Label)
+	return style
 }
 
 func (m model) workspaceTabs(width int) string {
-	items := m.nav.Items()
-	parts := make([]string, 0, len(items))
-	for _, item := range items {
-		label := item.Shortcut + " " + item.Label
-		if item.ID == m.nav.Active() {
-			parts = append(parts, pillStyle.Render(label))
-		} else {
-			parts = append(parts, clikit.StDim.Render(label))
-		}
+	if width < 1 {
+		return ""
 	}
-	return clikit.ClipLines(lipgloss.JoinHorizontal(lipgloss.Top, intersperse(parts, "  ")...), width)
+	items := m.nav.Items()
+	columns := 2
+	switch {
+	case width >= 132:
+		columns = 6
+	case width >= 64:
+		columns = 3
+	}
+	rows := make([]string, 0, (len(items)+columns-1)/columns)
+	for start := 0; start < len(items); start += columns {
+		end := min(start+columns, len(items))
+		cells := make([]string, 0, end-start)
+		for index := start; index < end; index++ {
+			cellWidth := width / columns
+			if index%columns < width%columns {
+				cellWidth++
+			}
+			item := items[index]
+			label := item.Shortcut + ". " + item.Label
+			if item.ID == workspaceLifecycle && lipgloss.Width(label) > cellWidth {
+				label = item.Shortcut + ". Gen / Clean"
+			}
+			if cellWidth > 1 {
+				label = ansi.Truncate(label, cellWidth, "…")
+			}
+			style := workspaceTabStyle(cellWidth, item.ID == m.nav.Active())
+			cells = append(cells, style.Render(label))
+		}
+		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, cells...))
+	}
+	return strings.Join(rows, "\n")
 }
 
 func (m model) shellFooter() string {
@@ -120,6 +151,8 @@ func (m model) workspaceBodyHeight() int {
 	if m.nav.Active() == workspaceDoctor {
 		chromeRows++
 	}
+	_, panelWidth := m.horizontalLayout()
+	chromeRows += max(0, lipgloss.Height(m.workspaceTabs(panelWidth))-1)
 	return max(1, m.height-chromeRows)
 }
 


### PR DESCRIPTION
## Context

The cockpit workspace tabs changed width when selected and the lifecycle workspace only exposed the default `atyrode clean` policy.

## Solution

- render responsive, equal-width numbered workspace tabs with a moving background selection
- add a Clean policy editor for keep count, keep-since, `--all`, and `--verbose`
- provide a maximum-reclaim shortcut while always retaining the current generation
- preserve exact preview-to-confirmed command arguments and reject mismatched preview policy
- separate JSON stdout from progress stderr without losing failure diagnostics

## Verification

- `go test ./...` in `pkgs/atyrode-tui`
- `nix build .#atyrode-tui --no-link`
- `nix build .#checks.x86_64-linux.go-fmt --no-link`
- `nix build .#checks.x86_64-linux.atyrode-cli --no-link`
- headless tmux/freeze verification at 150x44 and 44x18
- fixture confirmation of exact maximum/all/verbose preview and mutation argv