### PR TITLE
chore(omp): update to v17.0.1

### DIFF
--- a/docs/omp/README.md
+++ b/docs/omp/README.md
@@ -1,9 +1,9 @@
 # OMP feature wiki
 
-> - **Audited:** 2026-07-15
-> - **Repository pin:** `omp` v17.0.0
-> - **Upstream release:** [v17.0.0](https://github.com/can1357/oh-my-pi/releases/tag/v17.0.0) (2026-07-15)
-> - **Audit range:** v16.0.0 through v17.0.0, plus the v17.0.0 CLI help and documentation
+> - **Audited:** 2026-07-16
+> - **Repository pin:** `omp` v17.0.1
+> - **Upstream release:** [v17.0.1](https://github.com/can1357/oh-my-pi/releases/tag/v17.0.1) (2026-07-16)
+> - **Audit range:** v16.0.0 through v17.0.1, plus the v17.0.1 CLI help and documentation
 
 This is the compact “did you know this exists?” index for the OMP binary used by
 these dotfiles. It is for operators deciding what to invoke and for agents that
@@ -11,7 +11,7 @@ need to discover an OMP capability before proposing new wrapper code.
 
 ## Choose the correct surface first
 
-The [CLI reference](cli.md) describes **plain upstream `omp` v17.0.0**. These
+The [CLI reference](cli.md) describes **plain upstream `omp` v17.0.1**. These
 repository launchers are not interchangeable:
 
 | Invoke | Authentication and state | Configuration and policy |
@@ -59,16 +59,16 @@ managed launches, then directs the operator to the repository-owned edit paths.
 Claims in this wiki were checked against:
 
 1. the repository pin in [`pkgs/omp/default.nix`](../../pkgs/omp/default.nix);
-2. the output of the packaged `omp v17.0.0 --help` and each listed shell
+2. the output of the packaged `omp v17.0.1 --help` and each listed shell
    command's `--help`;
 3. the upstream documentation at the immutable
-   [`v17.0.0` tag](https://github.com/can1357/oh-my-pi/tree/v17.0.0/docs);
+   [`v17.0.1` tag](https://github.com/can1357/oh-my-pi/tree/v17.0.1/docs);
 4. upstream release notes from
    [v16.0.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.0.0) through
-   [v17.0.0](https://github.com/can1357/oh-my-pi/releases/tag/v17.0.0); and
+   [v17.0.1](https://github.com/can1357/oh-my-pi/releases/tag/v17.0.1); and
 5. the repository-owned wrapper behavior in [Agent tools](../agent-tools.md).
 
-No upstream release newer than v17.0.0 had been published when this audit was
+No upstream release newer than v17.0.1 had been published when this audit was
 written. Availability in upstream `main` or a newer release is not proof that a
 feature exists in the packaged binary.
 

--- a/docs/omp/cli.md
+++ b/docs/omp/cli.md
@@ -1,7 +1,7 @@
-# Plain OMP v17.0.0 CLI reference
+# Plain OMP v17.0.1 CLI reference
 
-> **Scope:** this page is a snapshot of the packaged **upstream `omp` v17.0.0**
-> executable, audited 2026-07-15. It is not a promise that `code`,
+> **Scope:** this page is a snapshot of the packaged **upstream `omp` v17.0.1**
+> executable, audited 2026-07-16. It is not a promise that `code`,
 > `omp-managed`, or `ompu` preserve every flag unchanged. See the
 > [launcher matrix](README.md#choose-the-correct-surface-first) first.
 
@@ -154,7 +154,7 @@ $ omp config managed --json
 ```
 
 The repository-packaged `omp` passthrough intercepts that one action before
-dispatching to upstream. `config managed` is not an upstream v17.0.0
+dispatching to upstream. `config managed` is not an upstream v17.0.1
 subcommand, despite the intentionally plain-looking invocation.
 
 ## Built-in agent tool catalog
@@ -173,7 +173,6 @@ The packaged root help advertises these default tools:
 | `inspect_image` | Vision-model image analysis |
 | `browser` | Puppeteer browser automation |
 | `task` | Parallel subagents |
-| `hub` | Peer messaging, background-job control, and supervised processes |
 | `todo` | Structured task-list state |
 | `web_search` | Search through configured web providers |
 | `ask` | Interactive operator questions |
@@ -181,13 +180,12 @@ The packaged root help advertises these default tools:
 Extensions and MCP servers can add tools, so `/tools` is authoritative for the
 active session. A wrapper can also limit or deny tools through policy.
 
-In v17.0.0, the essential `hub` tool replaces the separate `irc`, `job`, and
-`launch` agent tools while preserving peer messaging, background-job control,
-and supervised-process operations. Discoverable custom, MCP, image-generation,
-and TTS tools mount as `xd://` virtual devices by default: use `read xd://` to
-list them, `read xd://<tool>` for a contract, and `write xd://<tool>` to invoke
-one. Plan and preview resolution likewise moved from the removed `resolve` tool
-to `xd://propose`, `xd://resolve`, and `xd://reject`.
+The v17.0.1 root help does not advertise `hub`; do not assume it is available
+in a bare session. `/tools` is authoritative for the active surface.
+Discoverable custom, MCP, image-generation, and TTS tools can mount as `xd://`
+virtual devices: use `read xd://` to list mounted devices, `read xd://<tool>`
+for a contract, and `write xd://<tool>` to invoke one. Plan and preview
+resolution remains at `xd://propose`, `xd://resolve`, and `xd://reject`.
 
 Upstream v17 also defaults `astGrep.enabled` and
 `edit.enforceSeenLines` off. These dotfiles deliberately enable both in the
@@ -240,8 +238,8 @@ $ ompu "inspect this untrusted repository"
 ```
 
 Sources: packaged `omp --help`; tagged upstream
-[settings](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/settings.md),
-[providers](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/providers.md),
-[models](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/models.md), and
-[secrets](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/secrets.md)
+[settings](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/settings.md),
+[providers](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/providers.md),
+[models](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/models.md), and
+[secrets](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/secrets.md)
 documentation; repository [Agent tools](../agent-tools.md).

--- a/docs/omp/features.md
+++ b/docs/omp/features.md
@@ -1,12 +1,12 @@
-# OMP v17.0.0 capability field guide
+# OMP v17.0.1 capability field guide
 
 > **Scope:** built-in upstream capabilities present in the packaged `omp`
-> v17.0.0, audited 2026-07-15. Wrapper policy still matters: read the
+> v17.0.1, audited 2026-07-16. Wrapper policy still matters: read the
 > [launcher matrix](README.md#choose-the-correct-surface-first).
 
 This page favors discoverability over implementation detail. The release links
 identify when a capability materially appeared or changed during the audited
-v16 and v17 series; the immutable v17.0.0 documentation links define the
+v16 and v17 series; the immutable v17.0.1 documentation links define the
 packaged behavior.
 
 ## High-value “did you know?” workflows
@@ -20,9 +20,13 @@ packaged behavior.
 Inside a profile, `/login <provider>` and `/logout <provider>` manage
 provider-scoped credentials. `omp usage --redact` reports every authenticated
 account without exposing full account IDs; `omp dry-balance` previews OAuth
-account selection. See upstream
-[Providers](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/providers.md)
-and [Secrets](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/secrets.md).
+account selection. In v17.0.1, OAuth refresh writes are serialized across processes
+and failed background usage probes no longer disable otherwise usable rotating
+credentials; use `omp usage --redact` when checking accounts, never unredacted
+diagnostics. For paste-code providers, `/login` now mounts a focused input for
+the manual pairing code or redirect URL. See upstream
+[Providers](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/providers.md)
+and [Secrets](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/secrets.md).
 
 In these dotfiles, `code` keeps all trusted sessions and settings in client
 profile `default` while choosing credentials through isolated auth-broker
@@ -47,7 +51,7 @@ The session can also:
 
 These dotfiles manage the role map and fallback chains for generated launches;
 plain `omp` remains mutable. See upstream
-[Models](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/models.md).
+[Models](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/models.md).
 
 ### Change the shape of the work, not only the model
 
@@ -72,9 +76,10 @@ plain `omp` remains mutable. See upstream
 The `task` tool launches typed subagents and can isolate them in git worktrees.
 The Agent Control Center (`/agents`) shows live state and allows steering,
 killing, reviving, and transcript inspection. From an enabled `eval` workflow,
-`output(id)` retrieves task/agent output by ID. The essential `hub` tool unifies
-peer messaging, background-job control, and supervised long-running processes;
-background process/job state remains visible through `/jobs`.
+`output(id)` retrieves task/agent output by ID. Background process/job state
+remains visible through `/jobs`. The packaged v17.0.1 root help does not
+advertise `hub`; use `/tools` to confirm whether an active extension provides
+it rather than assuming it is available in a bare session.
 
 Useful distinctions:
 
@@ -98,9 +103,13 @@ OMP's transcript is a navigable tree, not a flat terminal log:
   resumable; and
 - `/fresh` resets provider stream state without discarding the local transcript.
 
+When `/resume` or plan approval replaces a session, v17.0.1 keeps its fullscreen
+overlay mounted until the rebuilt transcript is ready rather than briefly
+exposing the prior session.
+
 `/export` writes browsable HTML, while `/dump` copies the full textual
 transcript. See the tagged
-[session-operations reference](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/session-operations-export-share-fork-resume.md).
+[session-operations reference](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/session-operations-export-share-fork-resume.md).
 
 ### Share a snapshot or collaborate live—with different trust models
 
@@ -111,9 +120,9 @@ creates a read-only link. Guests can use `omp join <link>` or `/join <link>`.
 
 The host still runs the model and every tool. A full collab link is therefore a
 control credential and must be handled like a secret. See the tagged
-[Collab](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/collab.md)
+[Collab](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/collab.md)
 and
-[session-sharing](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/session-operations-export-share-fork-resume.md#share)
+[session-sharing](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/session-operations-export-share-fork-resume.md#share)
 docs.
 
 ### Diagnose and reshape context before it becomes a failure
@@ -130,8 +139,8 @@ docs.
   maintenance.
 
 See the tagged upstream
-[Memory](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/memory.md) and
-[Compaction](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/compaction.md)
+[Memory](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/memory.md) and
+[Compaction](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/compaction.md)
 references for the active backend and compaction modes.
 
 ### Use rich input without leaving the terminal
@@ -153,7 +162,7 @@ dependencies rather than assuming they are installed.
 
 ### Give the agent more than file and shell access
 
-The v17.0.0 tool ecosystem includes code-aware LSP operations,
+The v17.0.1 tool ecosystem includes code-aware LSP operations,
 document/archive reads, images, notebooks, browser automation, web search,
 structured todos, subagents, and interactive operator questions. The
 discoverable `eval` tool adds persistent language kernels when its runtimes are
@@ -179,10 +188,10 @@ Notable release-backed additions include:
   [v16.5.0](https://github.com/can1357/oh-my-pi/releases/tag/v16.5.0) and merged
   into the essential `hub` tool in v17.0.0; and
 - tagged tool contracts for
-  [image inspection](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/tools/inspect_image.md),
-  [image generation](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/tools/generate_image.md),
-  [speech generation](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/tools/tts.md),
-  and [evaluation](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/tools/eval.md).
+  [image inspection](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/tools/inspect_image.md),
+  [image generation](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/tools/generate_image.md),
+  [speech generation](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/tools/tts.md),
+  and [evaluation](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/tools/eval.md).
 
 In v17, custom, MCP, image-generation, and TTS tools are discoverable through
 the default-on `xd://` virtual-device transport rather than all being exposed
@@ -193,11 +202,11 @@ for any capability.
 
 ### Extend OMP without editing its core
 
-OMP v17.0.0 supports several extension boundaries:
+OMP v17.0.1 supports several extension boundaries:
 
 - TypeScript/JavaScript extensions and hooks via `-e`, `--hook`, discovery, or
   plugin packages;
-- project/user skills, filterable with `--skills`;
+- project/user skills, filterable with `--skills`; v17.0.1 reloads runtime skill discovery and `skill://` resolution after `/reload-plugins`, plugin setting changes, or `manage_skill` writes, so a restart is no longer required;
 - project/user rules, disableable with `--no-rules`;
 - discovery diagnostics for both skills and rules;
 - MCP servers managed through `/mcp`;
@@ -208,11 +217,11 @@ OMP v17.0.0 supports several extension boundaries:
   status widgets.
 
 Start with the tagged
-[Extensions](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/extensions.md),
-[Skills](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/skills.md),
-[Rule matching](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/rulebook-matching-pipeline.md),
-[MCP](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/mcp-config.md), and
-[TUI integration](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/tui.md)
+[Extensions](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/extensions.md),
+[Skills](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/skills.md),
+[Rule matching](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/rulebook-matching-pipeline.md),
+[MCP](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/mcp-config.md), and
+[TUI integration](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/tui.md)
 docs.
 
 ### Embed or automate the same agent
@@ -228,8 +237,8 @@ The binary is not limited to the interactive TUI:
 - hooks/extensions can observe and alter lifecycle events.
 
 See the tagged
-[RPC](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/rpc.md) and
-[auth broker/gateway](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/auth-broker-gateway.md)
+[RPC](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/rpc.md) and
+[auth broker/gateway](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/auth-broker-gateway.md)
 docs; use `omp acp --help` for the packaged ACP server surface.
 
 ### Inspect OMP itself before writing another wrapper
@@ -256,10 +265,17 @@ source or adding a duplicate diagnostic to `code`.
 ## Release-note radar through the pinned v17 line
 
 This is a compact audit of operator-visible changes recorded between v16.0.0
-and v17.0.0, not a replacement for the current-feature sections above. Release
+and v17.0.1, not a replacement for the current-feature sections above. Release
 notes can bundle or migrate older behavior, so an entry means “recorded in this
 release,” not necessarily “first invented here.”
 
+- [v17.0.1](https://github.com/can1357/oh-my-pi/releases/tag/v17.0.1) —
+  serialized rotating OAuth refreshes and safe background usage probes; focused
+  `/login` paste-code pairing input; runtime skill rediscovery after plugin/skill
+  changes; fullscreen session-replacement overlays for `/resume` and plan
+  approval; restored tmux modifyOtherKeys fallback; and refreshed provider model
+  catalog metadata, labels, limits, capabilities, and pricing. These are upstream
+  fixes, not changes to `code`, `omp-managed`, or `ompu` policy.
 - [v17.0.0](https://github.com/can1357/oh-my-pi/releases/tag/v17.0.0) —
   the essential `hub` tool replaces separate `irc`, `job`, and `launch` tools;
   discoverable tools move to default-on `xd://` virtual devices; plan/preview
@@ -348,12 +364,12 @@ change it. The pinned defaults include:
 | hold `Space` | Push-to-talk speech transcription |
 
 Keybindings live in `~/.omp/agent/keybindings.yml`; see the tagged
-[Keybindings](https://github.com/can1357/oh-my-pi/blob/v17.0.0/docs/keybindings.md)
+[Keybindings](https://github.com/can1357/oh-my-pi/blob/v17.0.1/docs/keybindings.md)
 reference.
 
 ## Built-in interactive slash-command index
 
-This table catalogs the v17.0.0 built-ins. `/help` remains authoritative because
+This table catalogs the v17.0.1 built-ins. `/help` remains authoritative because
 extensions may add commands and the active mode may restrict them.
 
 | Area | Commands |
@@ -383,4 +399,4 @@ Less obvious semantics:
   points to repository-owned edit paths.
 
 Source: tagged upstream
-[built-in slash-command registry](https://github.com/can1357/oh-my-pi/blob/v17.0.0/packages/coding-agent/src/slash-commands/builtin-registry.ts).
+[built-in slash-command registry](https://github.com/can1357/oh-my-pi/blob/v17.0.1/packages/coding-agent/src/slash-commands/builtin-registry.ts).

--- a/pkgs/omp/default.nix
+++ b/pkgs/omp/default.nix
@@ -6,23 +6,23 @@
 }:
 
 let
-  version = "17.0.0";
+  version = "17.0.1";
   sources = {
     "x86_64-linux" = {
       asset = "omp-linux-x64";
-      hash = "sha256-5fWlSniabyVL9bkxm86uMRUV2yroRu2YqhtsFmAKS8I=";
+      hash = "sha256-QnqHQ7C073AcxKDGa/HwuRzsBigOjfYilKEU4H+zghU=";
     };
     "aarch64-linux" = {
       asset = "omp-linux-arm64";
-      hash = "sha256-0BueJJ+l3tNhqFEdbQbqyWU9g7bzQ6d64/JbIBzRAV4=";
+      hash = "sha256-jOcwYeAvbU4H36FND1k9CJSYcFb3A7GMGxUY1WHupQk=";
     };
     "x86_64-darwin" = {
       asset = "omp-darwin-x64";
-      hash = "sha256-CBjUqw5UVzNEGkOIjHKRaA0akGbmQaCZb0P96X5Ov7c=";
+      hash = "sha256-FjGg7Y4vc0zoZ7tEvNuh/W3Os12KtMIKE3Yp69zWy0Y=";
     };
     "aarch64-darwin" = {
       asset = "omp-darwin-arm64";
-      hash = "sha256-wzuhrrOnFZlelzJmwHUW/mTdhBFye1oHXZjMNFTFdms=";
+      hash = "sha256-73v/zOUjOlogosd77hfgpY7uTYaoysxed9BaPO6VTPg=";
     };
   };
   source =


### PR DESCRIPTION
## Context

OMP v17.0.1 fixes provider OAuth refresh serialization, paste-code login, runtime skill reload, resume overlays, tmux keyboard handling, and model metadata. The repository still packaged and documented v17.0.0.

## Solution

- pin all four official v17.0.1 release assets using hashes produced by `scripts/update-pins.sh`
- refresh the versioned OMP field guide against the immutable v17.0.1 release and compare range
- preserve the v17.0.0 breaking-change history while adding a distinct v17.0.1 release radar
- document affected auth, skill, resume, terminal, and catalog behavior without conflating upstream OMP and repository wrappers

## How to test

- `nix build .#omp .#checks.x86_64-linux.omp-wrapper .#checks.x86_64-linux.docs-links --no-link`
- built executable reports `omp/17.0.1`
- configured `ompu` accepts the managed v17.0.1 tool allowlist without an unknown-tool rejection

Closes #227