### PR TITLE
ci(cli-kit): gate unit tests behind a flake check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -640,6 +640,9 @@
               .${system};
           };
           bootstrap = import ./checks/bootstrap.nix { inherit pkgs; };
+          # cli-kit is library-only, so no build depends on its derivation;
+          # exposing it as a check is what makes CI run its unit tests.
+          cli-kit = pkgs.cli-kit;
           codex-seed = import ./checks/codex-seed.nix { inherit lib pkgs; };
           get-entrypoint = import ./checks/get-sh.nix { inherit pkgs; };
           omp-seed = import ./checks/omp-seed.nix { inherit lib pkgs; };

--- a/pkgs/cli-kit/default.nix
+++ b/pkgs/cli-kit/default.nix
@@ -4,8 +4,9 @@
 }:
 
 # cli-kit is a library module (no executables) consumed by the custom CLIs via a
-# local `replace`. It is packaged here only so `nix flake check` builds and runs
-# its unit tests (buildGoModule's checkPhase) — the build installs nothing.
+# local `replace`. It is packaged here only so the flake can expose it under
+# checks.<system>.cli-kit, whose build runs the unit tests (buildGoModule's
+# checkPhase) — the build installs nothing.
 buildGoModule {
   pname = "cli-kit";
   version = "0.1.0";
@@ -19,7 +20,7 @@ buildGoModule {
     ];
   };
 
-  vendorHash = "sha256-tMop2DqUFQj17PYABbY78AGAK8ZiCZNYZSfun5hz8Vc=";
+  vendorHash = "sha256-88URr9JQsZvwEZ4F4R5R+2z9Xy26yjx7Js38KoCDhYA=";
 
   doCheck = true;
 


### PR DESCRIPTION
## Summary

`pkgs/cli-kit/default.nix` set `doCheck = true` with a comment claiming `nix flake check` builds and runs its unit tests. That claim was false: CI runs `nix flake check`, which only *evaluates* `packages.*` and *builds* `checks.*` — and nothing under `checks/` built `pkgs.cli-kit`. The `code-tui`/`atyrode-tui` builds vendor cli-kit's source via a local `replace` but run `go test` only under their own modRoot, so cli-kit's ~970 LOC of tests (`promptbox_test.go` etc.) gated nothing.

- Register `cli-kit = pkgs.cli-kit;` in the all-systems checks attrset, so `buildGoModule`'s checkPhase runs on every CI leg (the tests exercise arch-compiled code, so it belongs with `atyrode-cli`, not the x86_64-only lint block).
- Correct the stale comment in `pkgs/cli-kit/default.nix` to describe the actual mechanism.
- Fix the `vendorHash`, which had silently rotted since go.sum last changed — caught by the very first build of this derivation, which is direct proof the gap was real.

## Verification

- `nix build .#checks.x86_64-linux.cli-kit` builds and the checkPhase runs the full test suite (`ok cli-kit` — all test files live flat in the single root package).
- `nix eval .#checks.<system> --apply builtins.attrNames` shows `cli-kit` registered on all system legs.
- `nixfmt --check` clean on both edited files.

Note: if the planned code-tui/cli-kit extraction to a separate repo lands, tests move to that repo's CI and this wiring goes away with the package — no conflict in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)