### PR TITLE
ci: run documentation changes through matrix

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,11 +19,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Docs-only changes skip the 3-platform matrix (#169). Classification fails
-  # closed: any API error, empty file list, or non-PR event runs the full
-  # matrix. `README.md` and `docs/**` except the versioned `docs/omp/**` wiki
-  # are inert. The OMP wiki feeds package/capability metadata, so it runs the
-  # full matrix like every other derivation input.
+  # Every change runs the 3-platform matrix. Documentation can affect derivation
+  # hashes through the flake source, so it is not safe to classify `docs/**` or
+  # `README.md` as inert.
   changes:
     name: classify
     runs-on: ubuntu-24.04
@@ -45,8 +43,6 @@ jobs:
               code=false
               while IFS= read -r f; do
                 case "$f" in
-                  docs/omp/*) code=true ;;
-                  docs/* | README.md) ;;
                   *) code=true ;;
                 esac
               done <<EOF

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -448,19 +448,10 @@ fails the build instead of silently misrouting models.
 GitHub Actions runs the flake checks natively on x86_64 and aarch64 Linux and
 aarch64 macOS; platform-independent lints (docs-links, production-facts,
 nixfmt, go-fmt) are emitted on x86_64-linux only to avoid duplicate work
-(#169). Changes confined to `docs/**` and `README.md` skip the platform
-matrix entirely and build only the two intentional whole-tree lints —
-docs-links and production-facts, which scan documentation on purpose; the
-sole required status check is the always-reporting `ci-gate` job, so a
-skipped matrix can never leave a pull request stuck on a missing check. Any
-other Markdown file counts as code because it can be a derivation input
-(deployed `agents/skills`, omp rules, the managed Claude policy). The fast
-path guards its own invariant: `scripts/docs-drift-guard.sh` instantiates
-every check on every CI platform at the pull request's base and head
-(evaluation-only, no builds) and fails if the docs change altered any
-derivation other than those two lints — so a `docs/**` path silently
-becoming a derivation input blocks the merge instead of skipping real
-verification. The guard's comparison logic is regression-tested by the
-`docs-drift-guard` flake check, and it adds roughly three minutes of pure
-evaluation to a docs-only pull request (six instantiations: three systems
-at base and head).
+(#169). Every pull request runs the platform matrix, including documentation
+changes: a path beneath `docs/` can affect derivation hashes through the flake
+source even when no deployed file references that document. The sole required
+status check is the always-reporting `ci-gate` job. The
+`docs-drift-guard` flake check regression-tests the comparison logic used when
+evaluating a docs-only fast path; the fast path is not enabled while
+documentation remains a derivation input.


### PR DESCRIPTION
## What

Classify all documentation changes through the full platform matrix. Current flake source composition makes documentation changes affect non-lint derivation hashes; this preserves `docs-drift-guard` rather than weakening or bypassing its invariant. Update the CI documentation accordingly.

Refs #224

## Verification

- `nix build .#checks.x86_64-linux.docs-drift-guard --no-link`
- `git diff --check`