### PR TITLE
ci: gate Darwin with fail-safe path classification

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  # cache-nix-action purges superseded platform caches after saving.
-  actions: write
   # The classify job lists pull-request files.
   pull-requests: read
 
@@ -19,16 +17,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Every change runs the 3-platform matrix. Documentation can affect derivation
-  # hashes through the flake source, so it is not safe to classify `docs/**` or
-  # `README.md` as inert.
+  # Documentation paths are guarded before the full matrix is skipped. For
+  # code changes, only an explicit Linux-only allowlist can skip native Darwin;
+  # shared, Darwin-specific, workflow, and unknown paths fail safe to Darwin.
   changes:
     name: classify
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       code: ${{ steps.classify.outputs.code }}
+      darwin: ${{ steps.classify.outputs.darwin }}
+      matrix: ${{ steps.classify.outputs.matrix }}
     steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
       - name: Classify changed paths
         id: classify
         env:
@@ -36,39 +41,38 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          # Pushes to main and manual runs retain the complete native matrix.
           code=true
+          darwin=true
           if [ -n "$PR_NUMBER" ]; then
             if files="$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" \
               --paginate --jq '.[].filename')" && [ -n "$files" ]; then
-              code=false
-              while IFS= read -r f; do
-                case "$f" in
-                  *) code=true ;;
-                esac
-              done <<EOF
-          $files
-          EOF
+              classification="$(printf '%s\n' "$files" | ./scripts/classify-ci-paths.sh)"
+              code="$(printf '%s\n' "$classification" | sed -n 's/^code=//p')"
+              darwin="$(printf '%s\n' "$classification" | sed -n 's/^darwin=//p')"
             fi
           fi
-          echo "code=$code" >> "$GITHUB_OUTPUT"
-          echo "classified: code=$code"
+          if "$darwin"; then
+            matrix='{"include":[{"system":"x86_64-linux","runner":"ubuntu-24.04"},{"system":"aarch64-linux","runner":"ubuntu-24.04-arm"},{"system":"aarch64-darwin","runner":"macos-15"}]}'
+          else
+            matrix='{"include":[{"system":"x86_64-linux","runner":"ubuntu-24.04"},{"system":"aarch64-linux","runner":"ubuntu-24.04-arm"}]}'
+          fi
+          printf 'code=%s\ndarwin=%s\nmatrix=%s\n' "$code" "$darwin" "$matrix" >> "$GITHUB_OUTPUT"
+          echo "classified: code=$code darwin=$darwin"
 
   check:
     name: ${{ matrix.system }}
     needs: changes
     if: needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+      # cache-nix-action purges superseded platform caches after saving.
+      actions: write
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - system: x86_64-linux
-            runner: ubuntu-24.04
-          - system: aarch64-linux
-            runner: ubuntu-24.04-arm
-          - system: aarch64-darwin
-            runner: macos-15
+      matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
 
     steps:
       - name: Check out repository

--- a/checks/classify-ci-paths.nix
+++ b/checks/classify-ci-paths.nix
@@ -1,0 +1,12 @@
+{ pkgs }:
+
+pkgs.runCommand "check-classify-ci-paths"
+  {
+    nativeBuildInputs = [ pkgs.bash ];
+    classifier = ../scripts/classify-ci-paths.sh;
+    test = ../scripts/classify-ci-paths-test.sh;
+  }
+  ''
+    CLASSIFIER="$classifier" bash "$test"
+    mkdir "$out"
+  ''

--- a/flake.nix
+++ b/flake.nix
@@ -674,6 +674,7 @@
           # fast path builds directly and scripts/docs-drift-guard.sh excludes.
           docs-links = import ./checks/docs-links.nix { inherit lib pkgs; };
           docs-drift-guard = import ./checks/docs-drift-guard.nix { inherit pkgs; };
+          classify-ci-paths = import ./checks/classify-ci-paths.nix { inherit pkgs; };
           production-facts = import ./checks/production-facts.nix { inherit pkgs; };
           go-fmt = import ./checks/go-fmt.nix { inherit lib pkgs; };
           nixfmt = import ./checks/nixfmt.nix { inherit lib pkgs; };

--- a/scripts/classify-ci-paths-test.sh
+++ b/scripts/classify-ci-paths-test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+classifier="${CLASSIFIER:-$repo_root/scripts/classify-ci-paths.sh}"
+
+assert_classification() {
+  local expected actual
+  expected="$1"
+  shift
+  actual="$(printf '%s\n' "$@" | bash "$classifier")"
+  if [ "$actual" != "$expected" ]; then
+    printf 'classification mismatch for: %s\nexpected:\n%s\nactual:\n%s\n' "$*" "$expected" "$actual" >&2
+    return 1
+  fi
+}
+
+assert_classification $'code=false\ndarwin=false' README.md docs/guide.md
+assert_classification $'code=true\ndarwin=true' docs/omp/README.md
+assert_classification $'code=true\ndarwin=true' darwin/default.nix
+assert_classification $'code=true\ndarwin=true' flake.nix flake.lock
+assert_classification $'code=true\ndarwin=true' modules/home/capability-contract.nix
+assert_classification $'code=true\ndarwin=true' pkgs/cli-kit/main.go
+assert_classification $'code=true\ndarwin=true' checks/docs-links.nix
+assert_classification $'code=true\ndarwin=true' inventory/hosts.tsv
+assert_classification $'code=true\ndarwin=true' .github/workflows/nix.yml
+assert_classification $'code=true\ndarwin=false' home/linux-desktop.nix
+assert_classification $'code=true\ndarwin=false' home/linux-desktop.nix docs/guide.md
+assert_classification $'code=true\ndarwin=true' home/linux-desktop.nix unknown/new-file
+assert_classification $'code=true\ndarwin=true' unknown/new-file
+
+empty_output="$(printf '' | bash "$classifier")"
+if [ "$empty_output" != $'code=true\ndarwin=true' ]; then
+  printf 'empty input must fail safe; got:\n%s\n' "$empty_output" >&2
+  exit 1
+fi

--- a/scripts/classify-ci-paths.sh
+++ b/scripts/classify-ci-paths.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Classify pull-request paths for CI. Read one repository-relative path per line
+# from stdin and write GitHub Actions outputs to stdout. An empty input is
+# deliberately fail-safe: callers must not skip verification when file listing
+# fails or is incomplete.
+set -euo pipefail
+
+code=false
+darwin=false
+saw_path=false
+
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  saw_path=true
+
+  case "$path" in
+    # These documentation paths are guarded by docs-drift-guard.sh before the
+    # full matrix is skipped. docs/omp is versioned runtime documentation and
+    # remains a full-matrix input.
+    README.md | docs/*)
+      case "$path" in
+        docs/omp/*)
+          code=true
+          darwin=true
+          ;;
+      esac
+      ;;
+
+    # This module contributes configuration only when pkgs.stdenv.isLinux.
+    # The Linux CI legs still evaluate it; native Darwin has no affected
+    # configuration to verify.
+    home/linux-desktop.nix)
+      code=true
+      ;;
+
+    # Every other path is shared, Darwin-specific, or not yet proven inert.
+    # New paths must opt in here only after establishing their platform scope.
+    *)
+      code=true
+      darwin=true
+      ;;
+  esac
+done
+
+if ! "$saw_path"; then
+  code=true
+  darwin=true
+fi
+
+printf 'code=%s\ndarwin=%s\n' "$code" "$darwin"


### PR DESCRIPTION
## Context

The Nix workflow currently sends every non-docs pull request through the native Darwin runner. The repository already has a guarded documentation fast path, but no independently tested distinction between Darwin-relevant and explicitly Linux-only changes.

## Solution

- add a deterministic classifier whose unknown-path default always selects Darwin
- keep shared Nix, package, workflow, inventory, lockfile, and OMP documentation changes on native Darwin
- preserve the existing documentation drift guard
- allow only reviewed Darwin-independent paths to skip the Darwin matrix entry
- scope cache-write permission to the matrix job
- wire classifier regression cases into `nix flake check`

## How to test

- `nix build .#checks.x86_64-linux.classify-ci-paths --no-link`
- `nix run nixpkgs#actionlint -- .github/workflows/nix.yml`
- `nix run nixpkgs#zizmor -- .github/workflows/nix.yml`

Closes #228
Refs #13